### PR TITLE
Refactor the manual Makefiles

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -71,3 +71,5 @@ jobs:
       if: contains(matrix.os, 'ubuntu') && contains(matrix.gcc_v, '9')
       run: |
         make -f Makefile.manual
+        make -f Makefile.manual test
+        make -f Makefile.manual clean

--- a/Makefile.manual
+++ b/Makefile.manual
@@ -1,17 +1,21 @@
 # Fortran stdlib Makefile
 
 FC = gfortran
-FCFLAGS=-O0
+FCFLAGS = -Wall -Wextra -Wimplicit-interface -fPIC -g -fcheck=all
 
-.PHONY: all clean
+export FC
+export FCFLAGS
 
-all: stdlib tests 
+.PHONY: all clean test
 
-stdlib:
-	$(MAKE) -f Makefile.manual FC=${FC} FCFLAGS=${FCFLAGS} --directory=src
+all:
+	$(MAKE) -f Makefile.manual --directory=src
+	$(MAKE) -f Makefile.manual --directory=src/tests
 
-tests: stdlib
-	$(MAKE) -f Makefile.manual FC=${FC} FCFLAGS=${FCFLAGS} --directory=src/tests
+test:
+	$(MAKE) -f Makefile.manual --directory=src/tests test
+	@echo
+	@echo "All tests passed."
 
 clean:
 	$(MAKE) -f Makefile.manual clean --directory=src

--- a/Makefile.manual
+++ b/Makefile.manual
@@ -1,10 +1,10 @@
 # Fortran stdlib Makefile
 
 FC = gfortran
-FCFLAGS = -Wall -Wextra -Wimplicit-interface -fPIC -g -fcheck=all
+FFLAGS = -Wall -Wextra -Wimplicit-interface -fPIC -g -fcheck=all
 
 export FC
-export FCFLAGS
+export FFLAGS
 
 .PHONY: all clean test
 

--- a/src/Makefile.manual
+++ b/src/Makefile.manual
@@ -6,7 +6,6 @@ OBJS = stdlib_experimental_ascii.o \
 	   f18estop.o
 
 .PHONY: all clean
-.SUFFIXES: $(SUFFIXES) .f90 .o
 
 all: $(LIB)
 

--- a/src/Makefile.manual
+++ b/src/Makefile.manual
@@ -1,20 +1,20 @@
+LIB = libstdlib.a
+
 OBJS = stdlib_experimental_ascii.o \
        stdlib_experimental_error.o \
        stdlib_experimental_io.o \
+	   f18estop.o
 
 .PHONY: all clean
-.SUFFIXES: .f90 .o
+.SUFFIXES: $(SUFFIXES) .f90 .o
 
-all: $(OBJS)
+all: $(LIB)
 
-.f90.o:
-	$(FC) $(FCFLAGS) -c $<
-
-%.o: %.mod
-
-stdlib_experimental_ascii.o: stdlib_experimental_ascii.f90
-stdlib_experimental_error.o: stdlib_experimental_error.f90
-stdlib_experimental_io.o: stdlib_experimental_io.f90
+$(LIB): $(OBJS)
+	ar rcs $@ $(OBJS)
 
 clean:
-	$(RM) *.o *.mod
+	$(RM) $(LIB) $(OBJS) *.mod
+
+%.o: %.f90
+	$(FC) $(FCFLAGS) -c $<

--- a/src/Makefile.manual
+++ b/src/Makefile.manual
@@ -17,4 +17,4 @@ clean:
 	$(RM) $(LIB) $(OBJS) *.mod
 
 %.o: %.f90
-	$(FC) $(FCFLAGS) -c $<
+	$(FC) $(FFLAGS) -c $<

--- a/src/tests/Makefile.manual
+++ b/src/tests/Makefile.manual
@@ -1,12 +1,12 @@
-.PHONY: all clean
+.PHONY: all clean test
 
-all: ascii/test_ascii loadtxt/test_loadtxt
-
-ascii/test_ascii:
+all:
 	$(MAKE) -f Makefile.manual --directory=ascii
-
-loadtxt/test_loadtxt:
 	$(MAKE) -f Makefile.manual --directory=loadtxt
+
+test:
+	$(MAKE) -f Makefile.manual --directory=ascii test
+	$(MAKE) -f Makefile.manual --directory=loadtxt test
 
 clean:
 	$(MAKE) -f Makefile.manual --directory=ascii clean

--- a/src/tests/ascii/Makefile.manual
+++ b/src/tests/ascii/Makefile.manual
@@ -5,7 +5,6 @@ CPPFLAGS = -I../..
 LDFLAGS = -L../.. -lstdlib
 
 .PHONY: all clean test
-.SUFFIXES: $(SUFFIXES) .f90 .o
 
 all: $(PROG)
 

--- a/src/tests/ascii/Makefile.manual
+++ b/src/tests/ascii/Makefile.manual
@@ -10,7 +10,7 @@ LDFLAGS = -L../.. -lstdlib
 all: $(PROG)
 
 $(PROG): $(OBJS)
-	$(FC) $(FCFLAGS) $(CPPFLAGS) -o $@ $(OBJS) $(LDFLAGS)
+	$(FC) $(FFLAGS) $(CPPFLAGS) -o $@ $(OBJS) $(LDFLAGS)
 
 test:
 	./$(PROG)
@@ -19,4 +19,4 @@ clean:
 	$(RM) $(PROG) $(OBJS) *.mod
 
 %.o: %.f90
-	$(FC) $(FCFLAGS) $(CPPFLAGS) -c $<
+	$(FC) $(FFLAGS) $(CPPFLAGS) -c $<

--- a/src/tests/ascii/Makefile.manual
+++ b/src/tests/ascii/Makefile.manual
@@ -1,17 +1,22 @@
+PROG = test_ascii
+OBJS = test_ascii.o
+
 CPPFLAGS = -I../..
-OBJS = ../../stdlib_experimental_ascii.o \
-       ../../stdlib_experimental_error.o
+LDFLAGS = -L../.. -lstdlib
 
-.PHONY: all clean
-.SUFFIXES: .f90 .o
+.PHONY: all clean test
+.SUFFIXES: $(SUFFIXES) .f90 .o
 
-all: test_ascii
+all: $(PROG)
 
-test_ascii: test_ascii.f90 $(OBJS)
-	$(FC) $(FCFLAGS) $(CPPFLAGS) $< -o $@ $(OBJS)
+$(PROG): $(OBJS)
+	$(FC) $(FCFLAGS) $(CPPFLAGS) -o $@ $(OBJS) $(LDFLAGS)
 
-%.o: %.mod
+test:
+	./$(PROG)
 
 clean:
-	$(RM) test_ascii
-	$(RM) *.o *.mod
+	$(RM) $(PROG) $(OBJS) *.mod
+
+%.o: %.f90
+	$(FC) $(FCFLAGS) $(CPPFLAGS) -c $<

--- a/src/tests/loadtxt/Makefile.manual
+++ b/src/tests/loadtxt/Makefile.manual
@@ -2,7 +2,6 @@ CPPFLAGS = -I../..
 LDFLAGS = -L../.. -lstdlib
 
 .PHONY: all clean test
-.SUFFIXES: $(SUFFIXES) .f90 .o
 
 PROGS = test_loadtxt test_savetxt test_loadtxt_qp test_savetxt_qp
 OBJS = $(PROGS:=.o)

--- a/src/tests/loadtxt/Makefile.manual
+++ b/src/tests/loadtxt/Makefile.manual
@@ -1,20 +1,26 @@
 CPPFLAGS = -I../..
-OBJS = ../../stdlib_experimental_error.o \
-       ../../stdlib_experimental_io.o
+LDFLAGS = -L../.. -lstdlib
 
-.PHONY: all clean
-.SUFFIXES: .f90 .o
+.PHONY: all clean test
+.SUFFIXES: $(SUFFIXES) .f90 .o
 
-all: test_loadtxt test_savetxt
+PROGS = test_loadtxt test_savetxt test_loadtxt_qp test_savetxt_qp
+OBJS = $(PROGS:=.o)
 
-test_loadtxt: test_loadtxt.f90 $(OBJS)
-	$(FC) $(FCFLAGS) $(CPPFLAGS) $< -o $@ $(OBJS)
 
-test_savetxt: test_savetxt.f90 $(OBJS)
-	$(FC) $(FCFLAGS) $(CPPFLAGS) $< -o $@ $(OBJS)
+all: $(PROGS)
 
-%.o: %.mod
+$(PROGS): %: %.o
+	$(FC) $(FCFLAGS) $(CPPFLAGS) -o $@ $^ $(LDFLAGS)
+
+test:
+	./test_loadtxt
+	./test_loadtxt_qp
+	./test_savetxt
+	./test_savetxt_qp
 
 clean:
-	$(RM) test_loadtxt test_savetxt
-	$(RM) *.o *.mod
+	$(RM) $(PROGS) $(OBJS) tmp.dat tmp_qp.dat
+
+%.o: %.f90
+	$(FC) $(FCFLAGS) $(CPPFLAGS) -c $<

--- a/src/tests/loadtxt/Makefile.manual
+++ b/src/tests/loadtxt/Makefile.manual
@@ -11,7 +11,7 @@ OBJS = $(PROGS:=.o)
 all: $(PROGS)
 
 $(PROGS): %: %.o
-	$(FC) $(FCFLAGS) $(CPPFLAGS) -o $@ $^ $(LDFLAGS)
+	$(FC) $(FFLAGS) $(CPPFLAGS) -o $@ $^ $(LDFLAGS)
 
 test:
 	./test_loadtxt
@@ -23,4 +23,4 @@ clean:
 	$(RM) $(PROGS) $(OBJS) tmp.dat tmp_qp.dat
 
 %.o: %.f90
-	$(FC) $(FCFLAGS) $(CPPFLAGS) -c $<
+	$(FC) $(FFLAGS) $(CPPFLAGS) -c $<


### PR DESCRIPTION
* Compile the quadruple precision loadtxt
* Implement "make test" to run tests and run them at the CI
* Create a static libstdlib.a library and use it in tests
* Use more modern syntax and simplify
* Pass in the FC/FCFLAGS variables automatically
* Consolidate stdlib tests targets