### PR TITLE
Addition of checks and use of stdlib_experimental_ascii

### DIFF
--- a/src/stdlib_experimental_io.f90
+++ b/src/stdlib_experimental_io.f90
@@ -287,7 +287,7 @@ character(*), intent(in), optional :: mode
 integer, intent(out), optional :: io
 
 integer :: io_
-character(3):: mode_
+character(3) :: mode_
 character(:),allocatable :: action_, position_, status_, access_, form_
 
 

--- a/src/stdlib_experimental_io.f90
+++ b/src/stdlib_experimental_io.f90
@@ -232,16 +232,16 @@ integer function number_of_columns(s)
 
  integer :: ios
  character :: c
- logical :: lastwhite
+ logical :: lastblank
 
  rewind(s)
  number_of_columns = 0
- lastwhite = .true.
+ lastblank = .true.
  do
     read(s, '(a)', advance='no', iostat=ios) c
     if (ios /= 0) exit
-    if (lastwhite .and. .not. is_blank(c)) number_of_columns = number_of_columns + 1
-    lastwhite = is_blank(c)
+    if (lastblank .and. .not. is_blank(c)) number_of_columns = number_of_columns + 1
+    lastblank = is_blank(c)
  end do
  rewind(s)
 

--- a/src/stdlib_experimental_io.f90
+++ b/src/stdlib_experimental_io.f90
@@ -266,7 +266,7 @@ integer function number_of_rows_numeric(s)
 
 end function
 
-integer function open(filename, mode, io) result(u)
+integer function open(filename, mode, iostat) result(u)
 ! Open a file
 !
 ! To open a file to read:
@@ -284,7 +284,7 @@ integer function open(filename, mode, io) result(u)
 
 character(*), intent(in) :: filename
 character(*), intent(in), optional :: mode
-integer, intent(out), optional :: io
+integer, intent(out), optional :: iostat
 
 integer :: io_
 character(3) :: mode_
@@ -341,12 +341,16 @@ case default
     call error_stop("Unsupported mode: "//mode_(3:3))
 end select
 
-open(newunit=u, file=filename, &
-     action = action_, position = position_, status = status_, &
-     access = access_, form = form_, &
-     iostat = io_)
-
-if(present(io))io=io_
+if (present(iostat)) then
+    open(newunit=u, file=filename, &
+         action = action_, position = position_, status = status_, &
+         access = access_, form = form_, &
+         iostat = iostat)
+else
+    open(newunit=u, file=filename, &
+         action = action_, position = position_, status = status_, &
+         access = access_, form = form_)
+end if
 
 end function
 

--- a/src/stdlib_experimental_io.f90
+++ b/src/stdlib_experimental_io.f90
@@ -275,7 +275,7 @@ else
 end if
 end function
 
-integer function open(filename, mode) result(u)
+integer function open(filename, mode, io) result(u)
 ! Open a file
 !
 ! To open a file to read:
@@ -293,7 +293,9 @@ integer function open(filename, mode) result(u)
 
 character(*), intent(in) :: filename
 character(*), intent(in), optional :: mode
-integer :: io
+integer, intent(out), optional :: io
+
+integer :: io_
 character(3):: mode_
 character(:),allocatable :: action_, position_, status_, access_, form_
 
@@ -351,7 +353,9 @@ end select
 open(newunit=u, file=filename, &
      action = action_, position = position_, status = status_, &
      access = access_, form = form_, &
-     iostat = io)
+     iostat = io_)
+
+if(present(io))io=io_
 
 end function
 

--- a/src/stdlib_experimental_io.f90
+++ b/src/stdlib_experimental_io.f90
@@ -2,6 +2,7 @@ module stdlib_experimental_io
 use iso_fortran_env, only: sp=>real32, dp=>real64, qp=>real128
 use stdlib_experimental_error, only: error_stop
 use stdlib_experimental_optval, only: optval
+use stdlib_experimental_ascii, only: is_blank
 implicit none
 private
 ! Public API
@@ -239,8 +240,8 @@ integer function number_of_columns(s)
  do
     read(s, '(a)', advance='no', iostat=ios) c
     if (ios /= 0) exit
-    if (lastwhite .and. .not. whitechar(c)) number_of_columns = number_of_columns + 1
-    lastwhite = whitechar(c)
+    if (lastwhite .and. .not. is_blank(c)) number_of_columns = number_of_columns + 1
+    lastwhite = is_blank(c)
  end do
  rewind(s)
 
@@ -263,16 +264,6 @@ integer function number_of_rows_numeric(s)
 
  rewind(s)
 
-end function
-
-pure logical function whitechar(char) ! white character
-! returns .true. if char is space (32) or tab (9), .false. otherwise
-character, intent(in) :: char
-if (iachar(char) == 32 .or. iachar(char) == 9) then
-    whitechar = .true.
-else
-    whitechar = .false.
-end if
 end function
 
 integer function open(filename, mode, io) result(u)

--- a/src/stdlib_experimental_io.f90
+++ b/src/stdlib_experimental_io.f90
@@ -358,27 +358,35 @@ end function
 character(3) function parse_mode(mode) result(mode_)
 character(*), intent(in) :: mode
 
-integer::i
-character(:),allocatable::a
+integer :: i
+character(:),allocatable :: a
+logical :: lfirst(3)
 
 mode_ = 'r t'
 
 if (len_trim(mode) == 0) return
 a=trim(adjustl(mode))
 
+lfirst = .true.
 do i=1,len(a)
-    select case (a(i:i))
-    case('r', 'w', 'a', 'x')
+    if (lfirst(1) &
+        .and. (a(i:i) == 'r' .or. a(i:i) == 'w' .or. a(i:i) == 'a' .or. a(i:i) == 'x') &
+        ) then
         mode_(1:1) = a(i:i)
-    case('+')
+        lfirst(1)=.false.
+    else if (lfirst(2) .and. a(i:i) == '+') then
         mode_(2:2) = a(i:i)
-    case('t', 'b')
+        lfirst(2)=.false.
+    else if (lfirst(3) .and. (a(i:i) == 't' .or. a(i:i) == 'b')) then
         mode_(3:3) = a(i:i)
-    case(' ')
-        cycle
-    case default
+        lfirst(3)=.false.
+    else if (a(i:i) == ' ') then
+     cycle
+    else if(any(.not.lfirst)) then
+        call error_stop("Wrong mode: "//trim(a))
+    else
         call error_stop("Wrong character: "//a(i:i))
-    end select
+    endif
 end do
 
 end function

--- a/src/tests/io/test_open.f90
+++ b/src/tests/io/test_open.f90
@@ -6,16 +6,6 @@ implicit none
 character(:), allocatable :: filename
 integer :: io, u, a(3)
 
-!Wrong open
-filename = get_outpath() // "/does_not_exist.error"
-
-u = open(filename, "a", io)
-call assert(io /= 0)
-
-u = open(filename, "r", io)
-call assert(io /= 0)
-
-
 ! Text file
 filename = get_outpath() // "/io_open.dat"
 
@@ -47,30 +37,49 @@ close(u)
 filename = get_outpath() // "/io_open.stream"
 
 ! Test mode "w"
-u = open(filename, "wb", io)
-call assert(io == 0)
+u = open(filename, "wb")
 write(u) 1, 2, 3
 close(u)
 
 ! Test mode "r"
-u = open(filename, "rb", io)
-call assert(io == 0)
+u = open(filename, "rb")
 read(u) a
 call assert(all(a == [1, 2, 3]))
 close(u)
 
 ! Test mode "a"
-u = open(filename, "ab", io)
-call assert(io == 0)
+u = open(filename, "ab")
 write(u) 4, 5, 6
 close(u)
-u = open(filename, "rb", io)
-call assert(io == 0)
+u = open(filename, "rb")
 read(u) a
 call assert(all(a == [1, 2, 3]))
 read(u) a
 call assert(all(a == [4, 5, 6]))
 close(u)
+
+
+
+!0 and non-0 open
+filename = get_outpath() // "/io_open.stream"
+
+u = open(filename, "rb", io)
+call assert(io == 0)
+if (io == 0) close(u)
+
+u = open(filename, "ab")
+call assert(io == 0)
+if (io == 0) close(u)
+
+
+filename = get_outpath() // "/does_not_exist.error"
+
+u = open(filename, "a", io)
+call assert(io /= 0)
+
+u = open(filename, "r", io)
+call assert(io /= 0)
+
 
 contains
 

--- a/src/tests/io/test_open.f90
+++ b/src/tests/io/test_open.f90
@@ -67,7 +67,7 @@ u = open(filename, "rb", io)
 call assert(io == 0)
 if (io == 0) close(u)
 
-u = open(filename, "ab")
+u = open(filename, "ab", io)
 call assert(io == 0)
 if (io == 0) close(u)
 

--- a/src/tests/io/test_open.f90
+++ b/src/tests/io/test_open.f90
@@ -4,7 +4,16 @@ use stdlib_experimental_error, only: assert
 implicit none
 
 character(:), allocatable :: filename
-integer :: u, a(3)
+integer :: io, u, a(3)
+
+!Wrong open
+filename = get_outpath() // "/does_not_exist.error"
+
+u = open(filename, "a", io)
+call assert(io /= 0)
+
+u = open(filename, "r", io)
+call assert(io /= 0)
 
 
 ! Text file
@@ -38,21 +47,25 @@ close(u)
 filename = get_outpath() // "/io_open.stream"
 
 ! Test mode "w"
-u = open(filename, "wb")
+u = open(filename, "wb", io)
+call assert(io == 0)
 write(u) 1, 2, 3
 close(u)
 
 ! Test mode "r"
-u = open(filename, "rb")
+u = open(filename, "rb", io)
+call assert(io == 0)
 read(u) a
 call assert(all(a == [1, 2, 3]))
 close(u)
 
 ! Test mode "a"
-u = open(filename, "ab")
+u = open(filename, "ab", io)
+call assert(io == 0)
 write(u) 4, 5, 6
 close(u)
-u = open(filename, "rb")
+u = open(filename, "rb", io)
+call assert(io == 0)
 read(u) a
 call assert(all(a == [1, 2, 3]))
 read(u) a

--- a/src/tests/io/test_parse_mode.f90
+++ b/src/tests/io/test_parse_mode.f90
@@ -9,6 +9,8 @@ call test_parse_mode_reverse_order()
 
 call test_parse_mode_random_order()
 
+!call test_parse_mode_always_fail()
+
 contains
 
     subroutine test_parse_mode_expected_order()
@@ -149,21 +151,35 @@ contains
 
     m = parse_mode("tr+ ")
     call assert(m == "r+t")
-    m = parse_mode("wtt + ")
+    m = parse_mode("wt + ")
     call assert(m == "w+t")
     m = parse_mode("a + t")
     call assert(m == "a+t")
     m = parse_mode(" xt + ")
     call assert(m == "x+t")
 
-    m = parse_mode("t + t")
+    m = parse_mode(" + t")
     call assert(m == "r+t")
-    m = parse_mode(" ww + b")
+    m = parse_mode(" +w  b")
     call assert(m == "w+b")
     m = parse_mode("a + b")
     call assert(m == "a+b")
     m = parse_mode(" b + x  ")
     call assert(m == "x+b")
+
+    end subroutine
+
+    subroutine test_parse_mode_always_fail()
+    character(3) :: m
+
+    m = parse_mode("r+w")
+    call assert(m /= "r t")
+
+    m = parse_mode("tt")
+    call assert(m /= "r t")
+
+    m = parse_mode("bt")
+    call assert(m /= "r t")
 
     end subroutine
 


### PR DESCRIPTION
Additions/changes:
- some checks in `parse_mode` to return errors for modes such as `rr`, `rw`, `r++t`, `rbt`. (Note: I couldn't add these tests in CMake, or it should be one per file)
- the function `open` can return the `iostat` if requested
- (@certik) since #49 has been closed, `whitechar` is now replaced by `is_blank`


@scivision : Because I added checks in the function `parse_mode`, it uses again `if` statements instead of `select case`. Good for you?
