### PR TITLE
Enable make for quadrature

### DIFF
--- a/src/Makefile.manual
+++ b/src/Makefile.manual
@@ -1,9 +1,11 @@
-SRC = stdlib_experimental_ascii.f90 \
+SRC = f18estop.f90 \
+      stdlib_experimental_ascii.f90 \
       stdlib_experimental_error.f90 \
       stdlib_experimental_io.f90 \
-      stdlib_experimental_optval.f90 \
       stdlib_experimental_kinds.f90 \
-      f18estop.f90 \
+      stdlib_experimental_optval.f90 \
+      stdlib_experimental_quadrature.f90 \
+      stdlib_experimental_quadrature_trapz.f90 \
       stdlib_experimental_stats.f90 \
       stdlib_experimental_stats_mean.f90 \
       stdlib_experimental_stats_var.f90
@@ -39,6 +41,7 @@ stdlib_experimental_io.o: \
 	stdlib_experimental_optval.o \
 	stdlib_experimental_kinds.o
 stdlib_experimental_optval.o: stdlib_experimental_kinds.o
+stdlib_experimental_quadrature.o: stdlib_experimental_kinds.o
 stdlib_experimental_stats_mean.o: \
 	stdlib_experimental_optval.o \
 	stdlib_experimental_kinds.o \
@@ -47,7 +50,10 @@ stdlib_experimental_stats_var.o: \
 	stdlib_experimental_optval.o \
 	stdlib_experimental_kinds.o \
 	stdlib_experimental_stats.o
+
+# Fortran sources that are built from fypp templates
 stdlib_experimental_io.f90: stdlib_experimental_io.fypp
+stdlib_experimental_quadrature.f90: stdlib_experimental_quadrature.fypp
 stdlib_experimental_stats.f90: stdlib_experimental_stats.fypp
 stdlib_experimental_stats_mean.f90: stdlib_experimental_stats_mean.fypp
 stdlib_experimental_stats_var.f90: stdlib_experimental_stats_var.fypp

--- a/src/tests/Makefile.manual
+++ b/src/tests/Makefile.manual
@@ -4,12 +4,14 @@ all:
 	$(MAKE) -f Makefile.manual --directory=ascii
 	$(MAKE) -f Makefile.manual --directory=io
 	$(MAKE) -f Makefile.manual --directory=optval
+	$(MAKE) -f Makefile.manual --directory=quadrature
 	$(MAKE) -f Makefile.manual --directory=stats
 
 test:
 	$(MAKE) -f Makefile.manual --directory=ascii test
 	$(MAKE) -f Makefile.manual --directory=io test
 	$(MAKE) -f Makefile.manual --directory=optval test
+	$(MAKE) -f Makefile.manual --directory=quadrature test
 	$(MAKE) -f Makefile.manual --directory=stats test
 
 clean:


### PR DESCRIPTION
This PR enables building the new quadrature module, as well as tests, with the manual Makefiles.