### PR TITLE
variance_correction: small issue with debug mode of gfortran 7

### DIFF
--- a/src/stdlib_experimental_stats_var.fypp
+++ b/src/stdlib_experimental_stats_var.fypp
@@ -101,7 +101,7 @@ contains
             end do
           #:endfor
           case default
-            call error_stop("ERROR (mean): wrong dimension")
+            call error_stop("ERROR (var): wrong dimension")
         end select
         res = res / (n - merge(1, 0, optval(corrected, .true.)))
 
@@ -140,7 +140,7 @@ contains
             end do
           #:endfor
           case default
-            call error_stop("ERROR (mean): wrong dimension")
+            call error_stop("ERROR (var): wrong dimension")
         end select
         res = res / (n - merge(1, 0, optval(corrected, .true.)))
 
@@ -229,7 +229,7 @@ contains
             end do
           #:endfor
           case default
-            call error_stop("ERROR (mean): wrong dimension")
+            call error_stop("ERROR (var): wrong dimension")
         end select
         res = res / (n - merge(1, 0, (optval(corrected, .true.) .and. n > 0)))
 
@@ -264,7 +264,7 @@ contains
             end do
           #:endfor
           case default
-            call error_stop("ERROR (mean): wrong dimension")
+            call error_stop("ERROR (var): wrong dimension")
         end select
         res = res / (n - merge(1, 0, (optval(corrected, .true.) .and. n > 0)))
 

--- a/src/tests/stats/test_var.f90
+++ b/src/tests/stats/test_var.f90
@@ -57,7 +57,7 @@ program test_var
 
     !2dim
     print*,' test_sp_2dim'
-    s = d
+    allocate(s, source = real(d))
     call check( abs(var(s) - 13) < sptol)
     call check( all( abs( var(s, 1) - [20. / 3., 20. / 3., 5. / 3.]) < sptol))
     call check( all( abs( var(s, 2) - [19.0, 43. / 3., 31. / 3. , 7.0]) < sptol))
@@ -231,7 +231,7 @@ program test_var
 
     !2dim
     print*,' test_int32_2dim'
-    i32 = d
+    allocate(i32, source = int(d))
     call check( abs(var(i32) - 13) < dptol)
     call check( all( abs( var(i32,1) -&
                  [20._dp/3._dp, 20._dp/3._dp, 5._dp/3._dp]) < dptol))
@@ -321,7 +321,7 @@ program test_var
 
     !2dim
     print*,' test_int64_2dim'
-    i64 = d
+    allocate(i64, source = int(d, int64))
     call check( abs(var(i64) - 13) < dptol)
     call check( all( abs( var(i64,1) -&
                  [20._dp/3._dp, 20._dp/3._dp, 5._dp/3._dp]) < dptol))

--- a/src/tests/stats/test_varn.f90
+++ b/src/tests/stats/test_varn.f90
@@ -49,7 +49,7 @@ program test_varn
 
     !2dim
     print*,' test_sp_2dim'
-    s = d
+    allocate(s, source = real(d))
     call check( abs(var(s, corrected=.false.) - 13.*11./12.) < sptol)
     call check( all( abs( var(s, 1, corrected=.false.) - [20., 20., 5.]/4.) < sptol))
     call check( all( abs( var(s, 2, corrected=.false.) -&
@@ -227,7 +227,7 @@ program test_varn
     call check( abs(var(i321, 1, i321 < 5, corrected=.false.) - 5._dp/4.) < dptol)
 
     !2dim
-    i32 = d
+    allocate(i32, source = int(d, int32))
     print*,' test_int32_2dim'
     call check( abs(var(i32, corrected=.false.) - 13._dp*11./12.) < dptol)
     call check( all( abs( var(i32, 1, corrected=.false.) -&


### PR DESCRIPTION
Gfortran 7 with debug options (but not Gfortran 9) failed on, e.g., 
```fortran
i32 = d
```
So, I replaced the line by:
```fortran
allocate(i32, source = int(d)
```

