### PR TITLE
proposition for solving an issue with optval

### DIFF
--- a/src/common.fypp
+++ b/src/common.fypp
@@ -71,6 +71,27 @@ ${prefix + joinstr.join([line.strip() for line in txt.split("\n")]) + suffix}$
 #:enddef
 
 
+#! Brace enclosed, comma separated Fortran expressions for a shape.
+#!
+#! Args:
+#!   varname (str): Name of the variable to be used as origin
+#!   origrank (int): Rank of the original variable
+#!
+#! Returns:
+#!   Shape expression enclosed in braces, so that it can be used as suffix to
+#!   define array shapes in declarations.
+#!
+#:def shape(varname, origrank)
+  #:if origrank > 0
+    #:call join_lines(joinstr=", ", prefix="(", suffix=")")
+      #:for i in range(0, origrank)
+        size(${varname}$)
+      #:endfor
+    #:endcall
+  #:endif
+#:enddef
+
+
 #! Brace enclosed, comma separated Fortran expressions for a reduced shape.
 #!
 #! Rank of the original variable will be reduced by one. The routine generates

--- a/src/stdlib_experimental_optval.fypp
+++ b/src/stdlib_experimental_optval.fypp
@@ -1,4 +1,5 @@
 #:include "common.fypp"
+#:set RANKS = range(0, MAXRANK + 1)
 
 #:set KINDS_TYPES = REAL_KINDS_TYPES + INT_KINDS_TYPES + CMPLX_KINDS_TYPES + &
   & [('l1','logical')]
@@ -28,7 +29,9 @@ module stdlib_experimental_optval
     !! Fallback value for optional arguments
     !! ([Specification](../page/specs/stdlib_experimental_optval.html#description))
     #:for k1, t1 in KINDS_TYPES
-      module procedure optval_${t1[0]}$${k1}$
+      #:for rank in RANKS
+        module procedure optval_${t1[0]}$${k1}$_${rank}$
+      #:endfor
     #:endfor
     module procedure optval_character
      ! TODO: differentiate ascii & ucs char kinds
@@ -38,20 +41,22 @@ module stdlib_experimental_optval
 contains
 
   #:for k1, t1 in KINDS_TYPES
-    pure elemental function optval_${t1[0]}$${k1}$(x, default) result(y)
-    ${t1}$, intent(in), optional :: x
-    ${t1}$, intent(in) :: default
-    ${t1}$ :: y
+    #:for rank in RANKS
+    pure function optval_${t1[0]}$${k1}$_${rank}$(x, default) result(y)
+      ${t1}$, intent(in), optional :: x${ranksuffix(rank)}$
+      ${t1}$, intent(in) :: default${ranksuffix(rank)}$
+      ${t1}$ :: y${shape('default', rank)}$
 
-    if (present(x)) then
-       y = x
-    else
-       y = default
-    end if
-  end function optval_${t1[0]}$${k1}$
+      if (present(x)) then
+         y = x
+      else
+         y = default
+      end if
+    end function optval_${t1[0]}$${k1}$_${rank}$
+    #:endfor
   #:endfor
 
-  ! Cannot be made elemental
+
   pure function optval_character(x, default) result(y)
     character(len=*), intent(in), optional :: x
     character(len=*), intent(in) :: default


### PR DESCRIPTION
Proposition to solve the issue raised in [the comment of PR #205](https://github.com/fortran-lang/stdlib/pull/205#issue-425496020) by @MarDiehl

The `elemental` is removed and `fypp` is used to generate the different ranks.

@milancurcic 
We should probably match that the shape of `x` is the same as of `default`. The `pure` might need to be removed too.

__Note__: this is only a proposition for a possible issue. However, the issue must be clarified first.
__Note__: the issue seems to be a bug in Gfortran (see [bug 95446](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95446). Therefore, this issue should be closed without being merged.
