### PR TITLE
improve cmake build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
       run: brew install gcc@${GCC_V} || brew upgrade gcc@${GCC_V} || true
 
     - name: Configure with CMake
-      run: cmake -Wdev -S . -B build
+      run: cmake -Wdev -DCMAKE_BUILD_TYPE=Release -S . -B build
 
     - name: Build and compile
       run: cmake --build build || cmake --build build --verbose --parallel 1

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+build/
+
 # Prerequisites
 *.d
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,8 @@
-cmake_minimum_required(VERSION 3.5.0 FATAL_ERROR)
-
-enable_language(Fortran)
-
-project(stdlib)
-
+cmake_minimum_required(VERSION 3.5.0)
+project(stdlib Fortran)
 enable_testing()
+
+# this avoids stdlib and projects using stdlib from having to introspect stdlib's directory structure
+set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR})
 
 add_subdirectory(src)

--- a/src/stdlib_experimental_io.f90
+++ b/src/stdlib_experimental_io.f90
@@ -46,7 +46,7 @@ real(sp), allocatable, intent(out) :: d(:,:)
 integer :: s
 integer :: nrow,ncol,i
 
-open(newunit=s, file=filename, status="old")
+open(newunit=s, file=filename, status="old", action="read")
 
 ! determine number of columns
 ncol = number_of_columns(s)
@@ -89,7 +89,7 @@ real(dp), allocatable, intent(out) :: d(:,:)
 integer :: s
 integer :: nrow,ncol,i
 
-open(newunit=s, file=filename, status="old")
+open(newunit=s, file=filename, status="old", action="read")
 
 ! determine number of columns
 ncol = number_of_columns(s)
@@ -132,7 +132,7 @@ real(qp), allocatable, intent(out) :: d(:,:)
 integer :: s
 integer :: nrow,ncol,i
 
-open(newunit=s, file=filename, status="old")
+open(newunit=s, file=filename, status="old", action="read")
 
 ! determine number of columns
 ncol = number_of_columns(s)
@@ -164,7 +164,7 @@ real(sp), intent(in) :: d(:,:)           ! The 2D array to save
 ! call savetxt("log.txt", data)
 
 integer :: s, i
-open(newunit=s, file=filename, status="replace")
+open(newunit=s, file=filename, status="replace", action="write")
 do i = 1, size(d, 1)
     write(s, *) d(i, :)
 end do
@@ -187,7 +187,7 @@ real(dp), intent(in) :: d(:,:)           ! The 2D array to save
 ! call savetxt("log.txt", data)
 
 integer :: s, i
-open(newunit=s, file=filename, status="replace")
+open(newunit=s, file=filename, status="replace", action="write")
 do i = 1, size(d, 1)
     write(s, *) d(i, :)
 end do
@@ -210,7 +210,7 @@ real(qp), intent(in) :: d(:,:)           ! The 2D array to save
 ! call savetxt("log.txt", data)
 
 integer :: s, i
-open(newunit=s, file=filename, status="replace")
+open(newunit=s, file=filename, status="replace", action="write")
 do i = 1, size(d, 1)
     write(s, *) d(i, :)
 end do
@@ -243,9 +243,9 @@ integer function number_of_rows_numeric(s)
  ! determine number or rows
  integer,intent(in)::s
  integer :: ios
- 
+
  real::r
- 
+
  rewind(s)
  number_of_rows_numeric = 0
  do
@@ -253,7 +253,7 @@ integer function number_of_rows_numeric(s)
     if (ios /= 0) exit
     number_of_rows_numeric = number_of_rows_numeric + 1
  end do
- 
+
  rewind(s)
 
 end function

--- a/src/tests/ascii/CMakeLists.txt
+++ b/src/tests/ascii/CMakeLists.txt
@@ -1,5 +1,3 @@
-project(ascii)
-
 add_executable(test_ascii test_ascii.f90)
 target_link_libraries(test_ascii fortran_stdlib)
 

--- a/src/tests/ascii/CMakeLists.txt
+++ b/src/tests/ascii/CMakeLists.txt
@@ -1,9 +1,6 @@
-include_directories(${PROJECT_BINARY_DIR}/src)
-
 project(ascii)
 
 add_executable(test_ascii test_ascii.f90)
 target_link_libraries(test_ascii fortran_stdlib)
 
-add_test(test_ascii ${PROJECT_BINARY_DIR}/test_ascii)
-
+add_test(NAME ASCII COMMAND $<TARGET_FILE:test_ascii>)

--- a/src/tests/loadtxt/CMakeLists.txt
+++ b/src/tests/loadtxt/CMakeLists.txt
@@ -1,5 +1,3 @@
-project(loadtxt)
-
 add_executable(test_loadtxt test_loadtxt.f90)
 target_link_libraries(test_loadtxt fortran_stdlib)
 

--- a/src/tests/loadtxt/CMakeLists.txt
+++ b/src/tests/loadtxt/CMakeLists.txt
@@ -1,5 +1,3 @@
-include_directories(${PROJECT_BINARY_DIR}/src)
-
 project(loadtxt)
 
 add_executable(test_loadtxt test_loadtxt.f90)
@@ -8,8 +6,7 @@ target_link_libraries(test_loadtxt fortran_stdlib)
 add_executable(test_savetxt test_savetxt.f90)
 target_link_libraries(test_savetxt fortran_stdlib)
 
-add_test(test_loadtxt ${PROJECT_BINARY_DIR}/test_loadtxt)
-add_test(test_savetxt ${PROJECT_BINARY_DIR}/test_savetxt)
-
-file(COPY array1.dat  array2.dat  array3.dat  array4.dat
-     DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+add_test(NAME load_text COMMAND $<TARGET_FILE:test_loadtxt>
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+add_test(NAME save_text COMMAND $<TARGET_FILE:test_savetxt>
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/tests/loadtxt/CMakeLists.txt
+++ b/src/tests/loadtxt/CMakeLists.txt
@@ -6,7 +6,7 @@ target_link_libraries(test_loadtxt fortran_stdlib)
 add_executable(test_savetxt test_savetxt.f90)
 target_link_libraries(test_savetxt fortran_stdlib)
 
-add_test(NAME load_text COMMAND $<TARGET_FILE:test_loadtxt>
+add_test(NAME load_text COMMAND $<TARGET_FILE:test_loadtxt> ${CMAKE_CURRENT_BINARY_DIR}
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-add_test(NAME save_text COMMAND $<TARGET_FILE:test_savetxt>
+add_test(NAME save_text COMMAND $<TARGET_FILE:test_savetxt> ${CMAKE_CURRENT_BINARY_DIR}
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/tests/loadtxt/test_savetxt.f90
+++ b/src/tests/loadtxt/test_savetxt.f90
@@ -21,9 +21,9 @@ contains
 
     call get_command_argument(1, argv, status=ierr)
     if (ierr==0) then
-    outpath = trim(argv)
+        outpath = trim(argv)
     else
-    outpath = '.'
+        outpath = '.'
     endif
     end function get_outpath
 

--- a/src/tests/loadtxt/test_savetxt.f90
+++ b/src/tests/loadtxt/test_savetxt.f90
@@ -4,57 +4,77 @@ use stdlib_experimental_io, only: loadtxt, savetxt
 use stdlib_experimental_error, only: assert
 implicit none
 
-call test_sp()
-call test_dp()
-call test_qp()
+character(:), allocatable :: outpath
+
+outpath = get_outpath() // "/tmp.dat"
+
+call test_sp(outpath)
+call test_dp(outpath)
+call test_qp(outpath)
 
 contains
 
-    subroutine test_sp()
+    function get_outpath() result(outpath)
+    integer :: ierr
+    character(256) :: argv
+    character(:), allocatable :: outpath
+
+    call get_command_argument(1, argv, status=ierr)
+    if (ierr==0) then
+    outpath = trim(argv)
+    else
+    outpath = '.'
+    endif
+    end function get_outpath
+
+    subroutine test_sp(outpath)
+    character(*), intent(in) :: outpath
     real(sp) :: d(3, 2), e(2, 3)
     real(sp), allocatable :: d2(:, :)
     d = reshape([1, 2, 3, 4, 5, 6], [3, 2])
-    call savetxt("tmp.dat", d)
-    call loadtxt("tmp.dat", d2)
+    call savetxt(outpath, d)
+    call loadtxt(outpath, d2)
     call assert(all(shape(d2) == [3, 2]))
     call assert(all(abs(d-d2) < epsilon(1._sp)))
 
     e = reshape([1, 2, 3, 4, 5, 6], [2, 3])
-    call savetxt("tmp.dat", e)
-    call loadtxt("tmp.dat", d2)
+    call savetxt(outpath, e)
+    call loadtxt(outpath, d2)
     call assert(all(shape(d2) == [2, 3]))
     call assert(all(abs(e-d2) < epsilon(1._sp)))
     end subroutine
 
 
-    subroutine test_dp()
+    subroutine test_dp(outpath)
+    character(*), intent(in) :: outpath
     real(dp) :: d(3, 2), e(2, 3)
     real(dp), allocatable :: d2(:, :)
     d = reshape([1, 2, 3, 4, 5, 6], [3, 2])
-    call savetxt("tmp.dat", d)
-    call loadtxt("tmp.dat", d2)
+    call savetxt(outpath, d)
+    call loadtxt(outpath, d2)
     call assert(all(shape(d2) == [3, 2]))
     call assert(all(abs(d-d2) < epsilon(1._dp)))
 
     e = reshape([1, 2, 3, 4, 5, 6], [2, 3])
-    call savetxt("tmp.dat", e)
-    call loadtxt("tmp.dat", d2)
+    call savetxt(outpath, e)
+    call loadtxt(outpath, d2)
     call assert(all(shape(d2) == [2, 3]))
     call assert(all(abs(e-d2) < epsilon(1._dp)))
     end subroutine
 
-    subroutine test_qp()
+    subroutine test_qp(outpath)
+    character(*), intent(in) :: outpath
     real(qp) :: d(3, 2), e(2, 3)
     real(qp), allocatable :: d2(:, :)
     d = reshape([1, 2, 3, 4, 5, 6], [3, 2])
-    call savetxt("tmp.dat", d)
-    call loadtxt("tmp.dat", d2)
+    call savetxt(outpath, d)
+    call loadtxt(outpath, d2)
     call assert(all(shape(d2) == [3, 2]))
     call assert(all(abs(d-d2) < epsilon(1._qp)))
 
     e = reshape([1, 2, 3, 4, 5, 6], [2, 3])
-    call savetxt("tmp.dat", e)
-    call loadtxt("tmp.dat", d2)
+    call savetxt(outpath, e)
+    call loadtxt(outpath, d2)
     call assert(all(shape(d2) == [2, 3]))
     call assert(all(abs(e-d2) < epsilon(1._qp)))
     end subroutine


### PR DESCRIPTION
* use CMAKE_Fortran_MODULE_DIRECTORY to avoid introspecting directory structure
* don't build in-source, use test WORKING_DIRECTORY instead
* use modern add_test() syntax to avoid introspecting project directory structure
* use open(..., action=) to help indicate / safeguard intended file use
* don't have to accommodate CMake <= 2.4 circa 2006

closes #47 