### PR TITLE
Changes directory structure of stdlib as discussed in #216

### DIFF
--- a/.github/workflows/doc-deployment.yml
+++ b/.github/workflows/doc-deployment.yml
@@ -24,6 +24,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0 # Full history to get tag and commit info
+      - name: Install GFortran macOS
+        run: brew install gcc || brew upgrade gcc || true
       - name: Install Dependencies
         run: |
           pip3 install --prefer-binary --no-clean --disable-pip-version-check --progress-bar off lxml fypp

--- a/.github/workflows/doc-deployment.yml
+++ b/.github/workflows/doc-deployment.yml
@@ -24,8 +24,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0 # Full history to get tag and commit info
-      - name: Install GFortran macOS
-        run: brew install gcc || brew upgrade gcc || true
       - name: Install Dependencies
         run: |
           pip3 install --prefer-binary --no-clean --disable-pip-version-check --progress-bar off lxml fypp

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -25,9 +25,9 @@ experienced contributors will help it through all 5 steps.
    always better than large.  It is OK to implement only a few functions of a
    new module, and continue work on the others in a later PR. All new
    functionality goes into an "experimental" namespace
-   (`stdlib_experimental_*.f90`).  As part of the PR, when submitting a new
+   (`version: experimental`). As part of the PR, when submitting a new
    public facing API, please provide the initial draft of the specification
-   document as well as the the initial reference implementation of this
+   document as well as the initial reference implementation of this
    specification.  The
    [specification is a document](https://stdlib.fortran-lang.org/page/specs/index.html)
    that describes the API and

--- a/doc/specs/index.md
+++ b/doc/specs/index.md
@@ -11,17 +11,17 @@ This is and index/directory of the specifications (specs) for each new module/fe
 
 ## Experimental Features & Modules
 
- - [error](./stdlib_experimental_error.html) - Catching and handling errors
- - [IO](./stdlib_experimental_io.html) - Input/output helper & convenience
- - [linalg](./stdlib_experimental_linalg.html) - Linear Algebra
- - [optval](./stdlib_experimental_optval.html) - Fallback value for optional arguments
- - [quadrature](./stdlib_experimental_quadrature.html) - Numerical integration
- - [stats](./stdlib_experimental_stats.html) - Descriptive Statistics
+ - [error](./stdlib_error.html) - Catching and handling errors
+ - [IO](./stdlib_io.html) - Input/output helper & convenience
+ - [linalg](./stdlib_linalg.html) - Linear Algebra
+ - [optval](./stdlib_optval.html) - Fallback value for optional arguments
+ - [quadrature](./stdlib_quadrature.html) - Numerical integration
+ - [stats](./stdlib_stats.html) - Descriptive Statistics
 
 ## Missing specs
 
- - [ascii](https://github.com/fortran-lang/stdlib/blob/master/src/stdlib_experimental_ascii.f90)
- - [kinds](https://github.com/fortran-lang/stdlib/blob/master/src/stdlib_experimental_kinds.f90)
+ - [ascii](https://github.com/fortran-lang/stdlib/blob/master/src/stdlib_ascii.f90)
+ - [kinds](https://github.com/fortran-lang/stdlib/blob/master/src/stdlib_kinds.f90)
 
 ## Released/Stable Features & Modules
 

--- a/doc/specs/stdlib_error.md
+++ b/doc/specs/stdlib_error.md
@@ -1,5 +1,5 @@
 ---
-title: experimental_error
+title: error
 ---
 
 # Catching and handling errors
@@ -7,6 +7,10 @@ title: experimental_error
 [TOC]
 
 ## `check` - Checks the value of a logical condition
+
+### Version
+
+Experimental
 
 ### Description
 
@@ -43,7 +47,7 @@ If `condition` is `.false`., and:
 
 ```fortran
 program demo_check1
-    use stdlib_experimental_error, only: check
+    use stdlib_error, only: check
     implicit none
     integer :: a = 1
     ! If a /= 5, stops the program with exit code 1 and prints 'Check failed.'
@@ -52,7 +56,7 @@ end program demo_check1
 ```
 ```fortran
 program demo_check2
-    use stdlib_experimental_error, only: check
+    use stdlib_error, only: check
     implicit none
     integer :: a = 1
     ! If a /= 5, stops the program with exit code 1 and prints  'a == 5 failed.'
@@ -61,7 +65,7 @@ end program demo_check2
 ```
 ```fortran
 program demo_check3
-    use stdlib_experimental_error, only: check
+    use stdlib_error, only: check
     implicit none
     integer :: a = 1
     ! If a /= 5,  prints 'a == 5 failed.', but doesn't stop the program.
@@ -70,7 +74,7 @@ end program demo_check2
 ```
 ```fortran
 program demo_check3
-    use stdlib_experimental_error, only: check
+    use stdlib_error, only: check
     implicit none
     integer :: a = 1
     ! If a /= 5, stops the program with exit code 77 and prints 'a == 5 failed.'
@@ -80,13 +84,17 @@ end program demo_check3
 
 ## `error_stop` - aborts the program
 
+### Version
+
+Experimental
+
 ### Description
 
 Aborts the program with a message and a nonzero exit code.
 
 ### Syntax
 
-`call [[stdlib_experimental_error(module):error_stop(interface)]](msg, code)`
+`call [[stdlib_error(module):error_stop(interface)]](msg, code)`
 
 ### Arguments
 
@@ -104,7 +112,7 @@ Without error code:
 
 ```fortran
 program demo_error_stop1
-    use stdlib_experimental_error, only: error_stop
+    use stdlib_error, only: error_stop
     implicit none
     call error_stop("Invalid argument")
 end program demo_error_stop1
@@ -114,7 +122,7 @@ With error code:
 
 ```fortran
 program demo_error_stop2
-    use stdlib_experimental_error, only: error_stop
+    use stdlib_error, only: error_stop
     implicit none
     call error_stop("Invalid argument", code = 123)
 end program demo_error_stop2

--- a/doc/specs/stdlib_error.md
+++ b/doc/specs/stdlib_error.md
@@ -8,7 +8,7 @@ title: error
 
 ## `check` - Checks the value of a logical condition
 
-### Version
+### Status
 
 Experimental
 
@@ -84,7 +84,7 @@ end program demo_check3
 
 ## `error_stop` - aborts the program
 
-### Version
+### Status
 
 Experimental
 

--- a/doc/specs/stdlib_io.md
+++ b/doc/specs/stdlib_io.md
@@ -1,5 +1,5 @@
 ---
-title: experimental_IO
+title: IO
 ---
 
 # IO
@@ -8,12 +8,16 @@ title: experimental_IO
 
 ## `loadtxt` - load a 2D array from a text file
 
+### Version
+
+Experimental
+
 ### Description
 Loads a rank-2 `array` from a text file.
 
 ### Syntax
 
-`call [[stdlib_experimental_io(module):loadtxt(interface)]](filename, array)`
+`call [[stdlib_io(module):loadtxt(interface)]](filename, array)`
 
 ### Arguments
 
@@ -29,7 +33,7 @@ Returns an allocated rank-2 `array` with the content of `filename`.
 
 ```fortran
 program demo_loadtxt
-    use stdlib_experimental_io, only: loadtxt
+    use stdlib_io, only: loadtxt
     implicit none
     real, allocatable :: x(:,:)
     call loadtxt('example.dat', x) 
@@ -39,13 +43,17 @@ end program demo_loadtxt
 
 ## `open` - open a file
 
+### Version
+
+Experimental
+
 ### Description
 
 Returns the unit number of a file opened to read, to write, or to read and write. The file might be a text file or a binary file. All files are opened using a streamed access.
 
 ### Syntax
 
-`u = [[stdlib_experimental_io(module):open(function)]](filename [, mode] [, iostat])`
+`u = [[stdlib_io(module):open(function)]](filename [, mode] [, iostat])`
 
 ### Arguments
 
@@ -80,7 +88,7 @@ The result is a scalar of type `integer`.
 
 ```fortran
 program demo_open
-    use stdlib_experimental_io, only: open
+    use stdlib_io, only: open
     implicit none
     integer :: u
     u = open('example.dat', 'wt')
@@ -92,12 +100,16 @@ end program demo_open
 
 ## `savetxt` - save a 2D array into a text file
 
+### Version
+
+Experimental
+
 ### Description
 Saves a rank-2 `array` into a text file.
 
 ### Syntax
 
-`call [[stdlib_experimental_io(module):savetxt(interface)]](filename, array)`
+`call [[stdlib_io(module):savetxt(interface)]](filename, array)`
 
 ### Arguments
 
@@ -113,7 +125,7 @@ Provides a text file called `filename` that contains the rank-2 `array`.
 
 ```fortran
 program demo_savetxt
-    use stdlib_experimental_io, only: savetxt
+    use stdlib_io, only: savetxt
     implicit none
     real :: x(3,2) = 1
     call savetxt('example.dat', x) 

--- a/doc/specs/stdlib_io.md
+++ b/doc/specs/stdlib_io.md
@@ -8,7 +8,7 @@ title: IO
 
 ## `loadtxt` - load a 2D array from a text file
 
-### Version
+### Status
 
 Experimental
 
@@ -43,7 +43,7 @@ end program demo_loadtxt
 
 ## `open` - open a file
 
-### Version
+### Status
 
 Experimental
 
@@ -100,7 +100,7 @@ end program demo_open
 
 ## `savetxt` - save a 2D array into a text file
 
-### Version
+### Status
 
 Experimental
 

--- a/doc/specs/stdlib_linalg.md
+++ b/doc/specs/stdlib_linalg.md
@@ -1,5 +1,5 @@
 ---
-title: experimental_linalg
+title: linalg
 ---
 
 # Linear Algebra
@@ -8,13 +8,17 @@ title: experimental_linalg
 
 ## `diag` - Create a diagonal array or extract the diagonal elements of an array
 
+### Version
+
+Experimental
+
 ### Description
 
 Create a diagonal array or extract the diagonal elements of an array
 
 ### Syntax
 
-`d = [[stdlib_experimental_linalg(module):diag(interface)]](a [, k])`
+`d = [[stdlib_linalg(module):diag(interface)]](a [, k])`
 
 ### Arguments
 
@@ -30,7 +34,7 @@ Returns a diagonal array or a vector with the extracted diagonal elements.
 
 ```fortran
 program demo_diag1
-    use stdlib_experimental_linalg, only: diag
+    use stdlib_linalg, only: diag
     implicit none
     real, allocatable :: A(:,:)
     integer :: i
@@ -40,7 +44,7 @@ end program demo_diag1
 
 ```fortran
 program demo_diag2
-    use stdlib_experimental_linalg, only: diag
+    use stdlib_linalg, only: diag
     implicit none
     real :: v(:)
     real, allocatable :: A(:,:)
@@ -52,7 +56,7 @@ end program demo_diag2
 
 ```fortran
 program demo_diag3
-    use stdlib_experimental_linalg, only: diag
+    use stdlib_linalg, only: diag
     implicit none
     integer, parameter :: n = 10
     real :: c(n), ul(n-1)
@@ -66,7 +70,7 @@ end program demo_diag3
 
 ```fortran
 program demo_diag4
-    use stdlib_experimental_linalg, only: diag
+    use stdlib_linalg, only: diag
     implicit none
     integer, parameter :: n = 12
     real :: A(n,n)
@@ -79,7 +83,7 @@ end program demo_diag4
 
 ```fortran
 program demo_diag5
-    use stdlib_experimental_linalg, only: diag
+    use stdlib_linalg, only: diag
     implicit none
     integer, parameter :: n = 3
     real :: A(n,n)
@@ -93,13 +97,17 @@ end program demo_diag5
 
 ## `eye` - Construct the identity matrix
 
+### Version
+
+Experimental
+
 ### Description
 
 Construct the identity matrix
 
 ## Syntax
 
-`I = [[stdlib_experimental_linalg(module):eye(function)]](n)`
+`I = [[stdlib_linalg(module):eye(function)]](n)`
 
 ### Arguments
 
@@ -113,7 +121,7 @@ Returns the identity matrix, i.e. a square matrix with ones on the main diagonal
 
 ```fortran
 program demo_eye1
-    use stdlib_experimental_linalg, only: eye
+    use stdlib_linalg, only: eye
     implicit none
     real :: a(3,3)
     A = eye(3)
@@ -122,7 +130,7 @@ end program demo_eye1
 
 ```fortran
 program demo_eye2
-    use stdlib_experimental_linalg, only: eye, diag
+    use stdlib_linalg, only: eye, diag
     implicit none
     print *, all(eye(4) == diag([1,1,1,1])) ! prints .true.
 end program demo_eye2
@@ -130,13 +138,17 @@ end program demo_eye2
 
 ## `trace` - Trace of a matrix
 
+### Version
+
+Experimental
+
 ### Description
 
 Trace of a matrix (rank-2 array)
 
 ### Syntax
 
-`result = [stdlib_experimental_linalg(module):trace(interface)](A)`
+`result = [stdlib_linalg(module):trace(interface)](A)`
 
 ### Arguments
 
@@ -149,7 +161,7 @@ Returns the trace of the matrix, i.e. the sum of diagonal elements.
 ### Example
 ```fortran
 program demo_trace
-    use stdlib_experimental_linalg, only: trace
+    use stdlib_linalg, only: trace
     implicit none
     real :: A(3,3)
     A = reshape([1,2,3,4,5,6,7,8,9],[3,3])

--- a/doc/specs/stdlib_linalg.md
+++ b/doc/specs/stdlib_linalg.md
@@ -8,7 +8,7 @@ title: linalg
 
 ## `diag` - Create a diagonal array or extract the diagonal elements of an array
 
-### Version
+### Status
 
 Experimental
 
@@ -97,7 +97,7 @@ end program demo_diag5
 
 ## `eye` - Construct the identity matrix
 
-### Version
+### Status
 
 Experimental
 
@@ -138,7 +138,7 @@ end program demo_eye2
 
 ## `trace` - Trace of a matrix
 
-### Version
+### Status
 
 Experimental
 

--- a/doc/specs/stdlib_optval.md
+++ b/doc/specs/stdlib_optval.md
@@ -8,7 +8,7 @@ title: optval
 
 ## `optval` - fallback value for optional arguments
 
-### Version
+### Status
 
 Experimental
 

--- a/doc/specs/stdlib_optval.md
+++ b/doc/specs/stdlib_optval.md
@@ -1,5 +1,5 @@
 ---
-title: experimental_optval
+title: optval
 ---
 
 # Default values for optional arguments
@@ -7,6 +7,10 @@ title: experimental_optval
 [TOC]
 
 ## `optval` - fallback value for optional arguments
+
+### Version
+
+Experimental
 
 ### Description
 
@@ -16,7 +20,7 @@ This function is intended to be called in a procedure with one or more `optional
 
 ### Syntax
 
-`result = [[stdlib_experimental_optval(module):optval(interface)]](x, default)`
+`result = [[stdlib_optval(module):optval(interface)]](x, default)`
 
 ### Arguments
 
@@ -32,7 +36,7 @@ If `x` is present, the result is `x`, otherwise the result is `default`.
 
 ```fortran
 program demo_optval
-    use stdlib_experimental_optval, only: optval
+    use stdlib_optval, only: optval
     implicit none
     print *, root(64.0)
 ! 8.0

--- a/doc/specs/stdlib_quadrature.md
+++ b/doc/specs/stdlib_quadrature.md
@@ -1,5 +1,5 @@
 ---
-title: experimental_quadrature
+title: quadrature
 ---
 
 # Numerical integration
@@ -8,15 +8,19 @@ title: experimental_quadrature
 
 ## `trapz` - integrate sampled values using trapezoidal rule
 
+### Version
+
+Experimental
+
 ### Description
 
 Returns the trapezoidal rule integral of an array `y` representing discrete samples of a function. The integral is computed assuming either equidistant abscissas with spacing `dx` or arbitary abscissas `x`.
 
 ### Syntax
 
-`result = [[stdlib_experimental_quadrature(module):trapz(interface)]](y, x)`
+`result = [[stdlib_quadrature(module):trapz(interface)]](y, x)`
 
-`result = [[stdlib_experimental_quadrature(module):trapz(interface)]](y, dx)`
+`result = [[stdlib_quadrature(module):trapz(interface)]](y, dx)`
 
 ### Arguments
 
@@ -36,7 +40,7 @@ If the size of `y` is zero or one, the result is zero.
 
 ```fortran
 program demo_trapz
-    use stdlib_experimental_quadrature, only: trapz
+    use stdlib_quadrature, only: trapz
     implicit none
     real :: x(5) = [0., 1., 2., 3., 4.]
     real :: y(5) = x**2
@@ -49,13 +53,17 @@ end program demo_trapz
 
 ## `trapz_weights` - trapezoidal rule weights for given abscissas
 
+### Version
+
+Experimental
+
 ### Description
 
 Given an array of abscissas `x`, computes the array of weights `w` such that if `y` represented function values tabulated at `x`, then `sum(w*y)` produces a trapezoidal rule approximation to the integral.
 
 ### Syntax
 
-`result = [[stdlib_experimental_quadrature(module):trapz_weights(interface)]](x)`
+`result = [[stdlib_quadrature(module):trapz_weights(interface)]](x)`
 
 ### Arguments
 
@@ -71,7 +79,7 @@ If the size of `x` is one, then the sole element of the result is zero.
 
 ```fortran
 program demo_trapz_weights
-    use stdlib_experimental_quadrature, only: trapz_weights
+    use stdlib_quadrature, only: trapz_weights
     implicit none
     real :: x(5) = [0., 1., 2., 3., 4.]
     real :: y(5) = x**2
@@ -85,6 +93,10 @@ end program demo_trapz_weights
 
 ## `simps` - integrate sampled values using Simpson's rule
 
+### Version
+
+Experimental
+
 ### Description
 
 Returns the Simpson's rule integral of an array `y` representing discrete samples of a function. The integral is computed assuming either equidistant abscissas with spacing `dx` or arbitary abscissas `x`. 
@@ -93,9 +105,9 @@ Simpson's ordinary ("1/3") rule is used for odd-length arrays. For even-length a
 
 ### Syntax
 
-`result = [[stdlib_experimental_quadrature(module):simps(interface)]](y, x [, even])`
+`result = [[stdlib_quadrature(module):simps(interface)]](y, x [, even])`
 
-`result = [[stdlib_experimental_quadrature(module):simps(interface)]](y, dx [, even])`
+`result = [[stdlib_quadrature(module):simps(interface)]](y, dx [, even])`
 
 ### Arguments
 
@@ -119,7 +131,7 @@ If the size of `y` is two, the result is the same as if `trapz` had been called 
 
 ```fortran
 program demo_simps
-    use stdlib_experimental_quadrature, only: simps
+    use stdlib_quadrature, only: simps
     implicit none
     real :: x(5) = [0., 1., 2., 3., 4.]
     real :: y(5) = 3.*x**2
@@ -132,6 +144,10 @@ end program demo_simps
 
 ## `simps_weights` - Simpson's rule weights for given abscissas
 
+### Version
+
+Experimental
+
 ### Description
 
 Given an array of abscissas `x`, computes the array of weights `w` such that if `y` represented function values tabulated at `x`, then `sum(w*y)` produces a Simpson's rule approximation to the integral.
@@ -140,7 +156,7 @@ Simpson's ordinary ("1/3") rule is used for odd-length arrays. For even-length a
 
 ### Syntax
 
-`result = [[stdlib_experimental_quadrature(module):simps_weights(interface)]](x [, even])`
+`result = [[stdlib_quadrature(module):simps_weights(interface)]](x [, even])`
 
 ### Arguments
 
@@ -160,7 +176,7 @@ If the size of `x` is two, then the result is the same as if `trapz_weights` had
 
 ```fortran
 program demo_simps_weights
-    use stdlib_experimental_quadrature, only: simps_weights
+    use stdlib_quadrature, only: simps_weights
     implicit none
     real :: x(5) = [0., 1., 2., 3., 4.]
     real :: y(5) = 3.*x**2

--- a/doc/specs/stdlib_quadrature.md
+++ b/doc/specs/stdlib_quadrature.md
@@ -8,7 +8,7 @@ title: quadrature
 
 ## `trapz` - integrate sampled values using trapezoidal rule
 
-### Version
+### Status
 
 Experimental
 
@@ -53,7 +53,7 @@ end program demo_trapz
 
 ## `trapz_weights` - trapezoidal rule weights for given abscissas
 
-### Version
+### Status
 
 Experimental
 
@@ -93,7 +93,7 @@ end program demo_trapz_weights
 
 ## `simps` - integrate sampled values using Simpson's rule
 
-### Version
+### Status
 
 Experimental
 
@@ -144,7 +144,7 @@ end program demo_simps
 
 ## `simps_weights` - Simpson's rule weights for given abscissas
 
-### Version
+### Status
 
 Experimental
 

--- a/doc/specs/stdlib_stats.md
+++ b/doc/specs/stdlib_stats.md
@@ -8,7 +8,7 @@ title: stats
 
 ## `corr` - Pearson correlation of array elements
 
-### Version
+### Status
 
 Experimental
 
@@ -60,7 +60,7 @@ end program demo_corr
 
 ## `cov` - covariance of array elements
 
-### Version
+### Status
 
 Experimental
 
@@ -120,7 +120,7 @@ end program demo_cov
 
 ## `mean` - mean of array elements
 
-### Version
+### Status
 
 Experimental
 
@@ -168,7 +168,7 @@ end program demo_mean
 
 ## `moment` - central moments of array elements
 
-### Version
+### Status
 
 Experimental
 
@@ -239,7 +239,7 @@ end program demo_moment
 
 ## `var` - variance of array elements
 
-### Version
+### Status
 
 Experimental
 

--- a/doc/specs/stdlib_stats.md
+++ b/doc/specs/stdlib_stats.md
@@ -12,10 +12,6 @@ title: stats
 
 Experimental
 
-### Version
-
-Experimental
-
 ### Description
 
 Returns the Pearson correlation of the elements of `array` along dimension `dim` if the corresponding element in `mask` is `true`.

--- a/doc/specs/stdlib_stats.md
+++ b/doc/specs/stdlib_stats.md
@@ -1,5 +1,5 @@
 ---
-title: experimental_stats
+title: stats
 ---
 
 # Descriptive statistics
@@ -7,6 +7,14 @@ title: experimental_stats
 [TOC]
 
 ## `corr` - Pearson correlation of array elements
+
+### Version
+
+Experimental
+
+### Version
+
+Experimental
 
 ### Description
 
@@ -20,7 +28,7 @@ The Pearson correlation between two rows (or columns), say `x` and `y`, of `arra
 
 ### Syntax
 
-`result = [[stdlib_experimental_stats(module):corr(interface)]](array, dim [, mask])`
+`result = [[stdlib_stats(module):corr(interface)]](array, dim [, mask])`
 
 ### Arguments
 
@@ -45,7 +53,7 @@ If `mask` is specified, the result is the Pearson correlation of all elements of
 
 ```fortran
 program demo_corr
-    use stdlib_experimental_stats, only: corr
+    use stdlib_stats, only: corr
     implicit none
     real :: x(1:6) = [ 1., 2., 3., 4., 5., 6. ]
     real :: y(1:2, 1:3) = reshape([ -1., 40., -3., 4., 10., 6. ], [ 2, 3])
@@ -55,6 +63,10 @@ end program demo_corr
 ```
 
 ## `cov` - covariance of array elements
+
+### Version
+
+Experimental
 
 ### Description
 
@@ -73,7 +85,7 @@ The scaling can be changed with the logical argument `corrected`. If `corrected`
 
 ### Syntax
 
-`result = [[stdlib_experimental_stats(module):cov(interface)]](array, dim [, mask [, corrected]])`
+`result = [[stdlib_stats(module):cov(interface)]](array, dim [, mask [, corrected]])`
 
 ### Arguments
 
@@ -100,7 +112,7 @@ If `mask` is specified, the result is the covariance of all elements of `array` 
 
 ```fortran
 program demo_cov
-    use stdlib_experimental_stats, only: cov
+    use stdlib_stats, only: cov
     implicit none
     real :: x(1:6) = [ 1., 2., 3., 4., 5., 6. ]
     real :: y(1:2, 1:3) = reshape([ 1., 2., 3., 4., 5., 6. ], [ 2, 3])
@@ -112,15 +124,19 @@ end program demo_cov
 
 ## `mean` - mean of array elements
 
+### Version
+
+Experimental
+
 ### Description
 
 Returns the mean of all the elements of `array`, or of the elements of `array` along dimension `dim` if provided, and if the corresponding element in `mask` is `true`.
 
 ### Syntax
 
-`result = [[stdlib_experimental_stats(module):mean(interface)]](array [, mask])`
+`result = [[stdlib_stats(module):mean(interface)]](array [, mask])`
 
-`result = [[stdlib_experimental_stats(module):mean(interface)]](array, dim [, mask])`
+`result = [[stdlib_stats(module):mean(interface)]](array, dim [, mask])`
 
 ### Arguments
 
@@ -143,7 +159,7 @@ If `mask` is specified, the result is the mean of all elements of `array` corres
 
 ```fortran
 program demo_mean
-    use stdlib_experimental_stats, only: mean
+    use stdlib_stats, only: mean
     implicit none
     real :: x(1:6) = [ 1., 2., 3., 4., 5., 6. ]
     real :: y(1:2, 1:3) = reshape([ 1., 2., 3., 4., 5., 6. ], [ 2, 3])
@@ -155,6 +171,10 @@ end program demo_mean
 ```
 
 ## `moment` - central moments of array elements
+
+### Version
+
+Experimental
 
 ### Description
 
@@ -179,9 +199,9 @@ The _k_-th order moment about `center` is defined as :
 
 ### Syntax
 
-`result = [[stdlib_experimental_stats(module):moment(interface)]](array, order [, center [, mask]])`
+`result = [[stdlib_stats(module):moment(interface)]](array, order [, center [, mask]])`
 
-`result = [[stdlib_experimental_stats(module):moment(interface)]](array, order, dim [, center [, mask]])`
+`result = [[stdlib_stats(module):moment(interface)]](array, order, dim [, center [, mask]])`
 
 ### Arguments
 
@@ -208,7 +228,7 @@ If `mask` is specified, the result is the _k_-th  (central) moment of all elemen
 
 ```fortran
 program demo_moment
-    use stdlib_experimental_stats, only: moment
+    use stdlib_stats, only: moment
     implicit none
     real :: x(1:6) = [ 1., 2., 3., 4., 5., 6. ]
     real :: y(1:2, 1:3) = reshape([ 1., 2., 3., 4., 5., 6. ], [ 2, 3])
@@ -222,6 +242,10 @@ end program demo_moment
 ```
 
 ## `var` - variance of array elements
+
+### Version
+
+Experimental
 
 ### Description
 
@@ -240,9 +264,9 @@ The use of the term `n-1` for scaling is called Bessel 's correction. The scalin
 
 ### Syntax
 
-`result = [[stdlib_experimental_stats(module):var(interface)]](array [, mask [, corrected]])`
+`result = [[stdlib_stats(module):var(interface)]](array [, mask [, corrected]])`
 
-`result = [[stdlib_experimental_stats(module):var(interface)]](array, dim [, mask [, corrected]])`
+`result = [[stdlib_stats(module):var(interface)]](array, dim [, mask [, corrected]])`
 
 ### Arguments
 
@@ -269,7 +293,7 @@ If the variance is computed with only one single element, then the result is IEE
 
 ```fortran
 program demo_var
-    use stdlib_experimental_stats, only: var
+    use stdlib_stats, only: var
     implicit none
     real :: x(1:6) = [ 1., 2., 3., 4., 5., 6. ]
     real :: y(1:2, 1:3) = reshape([ 1., 2., 3., 4., 5., 6. ], [ 2, 3])

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,19 +2,19 @@
 
 # Create a list of the files to be preprocessed
 set(fppFiles
-    stdlib_experimental_io.fypp
-    stdlib_experimental_linalg.fypp
-    stdlib_experimental_linalg_diag.fypp
-    stdlib_experimental_optval.fypp
-    stdlib_experimental_stats.fypp
-    stdlib_experimental_stats_corr.fypp
-    stdlib_experimental_stats_cov.fypp
-    stdlib_experimental_stats_mean.fypp
-    stdlib_experimental_stats_moment.fypp
-    stdlib_experimental_stats_var.fypp
-    stdlib_experimental_quadrature.fypp
-    stdlib_experimental_quadrature_trapz.fypp
-    stdlib_experimental_quadrature_simps.fypp
+    stdlib_io.fypp
+    stdlib_linalg.fypp
+    stdlib_linalg_diag.fypp
+    stdlib_optval.fypp
+    stdlib_stats.fypp
+    stdlib_stats_corr.fypp
+    stdlib_stats_cov.fypp
+    stdlib_stats_mean.fypp
+    stdlib_stats_moment.fypp
+    stdlib_stats_var.fypp
+    stdlib_quadrature.fypp
+    stdlib_quadrature_trapz.fypp
+    stdlib_quadrature_simps.fypp
 )
 
 
@@ -30,10 +30,10 @@ endif()
 fypp_f90("${fyppFlags}" "${fppFiles}" outFiles)
 
 set(SRC
-    stdlib_experimental_ascii.f90
-    stdlib_experimental_error.f90
-    stdlib_experimental_kinds.f90
-    stdlib_experimental_system.F90
+    stdlib_ascii.f90
+    stdlib_error.f90
+    stdlib_kinds.f90
+    stdlib_system.F90
     ${outFiles}
 )
 

--- a/src/Makefile.manual
+++ b/src/Makefile.manual
@@ -67,5 +67,5 @@ stdlib_linalg_diag.f90: stdlib_linalg_diag.fypp
 stdlib_quadrature.f90: stdlib_quadrature.fypp
 stdlib_stats.f90: stdlib_stats.fypp
 stdlib_stats_mean.f90: stdlib_stats_mean.fypp
-stdlib_stats_moment.f90: stdlib_moment.fypp
+stdlib_stats_moment.f90: stdlib_stats_moment.fypp
 stdlib_stats_var.f90: stdlib_stats_var.fypp

--- a/src/Makefile.manual
+++ b/src/Makefile.manual
@@ -1,17 +1,17 @@
 SRC = f18estop.f90 \
-      stdlib_experimental_ascii.f90 \
-      stdlib_experimental_error.f90 \
-      stdlib_experimental_io.f90 \
-      stdlib_experimental_linalg.f90 \
-      stdlib_experimental_linalg_diag.f90 \
-      stdlib_experimental_kinds.f90 \
-      stdlib_experimental_optval.f90 \
-      stdlib_experimental_quadrature.f90 \
-      stdlib_experimental_quadrature_trapz.f90 \
-      stdlib_experimental_stats.f90 \
-      stdlib_experimental_stats_mean.f90 \
-      stdlib_experimental_stats_moment.f90 \
-      stdlib_experimental_stats_var.f90
+      stdlib_ascii.f90 \
+      stdlib_error.f90 \
+      stdlib_io.f90 \
+      stdlib_linalg.f90 \
+      stdlib_linalg_diag.f90 \
+      stdlib_kinds.f90 \
+      stdlib_optval.f90 \
+      stdlib_quadrature.f90 \
+      stdlib_quadrature_trapz.f90 \
+      stdlib_stats.f90 \
+      stdlib_stats_mean.f90 \
+      stdlib_stats_moment.f90 \
+      stdlib_stats_var.f90
 
 LIB = libstdlib.a
 
@@ -38,34 +38,34 @@ clean:
 	fypp $(FYPPFLAGS) $< $@
 
 # Fortran module dependencies
-f18estop.o: stdlib_experimental_error.o
-stdlib_experimental_error.o: stdlib_experimental_optval.o
-stdlib_experimental_io.o: \
-	stdlib_experimental_error.o \
-	stdlib_experimental_optval.o \
-	stdlib_experimental_kinds.o
-stdlib_experimental_linalg_diag.o: stdlib_experimental_kinds.o
-stdlib_experimental_optval.o: stdlib_experimental_kinds.o
-stdlib_experimental_quadrature.o: stdlib_experimental_kinds.o
-stdlib_experimental_stats_mean.o: \
-	stdlib_experimental_optval.o \
-	stdlib_experimental_kinds.o \
-	stdlib_experimental_stats.o
-stdlib_experimental_stats_moment.o: \
-	stdlib_experimental_optval.o \
-	stdlib_experimental_kinds.o \
-	stdlib_experimental_stats.o
-stdlib_experimental_stats_var.o: \
-	stdlib_experimental_optval.o \
-	stdlib_experimental_kinds.o \
-	stdlib_experimental_stats.o
+f18estop.o: stdlib_error.o
+stdlib_error.o: stdlib_optval.o
+stdlib_io.o: \
+	stdlib_error.o \
+	stdlib_optval.o \
+	stdlib_kinds.o
+stdlib_linalg_diag.o: stdlib_kinds.o
+stdlib_optval.o: stdlib_kinds.o
+stdlib_quadrature.o: stdlib_kinds.o
+stdlib_stats_mean.o: \
+	stdlib_optval.o \
+	stdlib_kinds.o \
+	stdlib_stats.o
+stdlib_stats_moment.o: \
+	stdlib_optval.o \
+	stdlib_kinds.o \
+	stdlib_stats.o
+stdlib_stats_var.o: \
+	stdlib_optval.o \
+	stdlib_kinds.o \
+	stdlib_stats.o
 
 # Fortran sources that are built from fypp templates
-stdlib_experimental_io.f90: stdlib_experimental_io.fypp
-stdlib_experimental_linalg.f90: stdlib_experimental_linalg.fypp
-stdlib_experimental_linalg_diag.f90: stdlib_experimental_linalg_diag.fypp
-stdlib_experimental_quadrature.f90: stdlib_experimental_quadrature.fypp
-stdlib_experimental_stats.f90: stdlib_experimental_stats.fypp
-stdlib_experimental_stats_mean.f90: stdlib_experimental_stats_mean.fypp
-stdlib_experimental_stats_moment.f90: stdlib_experimental_stats_moment.fypp
-stdlib_experimental_stats_var.f90: stdlib_experimental_stats_var.fypp
+stdlib_io.f90: stdlib_io.fypp
+stdlib_linalg.f90: stdlib_linalg.fypp
+stdlib_linalg_diag.f90: stdlib_linalg_diag.fypp
+stdlib_quadrature.f90: stdlib_quadrature.fypp
+stdlib_stats.f90: stdlib_stats.fypp
+stdlib_stats_mean.f90: stdlib_stats_mean.fypp
+stdlib_stats_moment.f90: stdlib_moment.fypp
+stdlib_stats_var.f90: stdlib_stats_var.fypp

--- a/src/f08estop.f90
+++ b/src/f08estop.f90
@@ -1,4 +1,4 @@
-submodule (stdlib_experimental_error) estop
+submodule (stdlib_error) estop
 
 implicit none
 

--- a/src/f18estop.f90
+++ b/src/f18estop.f90
@@ -1,4 +1,4 @@
-submodule (stdlib_experimental_error) estop
+submodule (stdlib_error) estop
 
 implicit none
 

--- a/src/stdlib_ascii.f90
+++ b/src/stdlib_ascii.f90
@@ -1,4 +1,4 @@
-module stdlib_experimental_ascii
+module stdlib_ascii
 
     implicit none
     private

--- a/src/stdlib_error.f90
+++ b/src/stdlib_error.f90
@@ -1,15 +1,17 @@
-module stdlib_experimental_error
+module stdlib_error
     !! Provides support for catching and handling errors
-    !! ([Specification](../page/specs/stdlib_experimental_error.html))
+    !! ([Specification](../page/specs/stdlib_error.html))
 use, intrinsic :: iso_fortran_env, only: stderr => error_unit
-use stdlib_experimental_optval, only: optval
+use stdlib_optval, only: optval
 implicit none
 private
 
 interface ! f{08,18}estop.f90
     module subroutine error_stop(msg, code)
+        !! version: experimental
+        !!
         !! Provides a call to `error stop` and allows the user to specify a code and message
-        !! ([Specification](..//page/specs/stdlib_experimental_error.html#description_1))
+        !! ([Specification](..//page/specs/stdlib_error.html#description_1))
         character(*), intent(in) :: msg
         integer, intent(in), optional :: code
     end subroutine error_stop
@@ -20,8 +22,10 @@ public :: check, error_stop
 contains
 
 subroutine check(condition, msg, code, warn)
+    !! version: experimental
+    !!
     !! Checks the value of a logical condition
-    !! ([Specification](../page/specs/stdlib_experimental_error.html#description))
+    !! ([Specification](../page/specs/stdlib_error.html#description))
     !!
     !!##### Behavior
     !!
@@ -77,4 +81,4 @@ subroutine check(condition, msg, code, warn)
 
 end subroutine check
 
-end module stdlib_experimental_error
+end module stdlib_error

--- a/src/stdlib_experimental_stats.fypp
+++ b/src/stdlib_experimental_stats.fypp
@@ -17,6 +17,7 @@ module stdlib_experimental_stats
   interface corr
     !! Pearson correlation of array elements
     !! ([Specification](../page/specs/stdlib_experimental_stats.html#description))
+    !! version: experimental
     #:for k1, t1 in RC_KINDS_TYPES
       #:set RName = rname("corr",1, t1, k1)
       module function ${RName}$(x, dim, mask) result(res)
@@ -107,6 +108,7 @@ module stdlib_experimental_stats
   interface cov
     !! Covariance of array elements
     !! ([Specification](../page/specs/stdlib_experimental_stats.html#description_1))
+    !! version: experimental
     #:for k1, t1 in RC_KINDS_TYPES
       #:set RName = rname("cov",1, t1, k1)
       module function ${RName}$(x, dim, mask, corrected) result(res)
@@ -204,6 +206,7 @@ module stdlib_experimental_stats
   interface mean
     !! Mean of array elements
     !! ([Specification](../page/specs/stdlib_experimental_stats.html#description_2))
+    !! version: experimental
     #:for k1, t1 in RC_KINDS_TYPES
       #:for rank in RANKS
         #:set RName = rname("mean_all",rank, t1, k1)
@@ -302,6 +305,7 @@ module stdlib_experimental_stats
   interface var
     !! Variance of array elements
     !! ([Specification](../page/specs/stdlib_experimental_stats.html#description_4))
+    !! version: experimental
 
     #:for k1, t1 in RC_KINDS_TYPES
       #:for rank in RANKS
@@ -409,6 +413,7 @@ module stdlib_experimental_stats
   interface moment
     !! Central moment of array elements
     !! ([Specification](../page/specs/stdlib_experimental_stats.html#description_3))
+    !! version: experimental
     #:for k1, t1 in RC_KINDS_TYPES
       #:for rank in RANKS
         #:set RName = rname("moment_all",rank, t1, k1)

--- a/src/stdlib_io.fypp
+++ b/src/stdlib_io.fypp
@@ -2,15 +2,15 @@
 
 #:set KINDS_TYPES = REAL_KINDS_TYPES + INT_KINDS_TYPES + CMPLX_KINDS_TYPES
 
-module stdlib_experimental_io
+module stdlib_io
   !! Provides a support for file handling
-  !! ([Specification](../page/specs/stdlib_experimental_io.html))
+  !! ([Specification](../page/specs/stdlib_io.html))
 
-  use stdlib_experimental_kinds, only: sp, dp, qp, &
+  use stdlib_kinds, only: sp, dp, qp, &
       int8, int16, int32, int64
-  use stdlib_experimental_error, only: error_stop
-  use stdlib_experimental_optval, only: optval
-  use stdlib_experimental_ascii, only: is_blank
+  use stdlib_error, only: error_stop
+  use stdlib_optval, only: optval
+  use stdlib_ascii, only: is_blank
   implicit none
   private
   ! Public API
@@ -20,16 +20,20 @@ module stdlib_experimental_io
   public :: parse_mode
 
   interface loadtxt
+    !! version: experimental
+    !!
     !! Loads a 2D array from a text file
-    !! ([Specification](../page/specs/stdlib_experimental_io.html#description))
+    !! ([Specification](../page/specs/stdlib_io.html#description))
     #:for k1, t1 in KINDS_TYPES
       module procedure loadtxt_${t1[0]}$${k1}$
     #:endfor
   end interface loadtxt
 
   interface savetxt
+    !! version: experimental
+    !!
     !! Saves a 2D array into a text file
-    !! ([Specification](../page/specs/stdlib_experimental_io.html#description_2))
+    !! ([Specification](../page/specs/stdlib_io.html#description_2))
     #:for k1, t1 in KINDS_TYPES
       module procedure savetxt_${t1[0]}$${k1}$
     #:endfor
@@ -39,6 +43,8 @@ contains
 
   #:for k1, t1 in KINDS_TYPES
     subroutine  loadtxt_${t1[0]}$${k1}$(filename, d)
+      !! version: experimental
+      !!
       !! Loads a 2D array from a text file.
       !!
       !! Arguments
@@ -88,6 +94,8 @@ contains
 
   #:for k1, t1 in KINDS_TYPES
     subroutine savetxt_${t1[0]}$${k1}$(filename, d)
+      !! version: experimental
+      !!
       !! Saves a 2D array into a text file.
       !!
       !! Arguments
@@ -116,6 +124,8 @@ contains
 
 
   integer function number_of_columns(s)
+    !! version: experimental
+    !!
     !! determine number of columns
     integer,intent(in) :: s
 
@@ -138,6 +148,8 @@ contains
 
 
   integer function number_of_rows_numeric(s) result(nrows)
+    !! version: experimental
+    !!
     !! determine number or rows
     integer,intent(in)::s
     integer :: ios
@@ -168,8 +180,10 @@ contains
 
 
   integer function open(filename, mode, iostat) result(u)
+    !! version: experimental
+    !!
     !! Opens a file
-    !! ([Specification](../page/specs/stdlib_experimental_io.html#description_1))
+    !! ([Specification](../page/specs/stdlib_io.html#description_1))
     !!
     !!##### Behavior
     !!

--- a/src/stdlib_kinds.f90
+++ b/src/stdlib_kinds.f90
@@ -1,4 +1,5 @@
-module stdlib_experimental_kinds
+module stdlib_kinds
+!! version: experimental
 use iso_fortran_env, only: sp=>real32, dp=>real64, qp=>real128
 use iso_fortran_env, only: int8, int16, int32, int64
 ! If we decide later to use iso_c_binding instead of iso_fortran_env:
@@ -7,4 +8,4 @@ use iso_fortran_env, only: int8, int16, int32, int64
 implicit none
 private
 public sp, dp, qp, int8, int16, int32, int64
-end module
+end module stdlib_kinds

--- a/src/stdlib_linalg.fypp
+++ b/src/stdlib_linalg.fypp
@@ -1,9 +1,9 @@
 #:include "common.fypp"
 #:set RCI_KINDS_TYPES = REAL_KINDS_TYPES + CMPLX_KINDS_TYPES + INT_KINDS_TYPES
-module stdlib_experimental_linalg
+module stdlib_linalg
   !!Provides a support for various linear algebra procedures
-  !! ([Specification](../page/specs/stdlib_experimental_linalg.html))
-  use stdlib_experimental_kinds, only: sp, dp, qp, &
+  !! ([Specification](../page/specs/stdlib_linalg.html))
+  use stdlib_kinds, only: sp, dp, qp, &
     int8, int16, int32, int64
   implicit none
   private
@@ -13,8 +13,10 @@ module stdlib_experimental_linalg
   public :: trace
 
   interface diag
+    !! version: experimental
+    !!
     !! Creates a diagonal array or extract the diagonal elements of an array
-    !! ([Specification](../page/specs/stdlib_experimental_linalg.html#description))
+    !! ([Specification](../page/specs/stdlib_linalg.html#description))
       !
       ! Vector to matrix
       !
@@ -52,8 +54,10 @@ module stdlib_experimental_linalg
 
   ! Matrix trace
   interface trace
+    !! version: experimental
+    !!
     !! Computes the trace of a matrix
-    !! ([Specification](../page/specs/stdlib_experimental_linalg.html#description_2))
+    !! ([Specification](../page/specs/stdlib_linalg.html#description_2))
     #:for k1, t1 in RCI_KINDS_TYPES
       module procedure trace_${t1[0]}$${k1}$
     #:endfor
@@ -62,8 +66,10 @@ module stdlib_experimental_linalg
 contains
 
     function eye(n) result(res)
+      !! version: experimental
+      !!
       !! Constructs the identity matrix
-      !! ([Specification](../page/specs/stdlib_experimental_linalg.html#description_1))
+      !! ([Specification](../page/specs/stdlib_linalg.html#description_1))
       integer, intent(in) :: n
       integer(int8) :: res(n, n)
       integer :: i

--- a/src/stdlib_linalg_diag.fypp
+++ b/src/stdlib_linalg_diag.fypp
@@ -1,6 +1,6 @@
 #:include "common.fypp"
 #:set RCI_KINDS_TYPES = REAL_KINDS_TYPES + CMPLX_KINDS_TYPES + INT_KINDS_TYPES
-submodule (stdlib_experimental_linalg) stdlib_experimental_linalg_diag
+submodule (stdlib_linalg) stdlib_linalg_diag
 
   implicit none
 

--- a/src/stdlib_optval.fypp
+++ b/src/stdlib_optval.fypp
@@ -3,12 +3,12 @@
 #:set KINDS_TYPES = REAL_KINDS_TYPES + INT_KINDS_TYPES + CMPLX_KINDS_TYPES + &
   & [('l1','logical')]
 
-module stdlib_experimental_optval
+module stdlib_optval
   !!
   !! Provides a generic function `optval`, which can be used to
   !! conveniently implement fallback values for optional arguments
   !! to subprograms
-  !! ([Specification](../page/specs/stdlib_experimental_optval.html))
+  !! ([Specification](../page/specs/stdlib_optval.html))
   !!
   !! If `x` is an `optional` parameter of a
   !! subprogram, then the expression `optval(x, default)` inside that
@@ -16,7 +16,7 @@ module stdlib_experimental_optval
   !!
   !! It is an error to call `optval` with a single actual argument.
   !!
-  use stdlib_experimental_kinds, only: sp, dp, qp, int8, int16, int32, int64
+  use stdlib_kinds, only: sp, dp, qp, int8, int16, int32, int64
   implicit none
 
 
@@ -25,8 +25,10 @@ module stdlib_experimental_optval
 
 
   interface optval
+    !! version: experimental
+    !!
     !! Fallback value for optional arguments
-    !! ([Specification](../page/specs/stdlib_experimental_optval.html#description))
+    !! ([Specification](../page/specs/stdlib_optval.html#description))
     #:for k1, t1 in KINDS_TYPES
       module procedure optval_${t1[0]}$${k1}$
     #:endfor
@@ -64,4 +66,4 @@ contains
     end if
   end function optval_character
 
-end module stdlib_experimental_optval
+end module stdlib_optval

--- a/src/stdlib_quadrature.fypp
+++ b/src/stdlib_quadrature.fypp
@@ -1,7 +1,7 @@
 #:include "common.fypp"
-module stdlib_experimental_quadrature
-    !! ([Specification](../page/specs/stdlib_experimental_quadrature.html#description))
-    use stdlib_experimental_kinds, only: sp, dp, qp
+module stdlib_quadrature
+    !! ([Specification](../page/specs/stdlib_quadrature.html#description))
+    use stdlib_kinds, only: sp, dp, qp
 
     implicit none
 
@@ -15,8 +15,10 @@ module stdlib_experimental_quadrature
 
 
     interface trapz
+	!! version: experimental
+	!!
         !! Integrates sampled values using trapezoidal rule
-        !! ([Specification](../page/specs/stdlib_experimental_quadrature.html#description))
+        !! ([Specification](../page/specs/stdlib_quadrature.html#description))
         #:for k1, t1 in REAL_KINDS_TYPES
         pure module function trapz_dx_${k1}$(y, dx) result(integral)
           ${t1}$, dimension(:), intent(in) :: y
@@ -35,8 +37,10 @@ module stdlib_experimental_quadrature
 
 
     interface trapz_weights
+	!! version: experimental
+	!!
         !! Integrates sampled values using trapezoidal rule weights for given abscissas
-        !! ([Specification](../page/specs/stdlib_experimental_quadrature.html#description_1))
+        !! ([Specification](../page/specs/stdlib_quadrature.html#description_1))
         #:for k1, t1 in REAL_KINDS_TYPES
         pure module function trapz_weights_${k1}$(x) result(w)
             ${t1}$, dimension(:), intent(in) :: x
@@ -47,8 +51,10 @@ module stdlib_experimental_quadrature
 
 
     interface simps
+	!! version: experimental
+	!!
         !! Integrates sampled values using Simpson's rule
-        !! ([Specification](../page/specs/stdlib_experimental_quadrature.html#description_3))
+        !! ([Specification](../page/specs/stdlib_quadrature.html#description_3))
         ! "recursive" is an implementation detail
         #:for k1, t1 in REAL_KINDS_TYPES
         pure recursive module function simps_dx_${k1}$(y, dx, even) result(integral)
@@ -70,8 +76,10 @@ module stdlib_experimental_quadrature
 
 
     interface simps_weights
+	!! version: experimental
+	!!
         !! Integrates sampled values using trapezoidal rule weights for given abscissas
-        !! ([Specification](../page/specs/stdlib_experimental_quadrature.html#description_3))
+        !! ([Specification](../page/specs/stdlib_quadrature.html#description_3))
         #:for k1, t1 in REAL_KINDS_TYPES
         pure recursive module function simps_weights_${k1}$(x, even) result(w)
             ${t1}$, dimension(:), intent(in) :: x
@@ -95,4 +103,4 @@ module stdlib_experimental_quadrature
         #:endfor
     end interface
 
-end module stdlib_experimental_quadrature
+end module stdlib_quadrature

--- a/src/stdlib_quadrature_simps.fypp
+++ b/src/stdlib_quadrature_simps.fypp
@@ -1,7 +1,7 @@
 #:include "common.fypp"
 
-submodule (stdlib_experimental_quadrature) stdlib_experimental_quadrature_simps
-    use stdlib_experimental_error, only: check
+submodule (stdlib_quadrature) stdlib_quadrature_simps
+    use stdlib_error, only: check
     implicit none
 
     ! internal use only
@@ -275,4 +275,4 @@ contains
 
 #:endfor
 
-end submodule stdlib_experimental_quadrature_simps
+end submodule stdlib_quadrature_simps

--- a/src/stdlib_quadrature_trapz.fypp
+++ b/src/stdlib_quadrature_trapz.fypp
@@ -1,7 +1,7 @@
 #:include "common.fypp"
 
-submodule (stdlib_experimental_quadrature) stdlib_experimental_quadrature_trapz
-    use stdlib_experimental_error, only: check
+submodule (stdlib_quadrature) stdlib_quadrature_trapz
+    use stdlib_error, only: check
     implicit none
 
 contains
@@ -84,4 +84,4 @@ contains
     end function trapz_weights_${KIND}$
 
 #:endfor
-end submodule stdlib_experimental_quadrature_trapz
+end submodule stdlib_quadrature_trapz

--- a/src/stdlib_stats.fypp
+++ b/src/stdlib_stats.fypp
@@ -2,11 +2,11 @@
 #:set RANKS = range(1, MAXRANK + 1)
 #:set REDRANKS = range(2, MAXRANK + 1)
 #:set RC_KINDS_TYPES = REAL_KINDS_TYPES + CMPLX_KINDS_TYPES
-module stdlib_experimental_stats
+module stdlib_stats
   !! Provides support for various statistical methods. This includes currently
   !! descriptive statistics
-  !! ([Specification](../page/specs/stdlib_experimental_stats.html))
-  use stdlib_experimental_kinds, only: sp, dp, qp, &
+  !! ([Specification](../page/specs/stdlib_stats.html))
+  use stdlib_kinds, only: sp, dp, qp, &
       int8, int16, int32, int64
   implicit none
   private
@@ -15,9 +15,10 @@ module stdlib_experimental_stats
 
 
   interface corr
-    !! Pearson correlation of array elements
-    !! ([Specification](../page/specs/stdlib_experimental_stats.html#description))
     !! version: experimental
+    !!
+    !! Pearson correlation of array elements
+    !! ([Specification](../page/specs/stdlib_stats.html#description))
     #:for k1, t1 in RC_KINDS_TYPES
       #:set RName = rname("corr",1, t1, k1)
       module function ${RName}$(x, dim, mask) result(res)
@@ -106,9 +107,10 @@ module stdlib_experimental_stats
 
 
   interface cov
-    !! Covariance of array elements
-    !! ([Specification](../page/specs/stdlib_experimental_stats.html#description_1))
     !! version: experimental
+    !!
+    !! Covariance of array elements
+    !! ([Specification](../page/specs/stdlib_stats.html#description_1))
     #:for k1, t1 in RC_KINDS_TYPES
       #:set RName = rname("cov",1, t1, k1)
       module function ${RName}$(x, dim, mask, corrected) result(res)
@@ -204,9 +206,10 @@ module stdlib_experimental_stats
 
 
   interface mean
-    !! Mean of array elements
-    !! ([Specification](../page/specs/stdlib_experimental_stats.html#description_2))
     !! version: experimental
+    !!
+    !! Mean of array elements
+    !! ([Specification](../page/specs/stdlib_stats.html#description_2))
     #:for k1, t1 in RC_KINDS_TYPES
       #:for rank in RANKS
         #:set RName = rname("mean_all",rank, t1, k1)
@@ -303,9 +306,10 @@ module stdlib_experimental_stats
 
 
   interface var
-    !! Variance of array elements
-    !! ([Specification](../page/specs/stdlib_experimental_stats.html#description_4))
     !! version: experimental
+    !!
+    !! Variance of array elements
+    !! ([Specification](../page/specs/stdlib_stats.html#description_4))
 
     #:for k1, t1 in RC_KINDS_TYPES
       #:for rank in RANKS
@@ -411,9 +415,10 @@ module stdlib_experimental_stats
 
 
   interface moment
-    !! Central moment of array elements
-    !! ([Specification](../page/specs/stdlib_experimental_stats.html#description_3))
     !! version: experimental
+    !!
+    !! Central moment of array elements
+    !! ([Specification](../page/specs/stdlib_stats.html#description_3))
     #:for k1, t1 in RC_KINDS_TYPES
       #:for rank in RANKS
         #:set RName = rname("moment_all",rank, t1, k1)
@@ -579,4 +584,4 @@ module stdlib_experimental_stats
     #:endfor
   end interface moment
 
-end module stdlib_experimental_stats
+end module stdlib_stats

--- a/src/stdlib_stats_corr.fypp
+++ b/src/stdlib_stats_corr.fypp
@@ -1,11 +1,11 @@
 #:include "common.fypp"
 #:set RC_KINDS_TYPES = REAL_KINDS_TYPES + CMPLX_KINDS_TYPES
-submodule (stdlib_experimental_stats) stdlib_experimental_stats_corr
+submodule (stdlib_stats) stdlib_stats_corr
 
   use, intrinsic:: ieee_arithmetic, only: ieee_value, ieee_quiet_nan
-  use stdlib_experimental_error, only: error_stop
-  use stdlib_experimental_linalg, only: diag
-  use stdlib_experimental_optval, only: optval
+  use stdlib_error, only: error_stop
+  use stdlib_linalg, only: diag
+  use stdlib_optval, only: optval
   implicit none
 
 contains

--- a/src/stdlib_stats_cov.fypp
+++ b/src/stdlib_stats_cov.fypp
@@ -1,10 +1,10 @@
 #:include "common.fypp"
 #:set RC_KINDS_TYPES = REAL_KINDS_TYPES + CMPLX_KINDS_TYPES
-submodule (stdlib_experimental_stats) stdlib_experimental_stats_cov
+submodule (stdlib_stats) stdlib_stats_cov
 
   use, intrinsic:: ieee_arithmetic, only: ieee_value, ieee_quiet_nan
-  use stdlib_experimental_error, only: error_stop
-  use stdlib_experimental_optval, only: optval
+  use stdlib_error, only: error_stop
+  use stdlib_optval, only: optval
   implicit none
 
 contains

--- a/src/stdlib_stats_mean.fypp
+++ b/src/stdlib_stats_mean.fypp
@@ -1,11 +1,11 @@
 #:include "common.fypp"
 #:set RANKS = range(1, MAXRANK + 1)
 #:set RC_KINDS_TYPES = REAL_KINDS_TYPES + CMPLX_KINDS_TYPES
-submodule (stdlib_experimental_stats) stdlib_experimental_stats_mean
+submodule (stdlib_stats) stdlib_stats_mean
 
   use, intrinsic:: ieee_arithmetic, only: ieee_value, ieee_quiet_nan
-  use stdlib_experimental_error, only: error_stop
-  use stdlib_experimental_optval, only: optval
+  use stdlib_error, only: error_stop
+  use stdlib_optval, only: optval
   implicit none
 
 contains

--- a/src/stdlib_stats_moment.fypp
+++ b/src/stdlib_stats_moment.fypp
@@ -2,11 +2,11 @@
 #:set RANKS = range(1, MAXRANK + 1)
 #:set REDRANKS = range(2, MAXRANK + 1)
 #:set RC_KINDS_TYPES = REAL_KINDS_TYPES + CMPLX_KINDS_TYPES
-submodule (stdlib_experimental_stats) stdlib_experimental_stats_moment
+submodule (stdlib_stats) stdlib_stats_moment
 
   use, intrinsic:: ieee_arithmetic, only: ieee_value, ieee_quiet_nan
-  use stdlib_experimental_error, only: error_stop
-  use stdlib_experimental_optval, only: optval
+  use stdlib_error, only: error_stop
+  use stdlib_optval, only: optval
   implicit none
 
 contains

--- a/src/stdlib_stats_var.fypp
+++ b/src/stdlib_stats_var.fypp
@@ -1,11 +1,11 @@
 #:include "common.fypp"
 #:set RANKS = range(1, MAXRANK + 1)
 #:set RC_KINDS_TYPES = REAL_KINDS_TYPES + CMPLX_KINDS_TYPES
-submodule (stdlib_experimental_stats) stdlib_experimental_stats_var
+submodule (stdlib_stats) stdlib_stats_var
 
   use, intrinsic:: ieee_arithmetic, only: ieee_value, ieee_quiet_nan
-  use stdlib_experimental_error, only: error_stop
-  use stdlib_experimental_optval, only: optval
+  use stdlib_error, only: error_stop
+  use stdlib_optval, only: optval
   implicit none
 
 contains

--- a/src/stdlib_system.F90
+++ b/src/stdlib_system.F90
@@ -1,4 +1,4 @@
-module stdlib_experimental_system
+module stdlib_system
 use, intrinsic :: iso_c_binding, only : c_int, c_long
 implicit none
 private
@@ -7,6 +7,8 @@ public :: sleep
 interface
 #ifdef _WIN32
 subroutine winsleep(dwMilliseconds) bind (C, name='Sleep')
+!! version: experimental
+!!
 !! void Sleep(DWORD dwMilliseconds)
 !! https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-sleep
 import c_long
@@ -14,6 +16,8 @@ integer(c_long), value, intent(in) :: dwMilliseconds
 end subroutine winsleep
 #else
 integer(c_int) function usleep(usec) bind (C)
+!! version: experimental
+!!
 !! int usleep(useconds_t usec);
 !! https://linux.die.net/man/3/usleep
 import c_int
@@ -25,6 +29,8 @@ end interface
 contains
 
 subroutine sleep(millisec)
+!! version: experimental
+!!
 integer, intent(in) :: millisec
 integer(c_int) :: ierr
 
@@ -40,4 +46,4 @@ if (ierr/=0) error stop 'problem with usleep() system call'
 
 end subroutine sleep
 
-end module stdlib_experimental_system
+end module stdlib_system

--- a/src/tests/ascii/test_ascii.f90
+++ b/src/tests/ascii/test_ascii.f90
@@ -1,7 +1,7 @@
 program test_ascii
 
-    use stdlib_experimental_error, only: check
-    use stdlib_experimental_ascii, only: lowercase, uppercase, digits, &
+    use stdlib_error, only: check
+    use stdlib_ascii, only: lowercase, uppercase, digits, &
         octal_digits, fullhex_digits, hex_digits, lowerhex_digits, &
         whitespace, letters, is_alphanum, is_alpha, is_lower, is_upper, &
         is_digit, is_octal_digit, is_hex_digit, is_white, is_blank, &

--- a/src/tests/io/test_loadtxt.f90
+++ b/src/tests/io/test_loadtxt.f90
@@ -1,7 +1,7 @@
 program test_loadtxt
-use stdlib_experimental_kinds, only: int32, sp, dp
-use stdlib_experimental_io, only: loadtxt
-use stdlib_experimental_error, only: error_stop
+use stdlib_kinds, only: int32, sp, dp
+use stdlib_io, only: loadtxt
+use stdlib_error, only: error_stop
 implicit none
 
 integer(int32), allocatable :: i(:, :)

--- a/src/tests/io/test_loadtxt_qp.f90
+++ b/src/tests/io/test_loadtxt_qp.f90
@@ -1,6 +1,6 @@
 program test_loadtxt_qp
-use stdlib_experimental_kinds, only: qp
-use stdlib_experimental_io, only: loadtxt
+use stdlib_kinds, only: qp
+use stdlib_io, only: loadtxt
 implicit none
 
 real(qp), allocatable :: q(:, :)

--- a/src/tests/io/test_open.f90
+++ b/src/tests/io/test_open.f90
@@ -1,6 +1,6 @@
 program test_open
-use stdlib_experimental_io, only: open
-use stdlib_experimental_error, only: check
+use stdlib_io, only: open
+use stdlib_error, only: check
 implicit none
 
 character(:), allocatable :: filename

--- a/src/tests/io/test_parse_mode.f90
+++ b/src/tests/io/test_parse_mode.f90
@@ -1,6 +1,6 @@
 program test_parse_mode
-use stdlib_experimental_io, only: parse_mode
-use stdlib_experimental_error, only: check
+use stdlib_io, only: parse_mode
+use stdlib_error, only: check
 implicit none
 
 call test_parse_mode_expected_order()

--- a/src/tests/io/test_savetxt.f90
+++ b/src/tests/io/test_savetxt.f90
@@ -1,7 +1,7 @@
 program test_savetxt
-use stdlib_experimental_kinds, only: int32, sp, dp
-use stdlib_experimental_io, only: loadtxt, savetxt
-use stdlib_experimental_error, only: check
+use stdlib_kinds, only: int32, sp, dp
+use stdlib_io, only: loadtxt, savetxt
+use stdlib_error, only: check
 implicit none
 
 character(:), allocatable :: outpath

--- a/src/tests/io/test_savetxt_qp.f90
+++ b/src/tests/io/test_savetxt_qp.f90
@@ -1,7 +1,7 @@
 program test_savetxt_qp
-use stdlib_experimental_kinds, only: qp
-use stdlib_experimental_io, only: loadtxt, savetxt
-use stdlib_experimental_error, only: check
+use stdlib_kinds, only: qp
+use stdlib_io, only: loadtxt, savetxt
+use stdlib_error, only: check
 implicit none
 
 character(:), allocatable :: outpath

--- a/src/tests/linalg/test_linalg.f90
+++ b/src/tests/linalg/test_linalg.f90
@@ -1,8 +1,8 @@
 program test_linalg
   
-  use stdlib_experimental_error, only: check
-  use stdlib_experimental_kinds, only: sp, dp, qp, int8, int16, int32, int64
-  use stdlib_experimental_linalg, only: diag, eye, trace
+  use stdlib_error, only: check
+  use stdlib_kinds, only: sp, dp, qp, int8, int16, int32, int64
+  use stdlib_linalg, only: diag, eye, trace
   
   implicit none
   

--- a/src/tests/optval/test_optval.f90
+++ b/src/tests/optval/test_optval.f90
@@ -2,8 +2,8 @@ program test_optval
   use, intrinsic :: iso_fortran_env, only: &
        sp => real32, dp => real64, qp => real128, &
        int8, int16, int32, int64
-  use stdlib_experimental_error, only: check
-  use stdlib_experimental_optval, only: optval
+  use stdlib_error, only: check
+  use stdlib_optval, only: optval
 
   implicit none
 

--- a/src/tests/quadrature/test_simps.f90
+++ b/src/tests/quadrature/test_simps.f90
@@ -1,7 +1,7 @@
 program test_simps
-    use stdlib_experimental_kinds, only: sp, dp, qp
-    use stdlib_experimental_error, only: check
-    use stdlib_experimental_quadrature, only: simps, simps_weights
+    use stdlib_kinds, only: sp, dp, qp
+    use stdlib_error, only: check
+    use stdlib_quadrature, only: simps, simps_weights
 
     implicit none
 

--- a/src/tests/quadrature/test_trapz.f90
+++ b/src/tests/quadrature/test_trapz.f90
@@ -1,7 +1,7 @@
 program test_trapz
-    use stdlib_experimental_kinds, only: sp, dp, qp
-    use stdlib_experimental_error, only: check
-    use stdlib_experimental_quadrature, only: trapz, trapz_weights
+    use stdlib_kinds, only: sp, dp, qp
+    use stdlib_error, only: check
+    use stdlib_quadrature, only: trapz, trapz_weights
 
     implicit none
 

--- a/src/tests/stats/test_corr.f90
+++ b/src/tests/stats/test_corr.f90
@@ -1,7 +1,7 @@
 program test_corr
-    use stdlib_experimental_error, only: check
-    use stdlib_experimental_kinds, only: sp, dp, int32, int64
-    use stdlib_experimental_stats, only: corr
+    use stdlib_error, only: check
+    use stdlib_kinds, only: sp, dp, int32, int64
+    use stdlib_stats, only: corr
     use,intrinsic :: ieee_arithmetic, only : ieee_is_nan
     implicit none
 

--- a/src/tests/stats/test_cov.f90
+++ b/src/tests/stats/test_cov.f90
@@ -1,7 +1,7 @@
 program test_cov
-    use stdlib_experimental_error, only: check
-    use stdlib_experimental_kinds, only: sp, dp, int32, int64
-    use stdlib_experimental_stats, only: cov, var
+    use stdlib_error, only: check
+    use stdlib_kinds, only: sp, dp, int32, int64
+    use stdlib_stats, only: cov, var
     use,intrinsic :: ieee_arithmetic, only : ieee_is_nan
     implicit none
 

--- a/src/tests/stats/test_mean.f90
+++ b/src/tests/stats/test_mean.f90
@@ -1,8 +1,8 @@
 program test_mean
-use stdlib_experimental_error, only: check
-use stdlib_experimental_kinds, only: sp, dp, int32, int64
-use stdlib_experimental_io, only: loadtxt
-use stdlib_experimental_stats, only: mean
+use stdlib_error, only: check
+use stdlib_kinds, only: sp, dp, int32, int64
+use stdlib_io, only: loadtxt
+use stdlib_stats, only: mean
 use,intrinsic :: ieee_arithmetic, only : ieee_is_nan
 implicit none
 

--- a/src/tests/stats/test_mean_f03.f90
+++ b/src/tests/stats/test_mean_f03.f90
@@ -1,8 +1,8 @@
 program test_mean
-use stdlib_experimental_error, only: check
-use stdlib_experimental_kinds, only: sp, dp, int32, int64
-use stdlib_experimental_io, only: loadtxt
-use stdlib_experimental_stats, only: mean
+use stdlib_error, only: check
+use stdlib_kinds, only: sp, dp, int32, int64
+use stdlib_io, only: loadtxt
+use stdlib_stats, only: mean
 implicit none
 
 real(dp), parameter :: dptol =10 * epsilon(1._dp)

--- a/src/tests/stats/test_moment.f90
+++ b/src/tests/stats/test_moment.f90
@@ -1,7 +1,7 @@
 program test_moment
-    use stdlib_experimental_error, only: check
-    use stdlib_experimental_kinds, only: sp, dp, int32, int64
-    use stdlib_experimental_stats, only: moment
+    use stdlib_error, only: check
+    use stdlib_kinds, only: sp, dp, int32, int64
+    use stdlib_stats, only: moment
     use,intrinsic :: ieee_arithmetic, only : ieee_is_nan
     implicit none
 

--- a/src/tests/stats/test_rawmoment.f90
+++ b/src/tests/stats/test_rawmoment.f90
@@ -1,7 +1,7 @@
 program test_rawmoment
-    use stdlib_experimental_error, only: check
-    use stdlib_experimental_kinds, only: sp, dp, int32, int64
-    use stdlib_experimental_stats, only: mean, moment
+    use stdlib_error, only: check
+    use stdlib_kinds, only: sp, dp, int32, int64
+    use stdlib_stats, only: mean, moment
     use,intrinsic :: ieee_arithmetic, only : ieee_is_nan
     implicit none
 

--- a/src/tests/stats/test_var.f90
+++ b/src/tests/stats/test_var.f90
@@ -1,7 +1,7 @@
 program test_var
-    use stdlib_experimental_error, only: check
-    use stdlib_experimental_kinds, only: sp, dp, int32, int64
-    use stdlib_experimental_stats, only: var
+    use stdlib_error, only: check
+    use stdlib_kinds, only: sp, dp, int32, int64
+    use stdlib_stats, only: var
     use,intrinsic :: ieee_arithmetic, only : ieee_is_nan
     implicit none
 

--- a/src/tests/stats/test_varn.f90
+++ b/src/tests/stats/test_varn.f90
@@ -1,7 +1,7 @@
 program test_varn
-    use stdlib_experimental_error, only: check
-    use stdlib_experimental_kinds, only: sp, dp, int32, int64
-    use stdlib_experimental_stats, only: var
+    use stdlib_error, only: check
+    use stdlib_kinds, only: sp, dp, int32, int64
+    use stdlib_stats, only: var
     use,intrinsic :: ieee_arithmetic, only : ieee_is_nan
     implicit none
 

--- a/src/tests/system/test_sleep.f90
+++ b/src/tests/system/test_sleep.f90
@@ -1,6 +1,6 @@
 program test_sleep
 use, intrinsic :: iso_fortran_env, only : int64, real64
-use stdlib_experimental_system, only : sleep
+use stdlib_system, only : sleep
 
 implicit none
 

--- a/src/tests/test_always_fail.f90
+++ b/src/tests/test_always_fail.f90
@@ -1,6 +1,6 @@
 program test_always_fail
 
-use stdlib_experimental_error, only: check
+use stdlib_error, only: check
 implicit none
 
 call check(.false.)

--- a/src/tests/test_always_skip.f90
+++ b/src/tests/test_always_skip.f90
@@ -1,6 +1,6 @@
 program test_always_skip
 
-use stdlib_experimental_error, only: check
+use stdlib_error, only: check
 implicit none
 
 call check(.false., code=77)


### PR DESCRIPTION
This PR changes the directory structure of stdlib as discussed in #216 opened by @wclodius2

In short:
* all "experimental" terms have been removed from the names of the modules
* a version ("experimental") tag has been added to all procedures and also in the specs. FORD uses the version tag as meta-data.
