### PR TITLE
Fix for an issue in stdlib_experimental_linalg_diag with Intel compiler

### DIFF
--- a/src/stdlib_experimental_linalg_diag.fypp
+++ b/src/stdlib_experimental_linalg_diag.fypp
@@ -7,7 +7,7 @@ submodule (stdlib_experimental_linalg) stdlib_experimental_linalg_diag
 contains
 
     #:for k1, t1 in RCI_KINDS_TYPES
-      function diag_${t1[0]}$${k1}$(v) result(res)
+      module function diag_${t1[0]}$${k1}$(v) result(res)
         ${t1}$, intent(in) :: v(:)
         ${t1}$ :: res(size(v),size(v))
         integer :: i
@@ -20,7 +20,7 @@ contains
 
 
     #:for k1, t1 in RCI_KINDS_TYPES
-      function diag_${t1[0]}$${k1}$_k(v,k) result(res)
+      module function diag_${t1[0]}$${k1}$_k(v,k) result(res)
         ${t1}$, intent(in) :: v(:)
         integer, intent(in) :: k
         ${t1}$ :: res(size(v)+abs(k),size(v)+abs(k))
@@ -44,7 +44,7 @@ contains
     #:endfor
 
     #:for k1, t1 in RCI_KINDS_TYPES
-      function diag_${t1[0]}$${k1}$_mat(A) result(res)
+      module function diag_${t1[0]}$${k1}$_mat(A) result(res)
         ${t1}$, intent(in) :: A(:,:)
         ${t1}$ :: res(minval(shape(A)))
         integer :: i
@@ -55,7 +55,7 @@ contains
     #:endfor
 
     #:for k1, t1 in RCI_KINDS_TYPES
-      function diag_${t1[0]}$${k1}$_mat_k(A,k) result(res)
+      module function diag_${t1[0]}$${k1}$_mat_k(A,k) result(res)
         ${t1}$, intent(in) :: A(:,:)
         integer, intent(in) :: k
         ${t1}$ :: res(minval(shape(A))-abs(k))


### PR DESCRIPTION
Mentioned by @MarDiehl in #205 

ifort message:
```
     function diag_cdp_mat(A) result(res)
---------------^
/home/jvandenp/stdlib/build/src/stdlib_experimental_linalg_diag.f90(350): error #6645: The name of the module procedure conflicts with a name in the encompassing scoping unit.   [DIAG_CQP_MA
T]
      function diag_cqp_mat(A) result(res)
---------------^
/home/jvandenp/stdlib/build/src/stdlib_experimental_linalg_diag.f90(358): error #6645: The name of the module procedure conflicts with a name in the encompassing scoping unit.   [DIAG_IINT8_
MAT]
```