### PR TITLE
make real128 optional

### DIFF
--- a/.github/workflows/ci_real128.yml
+++ b/.github/workflows/ci_real128.yml
@@ -1,4 +1,4 @@
-name: CI_windows
+name: ci_real128
 
 on: [push, pull_request]
 
@@ -6,16 +6,24 @@ env:
   CI: "ON"
 
 jobs:
-  cmake:
-    runs-on: windows-latest
+  linux:
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
 
     steps:
     - uses: actions/checkout@v1
 
-    - run: cmake -G "MinGW Makefiles" -DCMAKE_SH="CMAKE_SH-NOTFOUND" -Wdev -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_Fortran_FLAGS_DEBUG="-Wall -Wextra -Wimplicit-interface -fPIC -g -fcheck=all -fbacktrace"
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.x
 
+    - name: Set up CMake
+      run: pip install --upgrade cmake
+
+    - name: Cmake configure
+    - run: cmake -DREAL128=true -B build
       env:
         FC: gfortran
         CC: gcc
@@ -28,11 +36,11 @@ jobs:
       if: failure()
 
     - name: CTest
-      run: ctest --output-on-failure --parallel -V -LE quadruple_precision
+      run: ctest --output-on-failure --parallel -V
       working-directory: build
 
     - uses: actions/upload-artifact@v1
       if: failure()
       with:
-        name: WindowsCMakeTestlog
+        name: Real128CMakeTestlog
         path: build/Testing/Temporary/LastTest.log

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ enable_testing()
 #  and thereby can clash if module/submodule names are the same in different parts of library
 set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR})
 
+option(REAL128 "make real128 precision available")
+
 # --- compiler options
 if(CMAKE_Fortran_COMPILER_ID STREQUAL GNU)
   add_compile_options(-fimplicit-none)
@@ -21,5 +23,8 @@ include(CheckFortranSourceCompiles)
 include(CheckFortranSourceRuns)
 check_fortran_source_compiles("error stop i; end" f18errorstop SRC_EXT f90)
 check_fortran_source_runs("use, intrinsic :: iso_fortran_env, only : real128; real(real128) :: x; x = x+1; end" f03real128)
+if(NOT f03real128)
+  set(REAL128 false)
+endif()
 
 add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,9 +1,9 @@
 set(SRC
     stdlib_experimental_ascii.f90
-    stdlib_experimental_io.f90
+    stdlib_experimental_io.F90
     stdlib_experimental_error.f90
-    stdlib_experimental_optval.f90
-    stdlib_experimental_kinds.f90
+    stdlib_experimental_optval.F90
+    stdlib_experimental_kinds.F90
 )
 
 add_library(fortran_stdlib ${SRC})
@@ -12,6 +12,11 @@ if(f18errorstop)
   target_sources(fortran_stdlib PRIVATE f18estop.f90)
 else()
   target_sources(fortran_stdlib PRIVATE f08estop.f90)
+endif()
+
+if(REAL128)
+  target_compile_definitions(fortran_stdlib PRIVATE REAL128)
+  target_sources(fortran_stdlib PRIVATE io_qp.f90 opt_qp.f90)
 endif()
 
 add_subdirectory(tests)

--- a/src/io_qp.f90
+++ b/src/io_qp.f90
@@ -1,0 +1,74 @@
+submodule (stdlib_experimental_io) io_qp
+
+use stdlib_experimental_kinds, only : qp
+
+implicit none
+
+contains
+
+module procedure qloadtxt
+! Loads a 2D array from a text file.
+!
+! Arguments
+! ---------
+!
+! Filename to load the array from
+! The array 'd' will be automatically allocated with the correct dimensions
+!
+! Example
+! -------
+!
+! real(qp), allocatable :: data(:, :)
+! call loadtxt("log.txt", data)  ! 'data' will be automatically allocated
+!
+! Where 'log.txt' contains for example::
+!
+!     1 2 3
+!     2 4 6
+!     8 9 10
+!     11 12 13
+!     ...
+!
+integer :: s
+integer :: nrow,ncol,i
+
+s = open(filename)
+
+! determine number of columns
+ncol = number_of_columns(s)
+
+! determine number or rows
+nrow = number_of_rows_numeric(s)
+
+allocate(d(nrow, ncol))
+do i = 1, nrow
+    read(s, *) d(i, :)
+end do
+close(s)
+end procedure
+
+module procedure qsavetxt
+  ! Saves a 2D array into a textfile.
+  !
+  ! Arguments
+  ! ---------
+  !
+  !
+  ! Example
+  ! -------
+  !
+  ! real(dp) :: data(3, 2)
+  ! call savetxt("log.txt", data)
+
+  integer :: s, i
+  character(len=14) :: format_string
+
+  write(format_string, '(a1,i06,a7)') '(', size(d, 2), 'f40.34)'
+  s = open(filename, "w")
+  do i = 1, size(d, 1)
+      write(s, format_string) d(i, :)
+  end do
+  close(s)
+end procedure
+
+end submodule

--- a/src/opt_qp.f90
+++ b/src/opt_qp.f90
@@ -1,0 +1,15 @@
+submodule (stdlib_experimental_optval) opt_qp
+
+implicit none
+
+contains
+
+module procedure optval_qp
+  if (present(x)) then
+      y = x
+  else
+      y = default
+  end if
+end procedure optval_qp
+
+end submodule opt_qp

--- a/src/stdlib_experimental_kinds.F90
+++ b/src/stdlib_experimental_kinds.F90
@@ -1,10 +1,16 @@
 module stdlib_experimental_kinds
-use iso_fortran_env, only: sp=>real32, dp=>real64, qp=>real128
+use iso_fortran_env, only: sp=>real32, dp=>real64
+#ifdef REAL128
+use iso_fortran_env, only: qp=>real128
+#endif
 use iso_fortran_env, only: int8, int16, int32, int64
 ! If we decide later to use iso_fortran_env instead of iso_fortran_env:
 !use iso_c_binding, only: sp=>c_float, dp=>c_double, qp=>c_float128
 !use iso_c_binding, only: int8=>c_int8_t, int16=>c_int16_t, int32=>c_int32_t, int64=>c_int64_t
 implicit none
 private
-public sp, dp, qp, int8, int16, int32, int64
+public :: sp, dp, int8, int16, int32, int64
+#ifdef REAL128
+public :: qp
+#endif
 end module

--- a/src/stdlib_experimental_optval.F90
+++ b/src/stdlib_experimental_optval.F90
@@ -8,7 +8,11 @@ module stdlib_experimental_optval
   !!
   !! It is an error to call `optval` with a single actual argument.
   !!
-  use stdlib_experimental_kinds, only: sp, dp, qp, int8, int16, int32, int64
+  use stdlib_experimental_kinds, only: sp, dp, int8, int16, int32, int64
+#ifdef REAL128
+  use stdlib_experimental_kinds, only : qp
+#endif
+
   implicit none
 
 
@@ -19,7 +23,9 @@ module stdlib_experimental_optval
   interface optval
      module procedure optval_sp
      module procedure optval_dp
+#ifdef REAL128
      module procedure optval_qp
+#endif
      module procedure optval_int8
      module procedure optval_int16
      module procedure optval_int32
@@ -30,6 +36,15 @@ module stdlib_experimental_optval
      ! TODO: differentiate ascii & ucs char kinds
   end interface optval
 
+#ifdef REAL128
+  interface
+    module pure function optval_qp(x, default) result(y)
+      real(qp), intent(in), optional :: x
+      real(qp), intent(in) :: default
+      real(qp) :: y
+    end function
+  end interface
+#endif
 
 contains
 
@@ -58,19 +73,6 @@ contains
        y = default
     end if
   end function optval_dp
-
-
-  pure function optval_qp(x, default) result(y)
-    real(qp), intent(in), optional :: x
-    real(qp), intent(in) :: default
-    real(qp) :: y
-
-    if (present(x)) then
-       y = x
-    else
-       y = default
-    end if
-  end function optval_qp
 
 
   pure function optval_int8(x, default) result(y)

--- a/src/tests/io/CMakeLists.txt
+++ b/src/tests/io/CMakeLists.txt
@@ -1,10 +1,12 @@
 ADDTEST(loadtxt)
 ADDTEST(savetxt)
 
-ADDTEST(loadtxt_qp)
-ADDTEST(savetxt_qp)
-set_tests_properties(loadtxt_qp PROPERTIES LABELS quadruple_precision)
-set_tests_properties(savetxt_qp PROPERTIES LABELS quadruple_precision)
+if(REAL128)
+  ADDTEST(loadtxt_qp)
+  ADDTEST(savetxt_qp)
+  set_tests_properties(loadtxt_qp PROPERTIES LABELS quadruple_precision)
+  set_tests_properties(savetxt_qp PROPERTIES LABELS quadruple_precision)
+endif()
 
 ADDTEST(open)
 ADDTEST(parse_mode)

--- a/src/tests/optval/CMakeLists.txt
+++ b/src/tests/optval/CMakeLists.txt
@@ -1,1 +1,8 @@
-ADDTEST(optval)
+add_executable(test_optval test_optval.F90)
+target_link_libraries(test_optval fortran_stdlib)
+if(REAL128)
+  target_compile_definitions(test_optval PRIVATE REAL128)
+endif()
+add_test(NAME optval
+         COMMAND $<TARGET_FILE:test_optval> ${CMAKE_CURRENT_BINARY_DIR}
+         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/tests/optval/test_optval.F90
+++ b/src/tests/optval/test_optval.F90
@@ -9,8 +9,9 @@ program test_optval
 
   call test_optval_sp
   call test_optval_dp
+#ifdef REAL128
   call test_optval_qp
-
+#endif
   call test_optval_int8
   call test_optval_int16
   call test_optval_int32
@@ -22,14 +23,14 @@ program test_optval
 
 contains
 
-  
+
   subroutine test_optval_sp
     print *, "test_optval_sp"
     call assert(foo_sp(1.0_sp) == 1.0_sp)
     call assert(foo_sp() == 2.0_sp)
   end subroutine test_optval_sp
 
-  
+
   function foo_sp(x) result(z)
     real(sp), intent(in), optional :: x
     real(sp) :: z
@@ -43,41 +44,41 @@ contains
     call assert(foo_dp() == 2.0_dp)
   end subroutine test_optval_dp
 
-  
+
   function foo_dp(x) result(z)
     real(dp), intent(in), optional :: x
     real(dp) :: z
     z = optval(x, 2.0_dp)
   endfunction foo_dp
 
-
+#ifdef REAL128
   subroutine test_optval_qp
     print *, "test_optval_qp"
     call assert(foo_qp(1.0_qp) == 1.0_qp)
     call assert(foo_qp() == 2.0_qp)
   end subroutine test_optval_qp
 
-  
+
   function foo_qp(x) result(z)
     real(qp), intent(in), optional :: x
     real(qp) :: z
     z = optval(x, 2.0_qp)
   endfunction foo_qp
-  
-  
+#endif
+
   subroutine test_optval_int8
     print *, "test_optval_int8"
     call assert(foo_int8(1_int8) == 1_int8)
     call assert(foo_int8() == 2_int8)
   end subroutine test_optval_int8
 
-  
+
   function foo_int8(x) result(z)
     integer(int8), intent(in), optional :: x
     integer(int8) :: z
     z = optval(x, 2_int8)
   endfunction foo_int8
-  
+
 
   subroutine test_optval_int16
     print *, "test_optval_int16"
@@ -85,41 +86,41 @@ contains
     call assert(foo_int16() == 2_int16)
   end subroutine test_optval_int16
 
-  
+
   function foo_int16(x) result(z)
     integer(int16), intent(in), optional :: x
     integer(int16) :: z
     z = optval(x, 2_int16)
   endfunction foo_int16
 
-  
+
   subroutine test_optval_int32
     print *, "test_optval_int32"
     call assert(foo_int32(1_int32) == 1_int32)
     call assert(foo_int32() == 2_int32)
   end subroutine test_optval_int32
 
-  
+
   function foo_int32(x) result(z)
     integer(int32), intent(in), optional :: x
     integer(int32) :: z
     z = optval(x, 2_int32)
   endfunction foo_int32
 
-  
+
   subroutine test_optval_int64
     print *, "test_optval_int64"
     call assert(foo_int64(1_int64) == 1_int64)
     call assert(foo_int64() == 2_int64)
   end subroutine test_optval_int64
 
-  
+
   function foo_int64(x) result(z)
     integer(int64), intent(in), optional :: x
     integer(int64) :: z
     z = optval(x, 2_int64)
   endfunction foo_int64
-  
+
 
   subroutine test_optval_logical
     print *, "test_optval_logical"
@@ -127,13 +128,13 @@ contains
     call assert(.not.foo_logical())
   end subroutine test_optval_logical
 
-  
+
   function foo_logical(x) result(z)
     logical, intent(in), optional :: x
     logical :: z
     z = optval(x, .false.)
   endfunction foo_logical
-  
+
 
   subroutine test_optval_character
     print *, "test_optval_character"
@@ -141,11 +142,11 @@ contains
     call assert(foo_character() == "y")
   end subroutine test_optval_character
 
-  
+
   function foo_character(x) result(z)
     character(len=*), intent(in), optional :: x
     character(len=:), allocatable :: z
     z = optval(x, "y")
   endfunction foo_character
-  
+
 end program test_optval


### PR DESCRIPTION
fixes #88 
using Fortran `submodule`. The Makefiles would need to accommodate these changes

This is a cleaner, more modular approach than #83, which this supercedes.

To use real128, one would do 

```sh
cmake -B build -DREAL128=true
```

then this method can be extended for `real16` or other "exotic" kinds.

---

alternatives:

* generated source code
* just enclosing large bits of code inside `#ifdef`