### PR TITLE
ci ctest enhancements

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,6 +7,7 @@ env:
   CMAKE_BUILD_PARALLEL_LEVEL: "2" # 2 cores on each GHA VM, enable parallel builds
   CTEST_OUTPUT_ON_FAILURE: "ON" # This way we don't need a flag to ctest
   CTEST_PARALLEL_LEVEL: "2"
+  CTEST_TIME_TIMEOUT: "5"  # some failures hang forever
   HOMEBREW_NO_ANALYTICS: "ON" # Make Homebrew installation a little quicker
   HOMEBREW_NO_AUTO_UPDATE: "ON"
   HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK: "ON"
@@ -55,10 +56,15 @@ jobs:
       run: cmake -Wdev -DCMAKE_BUILD_TYPE=Release -S . -B build
 
     - name: Build and compile
-      run: cmake --build build || cmake --build build --verbose --parallel 1
+      run: cmake --build build
+
+    - name: catch build fail
+      run: cmake --build build --verbose --parallel 1
+      if: failure()
 
     - name: test
-      run: cmake --build build --target test
+      run: ctest --parallel --output-on-failure
+      working-directory: build
 
     - name: Test in-tree builds
       if: contains( matrix.gcc_v, '9') # Only test one compiler on each platform

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 env:
   CI: "ON"
+  CTEST_TIME_TIMEOUT: "5"  # some failures hang forever
 
 jobs:
   Build:
@@ -24,7 +25,8 @@ jobs:
     - name: CMake build
       run: cmake --build build --parallel
 
-    - run: cmake --build build --verbose --parallel 1
+    - name: catch build fail
+      run: cmake --build build --verbose --parallel 1
       if: failure()
 
     - name: CTest


### PR DESCRIPTION
* broken tests sometimes hang forever, and that's CTest's default, so make CTest have a finite timeout by default
* don't rely on shell-specific `||` to catch test failures, use a platform-agnostic `if:`
* invoke `ctest` directly to allow easier option access