### PR TITLE
Further Makefile improvements

### DIFF
--- a/src/Makefile.manual
+++ b/src/Makefile.manual
@@ -9,6 +9,7 @@ LIB = libstdlib.a
 
 OBJS = $(SRC:.f90=.o)
 MODS = $(OBJS:.o=.mod)
+SMODS = $(OBJS:.o=*.smod)
 
 .PHONY: all clean
 
@@ -18,7 +19,7 @@ $(LIB): $(OBJS)
 	ar rcs $@ $(OBJS)
 
 clean:
-	$(RM) $(LIB) $(OBJS) $(MODS)
+	$(RM) $(LIB) $(OBJS) $(MODS) $(SMODS)
 
 %.o: %.f90
 	$(FC) $(FFLAGS) -c $<

--- a/src/Makefile.manual
+++ b/src/Makefile.manual
@@ -5,6 +5,8 @@ OBJS = stdlib_experimental_ascii.o \
        stdlib_experimental_io.o \
 	   f18estop.o
 
+MODS = $(OBJS:.o=.mod)
+
 .PHONY: all clean
 
 all: $(LIB)
@@ -13,7 +15,7 @@ $(LIB): $(OBJS)
 	ar rcs $@ $(OBJS)
 
 clean:
-	$(RM) $(LIB) $(OBJS) *.mod
+	$(RM) $(LIB) $(OBJS) $(MODS)
 
 %.o: %.f90
 	$(FC) $(FFLAGS) -c $<

--- a/src/Makefile.manual
+++ b/src/Makefile.manual
@@ -22,3 +22,7 @@ clean:
 
 %.o: %.f90
 	$(FC) $(FFLAGS) -c $<
+
+
+# Fortran module dependencies
+f18estop.o: stdlib_experimental_error.o

--- a/src/Makefile.manual
+++ b/src/Makefile.manual
@@ -1,10 +1,13 @@
+SRC = stdlib_experimental_ascii.f90 \
+      stdlib_experimental_error.f90 \
+      stdlib_experimental_io.f90 \
+      f18estop.f90
+
 LIB = libstdlib.a
 
-OBJS = stdlib_experimental_ascii.o \
-       stdlib_experimental_error.o \
-       stdlib_experimental_io.o \
-	   f18estop.o
 
+
+OBJS = $(SRC:.f90=.o)
 MODS = $(OBJS:.o=.mod)
 
 .PHONY: all clean

--- a/src/tests/Makefile.manual.test.mk
+++ b/src/tests/Makefile.manual.test.mk
@@ -1,6 +1,8 @@
 # Common Makefile rules that are included from each test subdirectory's
 # Makefile
 
+CPPFLAGS += -I../..
+LDFLAGS += -L../.. -lstdlib
 
 OBJS = $(PROGS_SRC:.f90=.o)
 PROGS = $(OBJS:.o=)

--- a/src/tests/Makefile.manual.test.mk
+++ b/src/tests/Makefile.manual.test.mk
@@ -1,0 +1,25 @@
+# Common Makefile rules that are included from each test subdirectory's
+# Makefile
+
+
+OBJS = $(PROGS_SRC:.f90=.o)
+PROGS = $(OBJS:.o=)
+TESTPROGS = $(PROGS:=TEST)
+
+.PHONY: all clean test $(TESTPROGS)
+
+all: $(PROGS)
+
+test: $(TESTPROGS)
+
+$(TESTPROGS):
+	./$(@:TEST=)
+
+clean:
+	$(RM) $(PROGS) $(OBJS) $(CLEAN_FILES)
+
+%.o: %.f90
+	$(FC) $(FFLAGS) $(CPPFLAGS) -c $<
+
+$(PROGS): %: %.o
+	$(FC) $(FFLAGS) $(CPPFLAGS) -o $@ $^ $(LDFLAGS)

--- a/src/tests/ascii/Makefile.manual
+++ b/src/tests/ascii/Makefile.manual
@@ -1,21 +1,6 @@
-PROG = test_ascii
-OBJS = test_ascii.o
+PROGS_SRC = test_ascii.f90
 
 CPPFLAGS = -I../..
 LDFLAGS = -L../.. -lstdlib
 
-.PHONY: all clean test
-
-all: $(PROG)
-
-$(PROG): $(OBJS)
-	$(FC) $(FFLAGS) $(CPPFLAGS) -o $@ $(OBJS) $(LDFLAGS)
-
-test:
-	./$(PROG)
-
-clean:
-	$(RM) $(PROG) $(OBJS) *.mod
-
-%.o: %.f90
-	$(FC) $(FFLAGS) $(CPPFLAGS) -c $<
+include ../Makefile.manual.test.mk

--- a/src/tests/ascii/Makefile.manual
+++ b/src/tests/ascii/Makefile.manual
@@ -1,6 +1,4 @@
 PROGS_SRC = test_ascii.f90
 
-CPPFLAGS = -I../..
-LDFLAGS = -L../.. -lstdlib
 
 include ../Makefile.manual.test.mk

--- a/src/tests/loadtxt/Makefile.manual
+++ b/src/tests/loadtxt/Makefile.manual
@@ -3,22 +3,20 @@ PROGS_SRC = test_loadtxt.f90 \
 			test_loadtxt_qp.f90 \
 			test_savetxt_qp.f90
 
+CLEAN_FILES = tmp.dat tmp_qp.dat
+
 CPPFLAGS = -I../..
 LDFLAGS = -L../.. -lstdlib
+
 
 
 OBJS = $(PROGS_SRC:.f90=.o)
 PROGS = $(OBJS:.o=)
 TESTPROGS = $(PROGS:=TEST)
 
-
-
 .PHONY: all clean test $(TESTPROGS)
 
 all: $(PROGS)
-
-$(PROGS): %: %.o
-	$(FC) $(FFLAGS) $(CPPFLAGS) -o $@ $^ $(LDFLAGS)
 
 test: $(TESTPROGS)
 
@@ -26,7 +24,10 @@ $(TESTPROGS):
 	./$(@:TEST=)
 
 clean:
-	$(RM) $(PROGS) $(OBJS) tmp.dat tmp_qp.dat
+	$(RM) $(PROGS) $(OBJS) $(CLEAN_FILES)
 
 %.o: %.f90
 	$(FC) $(FFLAGS) $(CPPFLAGS) -c $<
+
+$(PROGS): %: %.o
+	$(FC) $(FFLAGS) $(CPPFLAGS) -o $@ $^ $(LDFLAGS)

--- a/src/tests/loadtxt/Makefile.manual
+++ b/src/tests/loadtxt/Makefile.manual
@@ -1,11 +1,18 @@
+PROGS_SRC = test_loadtxt.f90 \
+			test_savetxt.f90 \
+			test_loadtxt_qp.f90 \
+			test_savetxt_qp.f90
+
 CPPFLAGS = -I../..
 LDFLAGS = -L../.. -lstdlib
 
+
+OBJS = $(PROGS_SRC:.f90=.o)
+PROGS = $(OBJS:.o=)
+
+
+
 .PHONY: all clean test
-
-PROGS = test_loadtxt test_savetxt test_loadtxt_qp test_savetxt_qp
-OBJS = $(PROGS:=.o)
-
 
 all: $(PROGS)
 

--- a/src/tests/loadtxt/Makefile.manual
+++ b/src/tests/loadtxt/Makefile.manual
@@ -8,26 +8,4 @@ CLEAN_FILES = tmp.dat tmp_qp.dat
 CPPFLAGS = -I../..
 LDFLAGS = -L../.. -lstdlib
 
-
-
-OBJS = $(PROGS_SRC:.f90=.o)
-PROGS = $(OBJS:.o=)
-TESTPROGS = $(PROGS:=TEST)
-
-.PHONY: all clean test $(TESTPROGS)
-
-all: $(PROGS)
-
-test: $(TESTPROGS)
-
-$(TESTPROGS):
-	./$(@:TEST=)
-
-clean:
-	$(RM) $(PROGS) $(OBJS) $(CLEAN_FILES)
-
-%.o: %.f90
-	$(FC) $(FFLAGS) $(CPPFLAGS) -c $<
-
-$(PROGS): %: %.o
-	$(FC) $(FFLAGS) $(CPPFLAGS) -o $@ $^ $(LDFLAGS)
+include ../Makefile.manual.test.mk

--- a/src/tests/loadtxt/Makefile.manual
+++ b/src/tests/loadtxt/Makefile.manual
@@ -5,7 +5,5 @@ PROGS_SRC = test_loadtxt.f90 \
 
 CLEAN_FILES = tmp.dat tmp_qp.dat
 
-CPPFLAGS = -I../..
-LDFLAGS = -L../.. -lstdlib
 
 include ../Makefile.manual.test.mk

--- a/src/tests/loadtxt/Makefile.manual
+++ b/src/tests/loadtxt/Makefile.manual
@@ -9,21 +9,21 @@ LDFLAGS = -L../.. -lstdlib
 
 OBJS = $(PROGS_SRC:.f90=.o)
 PROGS = $(OBJS:.o=)
+TESTPROGS = $(PROGS:=TEST)
 
 
 
-.PHONY: all clean test
+.PHONY: all clean test $(TESTPROGS)
 
 all: $(PROGS)
 
 $(PROGS): %: %.o
 	$(FC) $(FFLAGS) $(CPPFLAGS) -o $@ $^ $(LDFLAGS)
 
-test:
-	./test_loadtxt
-	./test_loadtxt_qp
-	./test_savetxt
-	./test_savetxt_qp
+test: $(TESTPROGS)
+
+$(TESTPROGS):
+	./$(@:TEST=)
 
 clean:
 	$(RM) $(PROGS) $(OBJS) tmp.dat tmp_qp.dat


### PR DESCRIPTION
This further reduces the number of lines to maintain in Makefiles. The tests' Makefiles are now very short. In general we now simply list all the source files, similar to CMake.