### PR TITLE
Addition of TOCs in Markdown files

### DIFF
--- a/src/stdlib_experimental_io.md
+++ b/src/stdlib_experimental_io.md
@@ -1,7 +1,5 @@
 # IO
 
-## Implemented
-
 * [`loadtxt` - load a 2D array from a text file](#loadtxt---load-a-2d-array-from-a-text-file)
 * [`open` - open a file](#open---open-a-file)
 * [`savetxt` - save a 2D array into a text file](#savetxt---save-a-2d-array-into-a-text-file)

--- a/src/stdlib_experimental_io.md
+++ b/src/stdlib_experimental_io.md
@@ -2,28 +2,9 @@
 
 ## Implemented
 
-<!-- vim-markdown-toc GFM -->
-
 * [`loadtxt` - load a 2D array from a text file](#loadtxt---load-a-2d-array-from-a-text-file)
-	* [Description](#description)
-	* [Syntax](#syntax)
-	* [Arguments](#arguments)
-	* [Return value](#return-value)
-	* [Example](#example)
 * [`open` - open a file](#open---open-a-file)
-	* [Description](#description-1)
-	* [Syntax](#syntax-1)
-	* [Arguments](#arguments-1)
-	* [Return value](#return-value-1)
-	* [Example](#example-1)
 * [`savetxt` - save a 2D array into a text file](#savetxt---save-a-2d-array-into-a-text-file)
-	* [Description](#description-2)
-	* [Syntax](#syntax-2)
-	* [Arguments](#arguments-2)
-	* [Output](#output)
-	* [Example](#example-2)
-
-<!-- vim-markdown-toc -->
 
 ## `loadtxt` - load a 2D array from a text file
 

--- a/src/stdlib_experimental_io.md
+++ b/src/stdlib_experimental_io.md
@@ -2,10 +2,28 @@
 
 ## Implemented
 
- * `loadtxt`
- * `open`
- * `savetxt`
+<!-- vim-markdown-toc GFM -->
 
+* [`loadtxt` - load a 2D array from a text file](#loadtxt---load-a-2d-array-from-a-text-file)
+	* [Description](#description)
+	* [Syntax](#syntax)
+	* [Arguments](#arguments)
+	* [Return value](#return-value)
+	* [Example](#example)
+* [`open` - open a file](#open---open-a-file)
+	* [Description](#description-1)
+	* [Syntax](#syntax-1)
+	* [Arguments](#arguments-1)
+	* [Return value](#return-value-1)
+	* [Example](#example-1)
+* [`savetxt` - save a 2D array into a text file](#savetxt---save-a-2d-array-into-a-text-file)
+	* [Description](#description-2)
+	* [Syntax](#syntax-2)
+	* [Arguments](#arguments-2)
+	* [Output](#output)
+	* [Example](#example-2)
+
+<!-- vim-markdown-toc -->
 
 ## `loadtxt` - load a 2D array from a text file
 

--- a/src/stdlib_experimental_optval.md
+++ b/src/stdlib_experimental_optval.md
@@ -2,17 +2,7 @@
 
 ## Implemented
 
-
-<!-- vim-markdown-toc GFM -->
-
 * [`optval` - fallback value for optional arguments](#optval---fallback-value-for-optional-arguments)
-	* [Description](#description)
-	* [Syntax](#syntax)
-	* [Arguments](#arguments)
-	* [Return value](#return-value)
-	* [Example](#example)
-
-<!-- vim-markdown-toc -->
 
 ## `optval` - fallback value for optional arguments
 

--- a/src/stdlib_experimental_optval.md
+++ b/src/stdlib_experimental_optval.md
@@ -1,7 +1,5 @@
 # Default values for optional arguments
 
-## Implemented
-
 * [`optval` - fallback value for optional arguments](#optval---fallback-value-for-optional-arguments)
 
 ## `optval` - fallback value for optional arguments

--- a/src/stdlib_experimental_optval.md
+++ b/src/stdlib_experimental_optval.md
@@ -2,7 +2,17 @@
 
 ## Implemented
 
-* `optval`
+
+<!-- vim-markdown-toc GFM -->
+
+* [`optval` - fallback value for optional arguments](#optval---fallback-value-for-optional-arguments)
+	* [Description](#description)
+	* [Syntax](#syntax)
+	* [Arguments](#arguments)
+	* [Return value](#return-value)
+	* [Example](#example)
+
+<!-- vim-markdown-toc -->
 
 ## `optval` - fallback value for optional arguments
 

--- a/src/stdlib_experimental_quadrature.md
+++ b/src/stdlib_experimental_quadrature.md
@@ -2,8 +2,30 @@
 
 ## Implemented
 
-* `trapz`
-* `trapz_weights`
+<!-- vim-markdown-toc GFM -->
+
+	* [`trapz` - integrate sampled values using trapezoidal rule](#trapz---integrate-sampled-values-using-trapezoidal-rule)
+		* [Syntax](#syntax)
+		* [Arguments](#arguments)
+		* [Return value](#return-value)
+		* [Example](#example)
+	* [`trapz_weights` - trapezoidal rule weights for given abscissas](#trapz_weights---trapezoidal-rule-weights-for-given-abscissas)
+		* [Syntax](#syntax-1)
+		* [Arguments](#arguments-1)
+		* [Return value](#return-value-1)
+		* [Example](#example-1)
+* [`simps` - integrate sampled values using Simpson's rule (to be implemented)](#simps---integrate-sampled-values-using-simpsons-rule-to-be-implemented)
+		* [Syntax](#syntax-2)
+		* [Arguments](#arguments-2)
+		* [Return value](#return-value-2)
+		* [Example](#example-2)
+* [`simps_weights` - Simpson's rule weights for given abscissas (to be implemented)](#simps_weights---simpsons-rule-weights-for-given-abscissas-to-be-implemented)
+		* [Syntax](#syntax-3)
+		* [Arguments](#arguments-3)
+		* [Return value](#return-value-3)
+		* [Example](#example-3)
+
+<!-- vim-markdown-toc -->
 
 ## `trapz` - integrate sampled values using trapezoidal rule
 
@@ -78,7 +100,7 @@ end program
 
 ```
 
-# `simps` - integrate sampled values using Simpson's rule
+# `simps` - integrate sampled values using Simpson's rule (to be implemented)
 
 Returns the Simpson's rule integral of an array `y` representing discrete samples of a function. The integral is computed assuming either equidistant abscissas with spacing `dx` or arbitary abscissas `x`. 
 
@@ -112,7 +134,7 @@ If the size of `y` is two, the result is the same as if `trapz` had been called 
 
 TBD
 
-# `simps_weights` - Simpson's rule weights for given abscissas
+# `simps_weights` - Simpson's rule weights for given abscissas (to be implemented)
 
 Given an array of abscissas `x`, computes the array of weights `w` such that if `y` represented function values tabulated at `x`, then `sum(w*y)` produces a Simpson's rule approximation to the integral.
 

--- a/src/stdlib_experimental_quadrature.md
+++ b/src/stdlib_experimental_quadrature.md
@@ -1,7 +1,5 @@
 # Numerical integration
 
-## Implemented
-
 * [`trapz` - integrate sampled values using trapezoidal rule](#trapz---integrate-sampled-values-using-trapezoidal-rule)
 * [`trapz_weights` - trapezoidal rule weights for given abscissas](#trapz_weights---trapezoidal-rule-weights-for-given-abscissas)
 * [`simps` - integrate sampled values using Simpson's rule (to be implemented)](#simps---integrate-sampled-values-using-simpsons-rule-to-be-implemented)

--- a/src/stdlib_experimental_quadrature.md
+++ b/src/stdlib_experimental_quadrature.md
@@ -5,21 +5,25 @@
 <!-- vim-markdown-toc GFM -->
 
 * [`trapz` - integrate sampled values using trapezoidal rule](#trapz---integrate-sampled-values-using-trapezoidal-rule)
+	* [Description](#description)
 	* [Syntax](#syntax)
 	* [Arguments](#arguments)
 	* [Return value](#return-value)
 	* [Example](#example)
 * [`trapz_weights` - trapezoidal rule weights for given abscissas](#trapz_weights---trapezoidal-rule-weights-for-given-abscissas)
+	* [Description](#description-1)
 	* [Syntax](#syntax-1)
 	* [Arguments](#arguments-1)
 	* [Return value](#return-value-1)
 	* [Example](#example-1)
 * [`simps` - integrate sampled values using Simpson's rule (to be implemented)](#simps---integrate-sampled-values-using-simpsons-rule-to-be-implemented)
+	* [Description](#description-2)
 	* [Syntax](#syntax-2)
 	* [Arguments](#arguments-2)
 	* [Return value](#return-value-2)
 	* [Example](#example-2)
 * [`simps_weights` - Simpson's rule weights for given abscissas (to be implemented)](#simps_weights---simpsons-rule-weights-for-given-abscissas-to-be-implemented)
+	* [Description](#description-3)
 	* [Syntax](#syntax-3)
 	* [Arguments](#arguments-3)
 	* [Return value](#return-value-3)
@@ -28,6 +32,8 @@
 <!-- vim-markdown-toc -->
 
 ## `trapz` - integrate sampled values using trapezoidal rule
+
+### Description
 
 Returns the trapezoidal rule integral of an array `y` representing discrete samples of a function. The integral is computed assuming either equidistant abscissas with spacing `dx` or arbitary abscissas `x`.
 
@@ -68,6 +74,8 @@ end program
 
 ## `trapz_weights` - trapezoidal rule weights for given abscissas
 
+### Description
+
 Given an array of abscissas `x`, computes the array of weights `w` such that if `y` represented function values tabulated at `x`, then `sum(w*y)` produces a trapezoidal rule approximation to the integral.
 
 ### Syntax
@@ -102,6 +110,8 @@ end program
 
 ## `simps` - integrate sampled values using Simpson's rule (to be implemented)
 
+### Description
+
 Returns the Simpson's rule integral of an array `y` representing discrete samples of a function. The integral is computed assuming either equidistant abscissas with spacing `dx` or arbitary abscissas `x`. 
 
 Simpson's rule is defined for odd-length arrays only. For even-length arrays, an optional argument `even` may be used to specify at which index to replace Simpson's rule with Simpson's 3/8 rule. The 3/8 rule will be used for the array section `y(even:even+4)` and the ordinary Simpon's rule will be used elsewhere.
@@ -135,6 +145,8 @@ If the size of `y` is two, the result is the same as if `trapz` had been called 
 TBD
 
 ## `simps_weights` - Simpson's rule weights for given abscissas (to be implemented)
+
+### Description
 
 Given an array of abscissas `x`, computes the array of weights `w` such that if `y` represented function values tabulated at `x`, then `sum(w*y)` produces a Simpson's rule approximation to the integral.
 

--- a/src/stdlib_experimental_quadrature.md
+++ b/src/stdlib_experimental_quadrature.md
@@ -4,26 +4,26 @@
 
 <!-- vim-markdown-toc GFM -->
 
-	* [`trapz` - integrate sampled values using trapezoidal rule](#trapz---integrate-sampled-values-using-trapezoidal-rule)
-		* [Syntax](#syntax)
-		* [Arguments](#arguments)
-		* [Return value](#return-value)
-		* [Example](#example)
-	* [`trapz_weights` - trapezoidal rule weights for given abscissas](#trapz_weights---trapezoidal-rule-weights-for-given-abscissas)
-		* [Syntax](#syntax-1)
-		* [Arguments](#arguments-1)
-		* [Return value](#return-value-1)
-		* [Example](#example-1)
+* [`trapz` - integrate sampled values using trapezoidal rule](#trapz---integrate-sampled-values-using-trapezoidal-rule)
+	* [Syntax](#syntax)
+	* [Arguments](#arguments)
+	* [Return value](#return-value)
+	* [Example](#example)
+* [`trapz_weights` - trapezoidal rule weights for given abscissas](#trapz_weights---trapezoidal-rule-weights-for-given-abscissas)
+	* [Syntax](#syntax-1)
+	* [Arguments](#arguments-1)
+	* [Return value](#return-value-1)
+	* [Example](#example-1)
 * [`simps` - integrate sampled values using Simpson's rule (to be implemented)](#simps---integrate-sampled-values-using-simpsons-rule-to-be-implemented)
-		* [Syntax](#syntax-2)
-		* [Arguments](#arguments-2)
-		* [Return value](#return-value-2)
-		* [Example](#example-2)
+	* [Syntax](#syntax-2)
+	* [Arguments](#arguments-2)
+	* [Return value](#return-value-2)
+	* [Example](#example-2)
 * [`simps_weights` - Simpson's rule weights for given abscissas (to be implemented)](#simps_weights---simpsons-rule-weights-for-given-abscissas-to-be-implemented)
-		* [Syntax](#syntax-3)
-		* [Arguments](#arguments-3)
-		* [Return value](#return-value-3)
-		* [Example](#example-3)
+	* [Syntax](#syntax-3)
+	* [Arguments](#arguments-3)
+	* [Return value](#return-value-3)
+	* [Example](#example-3)
 
 <!-- vim-markdown-toc -->
 
@@ -100,7 +100,7 @@ end program
 
 ```
 
-# `simps` - integrate sampled values using Simpson's rule (to be implemented)
+## `simps` - integrate sampled values using Simpson's rule (to be implemented)
 
 Returns the Simpson's rule integral of an array `y` representing discrete samples of a function. The integral is computed assuming either equidistant abscissas with spacing `dx` or arbitary abscissas `x`. 
 
@@ -134,7 +134,7 @@ If the size of `y` is two, the result is the same as if `trapz` had been called 
 
 TBD
 
-# `simps_weights` - Simpson's rule weights for given abscissas (to be implemented)
+## `simps_weights` - Simpson's rule weights for given abscissas (to be implemented)
 
 Given an array of abscissas `x`, computes the array of weights `w` such that if `y` represented function values tabulated at `x`, then `sum(w*y)` produces a Simpson's rule approximation to the integral.
 

--- a/src/stdlib_experimental_quadrature.md
+++ b/src/stdlib_experimental_quadrature.md
@@ -2,34 +2,10 @@
 
 ## Implemented
 
-<!-- vim-markdown-toc GFM -->
-
 * [`trapz` - integrate sampled values using trapezoidal rule](#trapz---integrate-sampled-values-using-trapezoidal-rule)
-	* [Description](#description)
-	* [Syntax](#syntax)
-	* [Arguments](#arguments)
-	* [Return value](#return-value)
-	* [Example](#example)
 * [`trapz_weights` - trapezoidal rule weights for given abscissas](#trapz_weights---trapezoidal-rule-weights-for-given-abscissas)
-	* [Description](#description-1)
-	* [Syntax](#syntax-1)
-	* [Arguments](#arguments-1)
-	* [Return value](#return-value-1)
-	* [Example](#example-1)
 * [`simps` - integrate sampled values using Simpson's rule (to be implemented)](#simps---integrate-sampled-values-using-simpsons-rule-to-be-implemented)
-	* [Description](#description-2)
-	* [Syntax](#syntax-2)
-	* [Arguments](#arguments-2)
-	* [Return value](#return-value-2)
-	* [Example](#example-2)
 * [`simps_weights` - Simpson's rule weights for given abscissas (to be implemented)](#simps_weights---simpsons-rule-weights-for-given-abscissas-to-be-implemented)
-	* [Description](#description-3)
-	* [Syntax](#syntax-3)
-	* [Arguments](#arguments-3)
-	* [Return value](#return-value-3)
-	* [Example](#example-3)
-
-<!-- vim-markdown-toc -->
 
 ## `trapz` - integrate sampled values using trapezoidal rule
 

--- a/src/stdlib_experimental_stats.md
+++ b/src/stdlib_experimental_stats.md
@@ -2,28 +2,10 @@
 
 
 ## Implemented
-<!-- vim-markdown-toc GFM -->
 
 * [`mean` - mean of array elements](#mean---mean-of-array-elements)
-	* [Description](#description)
-	* [Syntax](#syntax)
-	* [Arguments](#arguments)
-	* [Return value](#return-value)
-	* [Example](#example)
 * [`moment` - central moment of array elements](#moment---central-moment-of-array-elements)
-	* [Description](#description-1)
-	* [Syntax](#syntax-1)
-	* [Arguments](#arguments-1)
-	* [Return value](#return-value-1)
-	* [Example](#example-1)
 * [`var` - variance of array elements](#var---variance-of-array-elements)
-	* [Description](#description-2)
-	* [Syntax](#syntax-2)
-	* [Arguments](#arguments-2)
-	* [Return value](#return-value-2)
-	* [Example](#example-2)
-
-<!-- vim-markdown-toc -->
 
 ## `mean` - mean of array elements
 

--- a/src/stdlib_experimental_stats.md
+++ b/src/stdlib_experimental_stats.md
@@ -1,8 +1,5 @@
 # Descriptive statistics
 
-
-## Implemented
-
 * [`mean` - mean of array elements](#mean---mean-of-array-elements)
 * [`moment` - central moment of array elements](#moment---central-moment-of-array-elements)
 * [`var` - variance of array elements](#var---variance-of-array-elements)


### PR DESCRIPTION
Some specs already contain multiple functions. So I thought it could be good to add TOCs for clarity.
Of course, it can be discussed/modified/removed, as usual.