### PR TITLE
logger: avoid trailing spaces when writing line 2+

### DIFF
--- a/src/stdlib_logger.f90
+++ b/src/stdlib_logger.f90
@@ -597,7 +597,7 @@ contains
                     return
                 else
                     write( unit, '(a)', err=999, iostat=iostat, iomsg=iomsg ) &
-                        string(count+1:index)
+                        string(count+1:index-1)
                     count = index
                     remain = length - count
                     return
@@ -632,7 +632,7 @@ contains
                     return
                 else
                     write( unit, '(a)', err=999, iostat=iostat, iomsg=iomsg ) &
-                        col_indent // string(count+1:index)
+                        col_indent // string(count+1:index-1)
                     count = index
                     remain = length - count
                     return


### PR DESCRIPTION
Currently, a trailing space will be present from the second line (there is no trailing space for the first line (see `format_fist_line` for details).
This PR avoids trailing spaces from the second line.

@wclodius2 What is on purpose that a trailing space remained from the second line?