### PR TITLE
Update CMakeLists handling of .mod files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,11 +2,6 @@ cmake_minimum_required(VERSION 3.14.0)
 project(stdlib Fortran)
 enable_testing()
 
-# this avoids stdlib and projects using stdlib from having to introspect stdlib's directory structure
-# FIXME: this eventually needs to be handled more precisely, as this spills all .mod/.smod into one directory
-#  and thereby can clash if module/submodule names are the same in different parts of library
-set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR})
-
 # --- compiler options
 if(CMAKE_Fortran_COMPILER_ID STREQUAL GNU)
   add_compile_options(-fimplicit-none)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,14 @@ set(SRC
 
 add_library(fortran_stdlib ${SRC})
 
+set(LIB_MOD_DIR ${CMAKE_CURRENT_BINARY_DIR}/mod_files/)
+set_target_properties(fortran_stdlib PROPERTIES
+    Fortran_MODULE_DIRECTORY ${LIB_MOD_DIR})
+target_include_directories(fortran_stdlib PUBLIC
+    $<BUILD_INTERFACE:${LIB_MOD_DIR}>
+    $<INSTALL_INTERFACE:include>
+)
+
 if(f18errorstop)
   target_sources(fortran_stdlib PRIVATE f18estop.f90)
 else()
@@ -22,3 +30,4 @@ install(TARGETS fortran_stdlib
         ARCHIVE DESTINATION lib
         LIBRARY DESTINATION lib
     )
+install(DIRECTORY ${LIB_MOD_DIR} DESTINATION include)


### PR DESCRIPTION
This resolves the issue @certik noted in #108 with the NAG compiler not finding the .mod files. It's unclear to me why things worked with other compilers, as this change is not NAG-specific at all.

This also handles installation of the .mod files (or whatever the compiler creates) which was missing before. One question is where the .mod files should be installed. This installs them into `include`, but it is arguably better to install them alongside the library file in the `lib` directory.

I've tested this with Intel and NAG (temporarily using the workarounds from #108).