### PR TITLE
fix build failure with nagfor7.0 because of using "complex" function

### DIFF
--- a/src/tests/io/test_savetxt.f90
+++ b/src/tests/io/test_savetxt.f90
@@ -86,13 +86,13 @@ contains
     character(*), intent(in) :: outpath
     complex(sp) :: d(3, 2), e(2, 3)
     complex(sp), allocatable :: d2(:, :)
-    d = cmplx(1, 1)* reshape([1, 2, 3, 4, 5, 6], [3, 2])
+    d = cmplx(1, 1,kind=sp)* reshape([1, 2, 3, 4, 5, 6], [3, 2])
     call savetxt(outpath, d)
     call loadtxt(outpath, d2)
     call check(all(shape(d2) == [3, 2]))
     call check(all(abs(d-d2) < epsilon(1._sp)))
 
-    e = cmplx(1, 1)* reshape([1, 2, 3, 4, 5, 6], [2, 3])
+    e = cmplx(1, 1,kind=sp)* reshape([1, 2, 3, 4, 5, 6], [2, 3])
     call savetxt(outpath, e)
     call loadtxt(outpath, d2)
     call check(all(shape(d2) == [2, 3]))
@@ -103,13 +103,13 @@ contains
     character(*), intent(in) :: outpath
     complex(dp) :: d(3, 2), e(2, 3)
     complex(dp), allocatable :: d2(:, :)
-    d = cmplx(1._dp, 1._dp)* reshape([1, 2, 3, 4, 5, 6], [3, 2])
+    d = cmplx(1._dp, 1._dp,kind=dp)* reshape([1, 2, 3, 4, 5, 6], [3, 2])
     call savetxt(outpath, d)
     call loadtxt(outpath, d2)
     call check(all(shape(d2) == [3, 2]))
     call check(all(abs(d-d2) < epsilon(1._dp)))
 
-    e = cmplx(1, 1)* reshape([1, 2, 3, 4, 5, 6], [2, 3])
+    e = cmplx(1, 1,kind=dp)* reshape([1, 2, 3, 4, 5, 6], [2, 3])
     call savetxt(outpath, e)
     call loadtxt(outpath, d2)
     call check(all(shape(d2) == [2, 3]))

--- a/src/tests/linalg/test_linalg.f90
+++ b/src/tests/linalg/test_linalg.f90
@@ -73,8 +73,8 @@ contains
           msg="sum(rye - diag([(1.0_sp,i=1,6)])) < sptol failed.",warn=warn)
 
     cye = eye(7)
-    call check(abs(trace(cye) - cmplx(7.0_sp,0.0_sp)) < sptol, &
-          msg="abs(trace(cye) - cmplx(7.0_sp,0.0_sp)) < sptol failed.",warn=warn)
+    call check(abs(trace(cye) - cmplx(7.0_sp,0.0_sp,kind=sp)) < sptol, &
+          msg="abs(trace(cye) - cmplx(7.0_sp,0.0_sp,kind=sp)) < sptol failed.",warn=warn)
   end subroutine
 
   subroutine test_diag_rsp
@@ -153,7 +153,7 @@ contains
   subroutine test_diag_csp
     integer, parameter :: n = 3
     complex(sp) :: v(n), a(n,n), b(n,n)
-    complex(sp), parameter :: i_ = cmplx(0,1)
+    complex(sp), parameter :: i_ = cmplx(0,1,kind=sp)
     integer :: i,j
     write(*,*) "test_diag_csp"
     a = diag([(i,i=1,n)]) + diag([(i_,i=1,n)])
@@ -170,7 +170,7 @@ contains
   subroutine test_diag_cdp
     integer, parameter :: n = 3
     complex(dp) :: v(n), a(n,n), b(n,n)
-    complex(dp), parameter :: i_ = cmplx(0,1)
+    complex(dp), parameter :: i_ = cmplx(0,1,kind=dp)
     integer :: i,j
     write(*,*) "test_diag_cdp"
     a = diag([i_],-2) + diag([i_],2)
@@ -181,7 +181,7 @@ contains
   subroutine test_diag_cqp
     integer, parameter :: n = 3
     complex(qp) :: v(n), a(n,n), b(n,n)
-    complex(qp), parameter :: i_ = cmplx(0,1)
+    complex(qp), parameter :: i_ = cmplx(0,1,kind=qp)
     integer :: i,j
     write(*,*) "test_diag_cqp"
     a = diag([i_,i_],-1) + diag([i_,i_],1)
@@ -333,7 +333,7 @@ contains
     integer, parameter :: n = 5
     real(sp) :: re(n,n), im(n,n)
     complex(sp) :: a(n,n), b(n,n)
-    complex(sp), parameter :: i_ = cmplx(0,1)
+    complex(sp), parameter :: i_ = cmplx(0,1,kind=sp)
     write(*,*) "test_trace_csp"
 
     call random_number(re)
@@ -352,12 +352,12 @@ contains
   subroutine test_trace_cdp
     integer, parameter :: n = 3
     complex(dp) :: a(n,n), ans
-    complex(dp), parameter :: i_ = cmplx(0,1)
+    complex(dp), parameter :: i_ = cmplx(0,1,kind=dp)
     integer :: j
     write(*,*) "test_trace_cdp"
     
     a = reshape([(j + (n**2 - (j-1))*i_,j=1,n**2)],[n,n])
-    ans = cmplx(15,15) !(1 + 5 + 9) + (9 + 5 + 1)i
+    ans = cmplx(15,15,kind=dp) !(1 + 5 + 9) + (9 + 5 + 1)i
 
     call check(abs(trace(a) - ans) < dptol, &
           msg="abs(trace(a) - ans) < dptol failed.",warn=warn)
@@ -366,7 +366,7 @@ contains
   subroutine test_trace_cqp
     integer, parameter :: n = 3
     complex(qp) :: a(n,n)
-    complex(qp), parameter :: i_ = cmplx(0,1)
+    complex(qp), parameter :: i_ = cmplx(0,1,kind=qp)
     write(*,*) "test_trace_cqp"
     a = 3*eye(n) + 4*eye(n)*i_ ! pythagorean triple
     call check(abs(trace(a)) - 3*5.0_qp < qptol, &

--- a/src/tests/optval/test_optval.f90
+++ b/src/tests/optval/test_optval.f90
@@ -100,7 +100,7 @@ contains
   subroutine test_optval_cdp
     complex(dp) :: z1
     print *, "test_optval_cdp"
-    z1 = cmplx(1.0_dp, 2.0_dp)
+    z1 = cmplx(1.0_dp, 2.0_dp,kind=dp)
     call check(foo_cdp(z1) == z1)
     call check(foo_cdp() == z1)
   end subroutine test_optval_cdp

--- a/src/tests/stats/test_cov.f90
+++ b/src/tests/stats/test_cov.f90
@@ -14,17 +14,17 @@ program test_cov
                                    2._dp, 4._dp, 6._dp, 8._dp,&
                                    9._dp, 10._dp, 11._dp, 12._dp], [4, 3])
 
-    complex(dp) :: cd1(5) = [ cmplx(0.57706_dp, 0.00000_dp),&
-                            cmplx(0.00000_dp, 1.44065_dp),&
-                            cmplx(1.26401_dp, 0.00000_dp),&
-                            cmplx(0.00000_dp, 0.88833_dp),&
-                            cmplx(1.14352_dp, 0.00000_dp)]
-    complex(dp) :: ds(2,3) = reshape([ cmplx(1._dp, 0._dp),&
-                            cmplx(0._dp, 2._dp),&
-                            cmplx(3._dp, 0._dp),&
-                            cmplx(0._dp, 4._dp),&
-                            cmplx(5._dp, 0._dp),&
-                            cmplx(0._dp, 6._dp)], [2, 3])
+    complex(dp) :: cd1(5) = [ cmplx(0.57706_dp, 0.00000_dp,kind=dp),&
+                            cmplx(0.00000_dp, 1.44065_dp,kind=dp),&
+                            cmplx(1.26401_dp, 0.00000_dp,kind=dp),&
+                            cmplx(0.00000_dp, 0.88833_dp,kind=dp),&
+                            cmplx(1.14352_dp, 0.00000_dp,kind=dp)]
+    complex(dp) :: ds(2,3) = reshape([ cmplx(1._dp, 0._dp,kind=dp),&
+                            cmplx(0._dp, 2._dp,kind=dp),&
+                            cmplx(3._dp, 0._dp,kind=dp),&
+                            cmplx(0._dp, 4._dp,kind=dp),&
+                            cmplx(5._dp, 0._dp,kind=dp),&
+                            cmplx(0._dp, 6._dp,kind=dp)], [2, 3])
 
 
     call test_sp(real(d1, sp), real(d, sp))

--- a/src/tests/stats/test_mean.f90
+++ b/src/tests/stats/test_mean.f90
@@ -44,7 +44,7 @@ call check( sum( abs( mean(d,2) - sum(d,2)/real(size(d,2), dp) )) < dptol)
 !csp
 
 call loadtxt("array3.dat", d)
-cs = cmplx(1._sp, 1._sp)*d
+cs = cmplx(1._sp, 1._sp,kind=sp)*d
 
 call check( abs(mean(cs) - sum(cs)/real(size(cs), sp)) < sptol)
 call check( sum( abs( mean(cs,1) - sum(cs,1)/real(size(cs,1), sp) )) < sptol)
@@ -53,7 +53,7 @@ call check( sum( abs( mean(cs,2) - sum(cs,2)/real(size(cs,2), sp) )) < sptol)
 !cdp
 
 call loadtxt("array3.dat", d)
-cd = cmplx(1._dp, 1._dp)*d
+cd = cmplx(1._dp, 1._dp,kind=dp)*d
 
 call check( abs(mean(cd) - sum(cd)/real(size(cd), dp)) < dptol)
 call check( sum( abs( mean(cd,1) - sum(cd,1)/real(size(cd,1), dp) )) < dptol)
@@ -102,7 +102,7 @@ allocate(cd3(size(d,1),size(d,2),3))
 cd3(:,:,1)=d;
 cd3(:,:,2)=d*1.5;
 cd3(:,:,3)=d*4;
-cd3 = cmplx(1._sp, 1._sp)*cd3
+cd3 = cmplx(1._sp, 1._sp,kind=sp)*cd3
 
 call check( abs(mean(cd3) - sum(cd3)/real(size(cd3), dp)) < dptol)
 call check( sum( abs( mean(cd3,1) - sum(cd3,1)/real(size(cd3,1), dp) )) < dptol)

--- a/src/tests/stats/test_var.f90
+++ b/src/tests/stats/test_var.f90
@@ -30,11 +30,11 @@ program test_var
                             cmplx(1.26401_sp, 0.00000_sp),&
                             cmplx(0.00000_sp, 0.88833_sp),&
                             cmplx(1.14352_sp, 0.00000_sp)]
-    complex(dp) :: cd1(5) = [ cmplx(0.57706_dp, 0.00000_dp),&
-                            cmplx(0.00000_dp, 1.44065_dp),&
-                            cmplx(1.26401_dp, 0.00000_dp),&
-                            cmplx(0.00000_dp, 0.88833_dp),&
-                            cmplx(1.14352_dp, 0.00000_dp)]
+    complex(dp) :: cd1(5) = [ cmplx(0.57706_dp, 0.00000_dp,kind=dp),&
+                            cmplx(0.00000_dp, 1.44065_dp,kind=dp),&
+                            cmplx(1.26401_dp, 0.00000_dp,kind=dp),&
+                            cmplx(0.00000_dp, 0.88833_dp,kind=dp),&
+                            cmplx(1.14352_dp, 0.00000_dp,kind=dp)]
     complex(sp) :: cs(5,3)
     complex(dp) :: cd(5,3)
 

--- a/src/tests/stats/test_varn.f90
+++ b/src/tests/stats/test_varn.f90
@@ -23,11 +23,11 @@ program test_varn
                                    9._dp, 10._dp, 11._dp, 12._dp], [4, 3])
 
 
-    complex(dp) :: cd1(5) = [ cmplx(0.57706_dp, 0.00000_dp),&
-                            cmplx(0.00000_dp, 1.44065_dp),&
-                            cmplx(1.26401_dp, 0.00000_dp),&
-                            cmplx(0.00000_dp, 0.88833_dp),&
-                            cmplx(1.14352_dp, 0.00000_dp)]
+    complex(dp) :: cd1(5) = [ cmplx(0.57706_dp, 0.00000_dp,kind=dp),&
+                            cmplx(0.00000_dp, 1.44065_dp,kind=dp),&
+                            cmplx(1.26401_dp, 0.00000_dp,kind=dp),&
+                            cmplx(0.00000_dp, 0.88833_dp,kind=dp),&
+                            cmplx(1.14352_dp, 0.00000_dp,kind=dp)]
     complex(dp) :: cd(5,3)
 
 


### PR DESCRIPTION
"complex" function which is not a fortran standard causes an error like below in nagfor.

(for example)
"Error: test_linalg.f90, line 445: Implicit type for COMPLEX in TEST_TRACE_CQP"

So, "complex" is replaced with "cmplx" which is one of the fortran standard function.
At the same time, I specified the "kind" value so that it has the same precision as the "cmplx" function argument.