### PR TITLE
Addition of access in the API of open function

### DIFF
--- a/src/stdlib_experimental_io.f90
+++ b/src/stdlib_experimental_io.f90
@@ -347,8 +347,8 @@ access_ = 'stream'
 
 if (present(access)) then
     select case (trim(adjustl(access)))
-    case('direct')
-        access_ = 'direct'
+!    case('direct')
+!        access_ = 'direct'
     case('sequential')
         access_ = 'sequential'
     case('stream')

--- a/src/stdlib_experimental_io.f90
+++ b/src/stdlib_experimental_io.f90
@@ -269,7 +269,7 @@ integer function number_of_rows_numeric(s)
 
 end function
 
-integer function open(filename, mode, iostat) result(u)
+integer function open(filename, mode, iostat, access) result(u)
 ! Open a file
 !
 ! To open a file to read:
@@ -287,6 +287,7 @@ integer function open(filename, mode, iostat) result(u)
 
 character(*), intent(in) :: filename
 character(*), intent(in), optional :: mode
+character(*), intent(in), optional :: access
 integer, intent(out), optional :: iostat
 
 integer :: io_
@@ -298,51 +299,64 @@ mode_ = parse_mode(optval(mode, ""))
 
 select case (mode_(1:2))
 case('r')
-    action_='read'
-    position_='asis'
-    status_='old'
+    action_ = 'read'
+    position_ = 'asis'
+    status_ = 'old'
 case('w')
-    action_='write'
-    position_='asis'
-    status_='replace'
+    action_ = 'write'
+    position_ = 'asis'
+    status_ = 'replace'
 case('a')
-    action_='write'
-    position_='append'
-    status_='old'
+    action_ = 'write'
+    position_ = 'append'
+    status_ = 'old'
 case('x')
-    action_='write'
-    position_='asis'
-    status_='new'
+    action_ = 'write'
+    position_ = 'asis'
+    status_ = 'new'
 case('r+')
-    action_='readwrite'
-    position_='asis'
-    status_='old'
+    action_ = 'readwrite'
+    position_ = 'asis'
+    status_ = 'old'
 case('w+')
-    action_='readwrite'
-    position_='asis'
-    status_='replace'
+    action_ = 'readwrite'
+    position_ = 'asis'
+    status_ = 'replace'
 case('a+')
-    action_='readwrite'
-    position_='append'
-    status_='old'
+    action_ = 'readwrite'
+    position_ = 'append'
+    status_ = 'old'
 case('x+')
-    action_='readwrite'
-    position_='asis'
-    status_='new'
+    action_ = 'readwrite'
+    position_ = 'asis'
+    status_ = 'new'
 case default
     call error_stop("Unsupported mode: "//mode_(1:2))
 end select
 
 select case (mode_(3:3))
 case('t')
-    form_='formatted'
+    form_ = 'formatted'
 case('b')
-    form_='unformatted'
+    form_ = 'unformatted'
 case default
     call error_stop("Unsupported mode: "//mode_(3:3))
 end select
 
 access_ = 'stream'
+
+if (present(access)) then
+    select case (trim(adjustl(access)))
+    case('direct')
+        access_ = 'direct'
+    case('sequential')
+        access_ = 'sequential'
+    case('stream')
+        access_ = 'stream'
+    case default
+        call error_stop("Unsupported access: "//trim(access))
+    end select
+end if
 
 if (present(iostat)) then
     open(newunit=u, file=filename, &

--- a/src/tests/io/Makefile.manual
+++ b/src/tests/io/Makefile.manual
@@ -5,7 +5,9 @@ PROGS_SRC = test_loadtxt.f90 \
 			test_parse_mode.f90 \
 			test_open.f90
 
-CLEAN_FILES = tmp.dat tmp_qp.dat io_open.dat io_open.stream
+CLEAN_FILES = tmp.dat tmp_qp.dat \
+		io_open_seq.dat io_open_stream.dat \
+		io_open_seq.bin io_open_stream.bin
 
 
 include ../Makefile.manual.test.mk

--- a/src/tests/io/test_open.f90
+++ b/src/tests/io/test_open.f90
@@ -6,8 +6,8 @@ implicit none
 character(:), allocatable :: filename
 integer :: io, u, a(3)
 
-! Text file
-filename = get_outpath() // "/io_open.dat"
+! Stream text file
+filename = get_outpath() // "/io_open_stream.dat"
 
 ! Test mode "w"
 u = open(filename, "w")
@@ -32,9 +32,34 @@ call assert(all(a == [4, 5, 6]))
 close(u)
 
 
+! Sequential text file
+filename = get_outpath() // "/io_open_seq.dat"
 
-! Stream file
-filename = get_outpath() // "/io_open.stream"
+! Test mode "w"
+u = open(filename, "w", access = 'sequential')
+write(u, *) 1, 2, 3
+close(u)
+
+! Test mode "r"
+u = open(filename, "r", access = 'sequential')
+read(u, *) a
+call assert(all(a == [1, 2, 3]))
+close(u)
+
+! Test mode "a"
+u = open(filename, "a", access = 'sequential')
+write(u, *) 4, 5, 6
+close(u)
+u = open(filename, "r", access = 'sequential')
+read(u, *) a
+call assert(all(a == [1, 2, 3]))
+read(u, *) a
+call assert(all(a == [4, 5, 6]))
+close(u)
+
+
+! Stream binary file
+filename = get_outpath() // "/io_open_stream.bin"
 
 ! Test mode "w"
 u = open(filename, "wb")
@@ -59,9 +84,34 @@ call assert(all(a == [4, 5, 6]))
 close(u)
 
 
+! Sequential binary file
+filename = get_outpath() // "/io_open_seq.bin"
+
+! Test mode "w"
+u = open(filename, "wb", access = 'sequential')
+write(u) 1, 2, 3
+close(u)
+
+! Test mode "r"
+u = open(filename, "rb", access = 'sequential')
+read(u) a
+call assert(all(a == [1, 2, 3]))
+close(u)
+
+! Test mode "a"
+u = open(filename, "ab", access = 'sequential')
+write(u) 4, 5, 6
+close(u)
+u = open(filename, "rb", access = 'sequential')
+read(u) a
+call assert(all(a == [1, 2, 3]))
+read(u) a
+call assert(all(a == [4, 5, 6]))
+close(u)
+
 
 !0 and non-0 open
-filename = get_outpath() // "/io_open.stream"
+filename = get_outpath() // "/io_open_stream.bin"
 
 u = open(filename, "rb", io)
 call assert(io == 0)


### PR DESCRIPTION
Here is a proposition for allowing different accesses in the API of `open`.
The default access is `stream` for both formatted and unformatted files.
This is based on discussions in #86 and in #14, and needs further discussion.