### PR TITLE
specified order of attributes #167

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -59,7 +59,7 @@ focus on the semantics of the proposed changes rather than style and formatting.
   real, dimension(:,:), allocatable :: b
   ```
 
-  When defining a lot of arrays of the same dimension ```dimension``` can be used as an exception.
+When defining many arrays of the same dimension, ```dimension``` can be used as an exception if it makes the code less verbose.
 * If ```optional``` attribute is used to declare a dummy argument, it should follow the intent attribute
 
 ## End <scope> block closing statements

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -44,7 +44,7 @@ focus on the semantics of the proposed changes rather than style and formatting.
 
 ## Attributes
 
-* Always specify ```intent``` for dummy arguments
+* Always specify ```intent``` for dummy arguments.
 * Don't use ```dimension``` attribute to declare arrays because it is less verbose.
   Use this:
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -42,14 +42,25 @@ focus on the semantics of the proposed changes rather than style and formatting.
 * Where conventional and appropriate shortening of a word is used then the underscore may be omitted,
   for example `linspace` is preferred over `lin_space`
 
-## Order of attributes
+## Attributes
 
-Similiar to the guidlines for indentation and whitespace, specifiying the order of appearance of attributes can  help reviewing code and git-diffs.
+* Always specify ```intent``` for dummy arguments
+* Don't use ```dimension``` attribute to declare arrays because it is less verbose.
+  Use this:
 
-1. ```dimension```
-2. ```allocatable```
-3. ```intent(intent-spec)```
-4. ```optional```
+  ```
+  real, allocatable :: a(:), b(:,:)
+  ```
+
+  instead of:
+
+  ```
+  real, dimension(:), allocatable :: a
+  real, dimension(:,:), allocatable :: b
+  ```
+
+  When defining a lot of arrays of the same dimension ```dimension``` can be used as an exception.
+* If ```optional``` attribute is used to declare a dummy argument, it should follow the intent attribute
 
 ## End <scope> block closing statements
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -42,6 +42,15 @@ focus on the semantics of the proposed changes rather than style and formatting.
 * Where conventional and appropriate shortening of a word is used then the underscore may be omitted,
   for example `linspace` is preferred over `lin_space`
 
+## Order of attributes
+
+Similiar to the guidlines for indentation and whitespace, specifiying the order of appearance of attributes can  help reviewing code and git-diffs.
+
+1. ```dimension```
+2. ```allocatable```
+3. ```intent(intent-spec)```
+4. ```optional```
+
 ## End <scope> block closing statements
 
 Fortran allows certain block constructs or scopes to include the name of the program unit in the end statement.

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -44,8 +44,8 @@ focus on the semantics of the proposed changes rather than style and formatting.
 
 ## Attributes
 
-* Always specify ```intent``` for dummy arguments.
-* Don't use ```dimension``` attribute to declare arrays because it is less verbose.
+* Always specify `intent` for dummy arguments.
+* Don't use `dimension` attribute to declare arrays because it is less verbose.
   Use this:
 
   ```
@@ -59,8 +59,8 @@ focus on the semantics of the proposed changes rather than style and formatting.
   real, dimension(:,:), allocatable :: b
   ```
 
-When defining many arrays of the same dimension, ```dimension``` can be used as an exception if it makes the code less verbose.
-* If ```optional``` attribute is used to declare a dummy argument, it should follow the intent attribute
+  When defining many arrays of the same dimension, `dimension` can be used as an exception if it makes the code less verbose.
+* If the `optional` attribute is used to declare a dummy argument, it should follow the `intent` attribute.
 
 ## End <scope> block closing statements
 


### PR DESCRIPTION
Lets discuss if this is need or giving to much overhead. For now there is positive (@jvdp1 ) and negative (@certik ) feedback.

In my opinion a standard library should not only provide functionalty, it also should give example how to use a programming language in an elegant way. We decided already in the STYLE_GUIDE.md to include indentation and whitespaces conventions which have of course bigger impact but specifiying that at an end of a scope there should be a closing statment is quite a minor thing so why to draw a line when specifiying the order of attritbutes?