### PR TITLE
Install GFortran macOS in doc-deployment CI

### DIFF
--- a/.github/workflows/doc-deployment.yml
+++ b/.github/workflows/doc-deployment.yml
@@ -24,6 +24,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0 # Full history to get tag and commit info
+      - name: Install GFortran macOS
+        run: brew install gcc10 || brew upgrade gcc10 || true
       - name: Install Dependencies
         run: |
           pip3 install --prefer-binary --no-clean --disable-pip-version-check --progress-bar off lxml fypp

--- a/.github/workflows/doc-deployment.yml
+++ b/.github/workflows/doc-deployment.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           fetch-depth: 0 # Full history to get tag and commit info
       - name: Install GFortran macOS
-        run: brew install gcc10 || brew upgrade gcc10 || true
+        run: brew install gcc || brew upgrade gcc || true
       - name: Install Dependencies
         run: |
           pip3 install --prefer-binary --no-clean --disable-pip-version-check --progress-bar off lxml fypp


### PR DESCRIPTION
Issue: gfortran was not found for the doc-deployment script.
Installing it solved the problem.