### PR TITLE
Use epsilon() for tolerances

### DIFF
--- a/src/tests/stats/test_mean.f90
+++ b/src/tests/stats/test_mean.f90
@@ -5,8 +5,8 @@ use stdlib_experimental_io, only: loadtxt
 use stdlib_experimental_stats, only: mean
 implicit none
 
-real(sp), parameter :: sptol = 1.2e-06_sp
-real(dp), parameter :: dptol = 2.2e-15_dp
+real(sp), parameter :: sptol = 10 * epsilon(1._sp)
+real(dp), parameter :: dptol = 10 * epsilon(1._dp)
 
 real(sp) :: s1(3) = [1.0_sp, 2.0_sp, 3.0_sp]
 


### PR DESCRIPTION
The original tolerances look arbitrary:

    real(sp), parameter :: sptol = 1.2e-06_sp
    real(dp), parameter :: dptol = 2.2e-15_dp

but when written using epsilon() they are almost exactly 10x the machine
epsilon for the particular precision kind:

    real(sp), parameter :: sptol = 10.06633 * epsilon(1._sp)
    real(dp), parameter :: dptol = 9.907919 * epsilon(1._dp)

so I just rounded it to 10:

    real(sp), parameter :: sptol = 10 * epsilon(1._sp)
    real(dp), parameter :: dptol = 10 * epsilon(1._dp)

which now shows the intent more clearly: the tolerance assumes we lose
one digit of accuracy.