### PR TITLE
Add spec for optval

### DIFF
--- a/src/stdlib_experimental_optval.md
+++ b/src/stdlib_experimental_optval.md
@@ -10,7 +10,7 @@
 
 Returns `x` if it is PRESENT, otherwise `default`. 
 
-This function is intended to be called in a proceudre with one or more OPTIONAL arguments, in order to conveniently fall back to a default value if an OPTIONAL argument is not PRESENT.
+This function is intended to be called in a procedure with one or more OPTIONAL arguments, in order to conveniently fall back to a default value if an OPTIONAL argument is not PRESENT.
 
 ### Syntax
 
@@ -40,7 +40,7 @@ contains
     real function root(x, n)
 	real, intent(in) :: x
         integer, intent(in), optional :: n
-	root = x**(1.0/optval(n, 2))
+        root = x**(1.0/optval(n, 2))
     end function root
 end program demo_optval
 ```

--- a/src/stdlib_experimental_optval.md
+++ b/src/stdlib_experimental_optval.md
@@ -1,0 +1,46 @@
+# Default values for optional arguments
+
+## Implemented
+
+* `optval`
+
+## `optval` - fallback value for optional arguments
+
+### Description
+
+Returns `x` if it is PRESENT, otherwise `default`. 
+
+This function is intended to be called in a proceudre with one or more OPTIONAL arguments, in order to conveniently fall back to a default value if an OPTIONAL argument is not PRESENT.
+
+### Syntax
+
+`result = optval(x, default)`
+
+### Arguments
+
+`x`: Shall be of type `integer`, `real`, `complex`, or `logical`, or a scalar of type `character`.
+
+`default`: Shall have the same type, kind, and rank as `x`.
+
+### Return value
+
+If `x` is PRESENT, the result is `x`, otherwise the result is `default`.
+
+### Example
+
+```fortran
+program demo_optval
+    use stdlib_experimental_optval, only: optval
+	implicit none
+	print *, root(64.0)
+! 8.0
+    print *, root(64.0, 3)
+! 4.0
+contains
+    real function root(x, n)
+	    real, intent(in) :: x
+	    integer, intent(in), optional :: n
+		root = x**(1.0/optval(n, 2))
+    end function root
+end program demo_optval
+```

--- a/src/stdlib_experimental_optval.md
+++ b/src/stdlib_experimental_optval.md
@@ -31,16 +31,16 @@ If `x` is PRESENT, the result is `x`, otherwise the result is `default`.
 ```fortran
 program demo_optval
     use stdlib_experimental_optval, only: optval
-	implicit none
-	print *, root(64.0)
+    implicit none
+    print *, root(64.0)
 ! 8.0
     print *, root(64.0, 3)
 ! 4.0
 contains
     real function root(x, n)
-	    real, intent(in) :: x
-	    integer, intent(in), optional :: n
-		root = x**(1.0/optval(n, 2))
+	real, intent(in) :: x
+        integer, intent(in), optional :: n
+	root = x**(1.0/optval(n, 2))
     end function root
 end program demo_optval
 ```

--- a/src/stdlib_experimental_optval.md
+++ b/src/stdlib_experimental_optval.md
@@ -8,9 +8,9 @@
 
 ### Description
 
-Returns `x` if it is PRESENT, otherwise `default`. 
+Returns `x` if it is present, otherwise `default`. 
 
-This function is intended to be called in a procedure with one or more OPTIONAL arguments, in order to conveniently fall back to a default value if an OPTIONAL argument is not PRESENT.
+This function is intended to be called in a procedure with one or more `optional` arguments, in order to conveniently fall back to a default value if an `optional` argument is not present.
 
 ### Syntax
 
@@ -24,7 +24,7 @@ This function is intended to be called in a procedure with one or more OPTIONAL 
 
 ### Return value
 
-If `x` is PRESENT, the result is `x`, otherwise the result is `default`.
+If `x` is present, the result is `x`, otherwise the result is `default`.
 
 ### Example
 


### PR DESCRIPTION
I based this on the structure of the spec for `mean`. Things I'm not 100% sure of

- Is an "implemented" section necessary for this case?
- Do we want language-defined terms capitalized or formatted some other way, e.g., PRESENT vs present vs `present`?
- Is my mixed usage of "default" and "fallback" a problem?