### PR TITLE
adapt_CI: correction to avoid RANK>4 in Github actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -73,7 +73,7 @@ jobs:
     - name: Test in-tree builds
       if: contains( matrix.gcc_v, '9') # Only test one compiler on each platform
       run: |
-          cmake .
+          cmake -DCMAKE_MAXIMUM_RANK=4 .
           cmake --build .
           cmake --build . --target test
 


### PR DESCRIPTION
I think I found the issue in #161 for which the Github action failed due to too long times needed for the manual Makefiles.

The issue is that the tests for in-tree builds generate the `.f90` from `fypp` with RANK = 15. Because these are generated before running the manual Makefiles (and that there is no cleaning), the manual Makefiles do not generate them anymore, and try to compile all the `.f90` files generated with RANK=15 (instead of RANK=4 as for CMake).

This proposition fixes this issue (and will fix the issue in #161 once merged there).

Times needed for the checks are also now more manageable.

 