### PR TITLE
stdlib_experimental_io(open): support for unformatted sequential files

### DIFF
--- a/src/stdlib_experimental_io.f90
+++ b/src/stdlib_experimental_io.f90
@@ -337,6 +337,9 @@ case('t')
 case('b', 's')
     access_='stream'
     form_='unformatted'
+case('u')
+    access_='sequential'
+    form_='unformatted'
 case default
     call error_stop("Unsupported mode: "//mode_(3:3))
 end select
@@ -376,7 +379,10 @@ do i=1,len(a)
     else if (lfirst(2) .and. a(i:i) == '+') then
         mode_(2:2) = a(i:i)
         lfirst(2)=.false.
-    else if (lfirst(3) .and. (a(i:i) == 't' .or. a(i:i) == 'b')) then
+    else if (lfirst(3) &
+             .and. (a(i:i) == 't' &
+             .or. a(i:i) == 'b' .or. a(i:i) == 's'&
+             .or. a(i:i) == 'u')) then
         mode_(3:3) = a(i:i)
         lfirst(3)=.false.
     else if (a(i:i) == ' ') then
@@ -385,7 +391,7 @@ do i=1,len(a)
         call error_stop("Wrong mode: "//trim(a))
     else
         call error_stop("Wrong character: "//a(i:i))
-    endif
+    end if
 end do
 
 end function

--- a/src/tests/io/Makefile.manual
+++ b/src/tests/io/Makefile.manual
@@ -5,7 +5,7 @@ PROGS_SRC = test_loadtxt.f90 \
 			test_parse_mode.f90 \
 			test_open.f90
 
-CLEAN_FILES = tmp.dat tmp_qp.dat io_open.dat io_open.stream
+CLEAN_FILES = tmp.dat tmp_qp.dat io_open.dat io_open.stream io_open.bin
 
 
 include ../Makefile.manual.test.mk

--- a/src/tests/io/test_open.f90
+++ b/src/tests/io/test_open.f90
@@ -59,6 +59,31 @@ call assert(all(a == [4, 5, 6]))
 close(u)
 
 
+! Unformatted sequential file
+filename = get_outpath() // "/io_open.bin"
+
+! Test mode "w"
+u = open(filename, "wu")
+write(u) 1, 2, 3
+close(u)
+
+! Test mode "r"
+u = open(filename, "ru")
+read(u) a
+call assert(all(a == [1, 2, 3]))
+close(u)
+
+! Test mode "a"
+u = open(filename, "au")
+write(u) 4, 5, 6
+close(u)
+u = open(filename, "ru")
+read(u) a
+call assert(all(a == [1, 2, 3]))
+read(u) a
+call assert(all(a == [4, 5, 6]))
+close(u)
+
 
 !0 and non-0 open
 filename = get_outpath() // "/io_open.stream"


### PR DESCRIPTION
Addition of a support for opening unformatted sequential files