### PR TITLE
Test in-tree builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,3 +59,10 @@ jobs:
 
     - name: test
       run: cmake --build build --target test
+
+    - name: Test in-tree builds
+      if: contains( matrix.gcc_v, '9') # Only test one compiler on each platform
+      run: |
+          cmake .
+          cmake --build .
+          cmake --build . --target test


### PR DESCRIPTION
This adds one in-tree build test for each platform, to ensure our CMake
build system works both out-of-tree as well as in-tree.

In terms of costs, it seems to add 1s on one Linux build, and 3s on one macOS build.