### PR TITLE
Logger: support of new_line() in the output of the logger

### DIFF
--- a/src/stdlib_logger.f90
+++ b/src/stdlib_logger.f90
@@ -546,8 +546,7 @@ contains
 
             if ( self % max_width == 0 .or.                                         &
                 ( length <= self % max_width .and.                                  &
-                index( string(1:min(length, self % max_width)), new_line('a')) == 0 &
-                )) then
+                index( string(1:length), new_line('a')) == 0 ) ) then
                 write( unit, '(a)', err=999, iostat=iostat, iomsg=iomsg ) &
                     string(1:length)
                 remain = 0

--- a/src/stdlib_logger.f90
+++ b/src/stdlib_logger.f90
@@ -523,7 +523,7 @@ contains
         character(*), intent(in)       :: procedure_name
         character(*), intent(in)       :: col_indent
 
-        integer :: count, indent_len, index, iostat, length, remain
+        integer :: count, indent_len, index_, iostat, length, remain
         character(256) :: iomsg
 
         length = len_trim(string)
@@ -551,11 +551,14 @@ contains
                 return
             else
 
-                do index=self % max_width, 1, -1
-                    if ( string(index:index) == ' ' ) exit
-                end do
+                index_ = index( string(1:self % max_width), new_line('a'))
+                if ( index_ == 0 ) then
+                    do index_=self % max_width, 1, -1
+                        if ( string(index_:index_) == ' ' ) exit
+                    end do
+                end if
 
-                if ( index == 0 ) then
+                if ( index_ == 0 ) then
                     write( unit, '(a)', err=999, iostat=iostat, iomsg=iomsg ) &
                         string(1:self % max_width)
                     count = self % max_width
@@ -563,8 +566,8 @@ contains
                     return
                 else
                     write( unit, '(a)', err=999, iostat=iostat, iomsg=iomsg ) &
-                        string(1:index-1)
-                    count = index
+                        string(1:index_-1)
+                    count = index_
                     remain = length - count
                     return
                 end if
@@ -585,11 +588,15 @@ contains
                 return
             else
 
-                do index=count+self % max_width, count+1, -1
-                    if ( string(index:index) == ' ' ) exit
-                end do
+                index_ = count + index( string(count+1:count+self % max_width), &
+                    new_line('a'))
+                if(index_ == count) then
+                    do index_=count+self % max_width, count+1, -1
+                        if ( string(index_:index_) == ' ' ) exit
+                    end do
+                end if
 
-                if ( index == count ) then
+                if ( index_ == count ) then
                     write( unit, '(a)', err=999, iostat=iostat, iomsg=iomsg ) &
                         string(count+1:count+self % max_width)
                     count = count + self % max_width
@@ -597,8 +604,8 @@ contains
                     return
                 else
                     write( unit, '(a)', err=999, iostat=iostat, iomsg=iomsg ) &
-                        string(count+1:index-1)
-                    count = index
+                        string(count+1:index_-1)
+                    count = index_
                     remain = length - count
                     return
                 end if
@@ -611,7 +618,8 @@ contains
 
         subroutine indent_format_subsequent_line()
 
-            if ( remain <= self % max_width - indent_len ) then
+            if ( index( string(count+1:length), new_line('a')) == 0 .and. &
+                remain <= self % max_width - indent_len ) then
                 write( unit, '(a)', err=999, iostat=iostat, iomsg=iomsg ) &
                     col_indent // string(count+1:length)
                 count = length
@@ -619,11 +627,15 @@ contains
                 return
             else
 
-                do index=count+self % max_width-indent_len, count+1, -1
-                    if ( string(index:index) == ' ' ) exit
-                end do
+                index_ = count + index( string(count+1:count+self % max_width &
+                    - indent_len), new_line('a'))
+                if(index_ == count) then
+                    do index_=count+self % max_width-indent_len, count+1, -1
+                        if ( string(index_:index_) == ' ' ) exit
+                    end do
+                end if
 
-                if ( index == count ) then
+                if ( index_ == count ) then
                     write( unit, '(a)', err=999, iostat=iostat, iomsg=iomsg ) &
                         col_indent // &
                         string(count+1:count+self % max_width-indent_len)
@@ -632,8 +644,8 @@ contains
                     return
                 else
                     write( unit, '(a)', err=999, iostat=iostat, iomsg=iomsg ) &
-                        col_indent // string(count+1:index-1)
-                    count = index
+                        col_indent // string(count+1:index_-1)
+                    count = index_
                     remain = length - count
                     return
                 end if

--- a/src/stdlib_logger.f90
+++ b/src/stdlib_logger.f90
@@ -544,8 +544,8 @@ contains
 
         subroutine format_first_line()
 
-            if ( self % max_width == 0 .or. &
-                ( length <= self % max_width .and. &
+            if ( self % max_width == 0 .or.                                         &
+                ( length <= self % max_width .and.                                  &
                 index( string(1:min(length, self % max_width)), new_line('a')) == 0 &
                 )) then
                 write( unit, '(a)', err=999, iostat=iostat, iomsg=iomsg ) &
@@ -630,7 +630,7 @@ contains
                 return
             else
 
-                index_ = count + index( string(count+1: &
+                index_ = count + index( string(count+1:                   &
                     min ( length, count+self % max_width - indent_len) ), &
                     new_line('a'))
                 if(index_ == count) then
@@ -641,7 +641,7 @@ contains
 
                 if ( index_ == count ) then
                     write( unit, '(a)', err=999, iostat=iostat, iomsg=iomsg ) &
-                        col_indent // &
+                        col_indent //                                         &
                         string(count+1:count+self % max_width-indent_len)
                     count = count + self % max_width - indent_len
                     remain = length - count

--- a/src/stdlib_logger.f90
+++ b/src/stdlib_logger.f90
@@ -544,14 +544,17 @@ contains
 
         subroutine format_first_line()
 
-            if ( length <= self % max_width .or. self % max_width == 0 ) then
+            if ( self % max_width == 0 .or. &
+                ( length <= self % max_width .and. &
+                index( string(1:min(length, self % max_width)), new_line('a')) == 0 &
+                )) then
                 write( unit, '(a)', err=999, iostat=iostat, iomsg=iomsg ) &
                     string(1:length)
                 remain = 0
                 return
             else
 
-                index_ = index( string(1:self % max_width), new_line('a'))
+                index_ = index( string(1:min(length, self % max_width)), new_line('a'))
                 if ( index_ == 0 ) then
                     do index_=self % max_width, 1, -1
                         if ( string(index_:index_) == ' ' ) exit
@@ -627,8 +630,9 @@ contains
                 return
             else
 
-                index_ = count + index( string(count+1:count+self % max_width &
-                    - indent_len), new_line('a'))
+                index_ = count + index( string(count+1: &
+                    min ( length, count+self % max_width - indent_len) ), &
+                    new_line('a'))
                 if(index_ == count) then
                     do index_=count+self % max_width-indent_len, count+1, -1
                         if ( string(index_:index_) == ' ' ) exit

--- a/src/tests/logger/test_stdlib_logger.f90
+++ b/src/tests/logger/test_stdlib_logger.f90
@@ -191,6 +191,13 @@ contains
             module = 'N/A', &
             procedure = 'TEST_STDLIB_LOGGER' )
 
+        call global % log_message( 'The last word of the first line ' //      &
+            new_line('a')//'should be "line". "Line"' // new_line('a') //     &
+            'is also the last word for the second line. The following ' //    &
+            'lines should be limited to 72 columns width.' , &
+            module = 'N/A', &
+            procedure = 'TEST_STDLIB_LOGGER' )
+
         call global % configure( add_blank_line=.false., indent=.true., &
             max_width=72, time_stamp=.true. )
 
@@ -200,6 +207,14 @@ contains
             'by MODULE % PROCEDURE, have a prefix of WARN, and be ' //  &
             'indented by 4 columns on subsequent lines.',               &
             module = 'N/A',                                             &
+            procedure = 'TEST_STDLIB_LOGGER' )
+
+        call global % log_message( 'The last word of the first line ' //      &
+            new_line('a')//'should be "the". "Line"' // new_line('a') //      &
+            'should be the last word for the second line. The following ' //  &
+            'lines should be limited to 72 columns width. From the second ' //&
+            'line, all lines should be indented by 4 columns.' ,&
+            module = 'N/A', &
             procedure = 'TEST_STDLIB_LOGGER' )
 
     end subroutine test_logging_configuration

--- a/src/tests/logger/test_stdlib_logger.f90
+++ b/src/tests/logger/test_stdlib_logger.f90
@@ -138,7 +138,7 @@ contains
             'to OUTPUT_UNIT, unlimited in width, not preceded by ' //      &
             'a blank line, then by a time stamp, then by MODULE % ' //     &
             'PROCEDURE, be prefixed by INFO. ' // new_line('a') //         &
-            'This is a new line of the same log message.',                  &
+            'This is a new line of the same log message.',                 &
             module = 'N/A',                                                &
             procedure = 'TEST_STDLIB_LOGGER' )
 

--- a/src/tests/logger/test_stdlib_logger.f90
+++ b/src/tests/logger/test_stdlib_logger.f90
@@ -134,6 +134,14 @@ contains
             module = 'N/A',                                                &
             procedure = 'TEST_STDLIB_LOGGER' )
 
+        call global % log_information( 'This message should be output ' // &
+            'to OUTPUT_UNIT, unlimited in width, not preceded by ' //      &
+            'a blank line, then by a time stamp, then by MODULE % ' //     &
+            'PROCEDURE, be prefixed by INFO. ' // new_line('a') //         &
+            'This is a new line of the same log message.',                  &
+            module = 'N/A',                                                &
+            procedure = 'TEST_STDLIB_LOGGER' )
+
         call global % configure( add_blank_line=.true., indent=.false., &
             max_width=72, time_stamp=.false. )
 
@@ -142,7 +150,7 @@ contains
             log_units=log_units )
 
         if ( add_blank_line ) then
-            write(*,*) 'ADD_BLANK_LINE is now .FALSE. as expected.'
+            write(*,*) 'ADD_BLANK_LINE is now .TRUE. as expected.'
 
         else
             error stop 'ADD_BLANKLINE is now .FALSE. contrary to expectations.'


### PR DESCRIPTION
A proposition to support `new_line` properly when inserted in a message as, e.g.,:
```fortran
call global % log_message( 'Possible issues: ' // new_line('a') // &
 ' 1) First possible issue' // new_line('a') // &
 ' 2) Second possible issue') 