### PR TITLE
ci: add windows workflow

### DIFF
--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -1,0 +1,37 @@
+name: CI_windows
+
+on: [push, pull_request]
+
+env:
+  CI: "ON"
+
+jobs:
+  Build:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - run: cmake -G "MinGW Makefiles" -DCMAKE_SH="CMAKE_SH-NOTFOUND" -Wdev -B build
+      env:
+        FC: gfortran
+        CC: gcc
+        CXX: g++
+
+    - name: CMake build
+      run: cmake --build build --parallel
+
+    - run: cmake --build build --verbose --parallel 1
+      if: failure()
+
+    - name: CTest
+      run: ctest --parallel -V
+      working-directory: build
+
+    - uses: actions/upload-artifact@v1
+      if: failure()
+      with:
+        name: WindowsCMakeTestlog
+        path: build/Testing/Temporary/LastTest.log


### PR DESCRIPTION
It can be advantageous to have distinct workflows on a per-operating system basis,
to quickly see the scope of a failure.

This CI will fail until the quad-precision code is made conditional on a build system test (CMake >= 3.14 `check_fortran_source_runs()`) to make quad-precision optional in library and tests.
In the library, this can be done via Fortran `submodule`. In the test, it can be done via preprocessor `#ifdef usereal128` or similar introduced via CMake as a result of configure checks