### PR TITLE
Logger safe async io

### DIFF
--- a/doc/specs/index.md
+++ b/doc/specs/index.md
@@ -14,6 +14,7 @@ This is and index/directory of the specifications (specs) for each new module/fe
  - [error](./stdlib_error.html) - Catching and handling errors
  - [IO](./stdlib_io.html) - Input/output helper & convenience
  - [linalg](./stdlib_linalg.html) - Linear Algebra
+ - [logger](./stdlib_logger.html) - Runtime logging system
  - [optval](./stdlib_optval.html) - Fallback value for optional arguments
  - [quadrature](./stdlib_quadrature.html) - Numerical integration
  - [stats](./stdlib_stats.html) - Descriptive Statistics

--- a/doc/specs/stdlib_logger.md
+++ b/doc/specs/stdlib_logger.md
@@ -34,6 +34,10 @@ The logger variables have the option to:
 * indent subsequent lines of the messages; and
 * format the text to fit within a maximum column width.
 
+While every effort has been made to make the code thread and
+asynchronous I/O safe, it is always best to have each process write to
+its own dedicated logger file.
+
 Note: Loggers of type `logger_type` normally report their messages to I/O
 units in the internal list termed `log_units`. However if `log_units`
 is empty then the messages go to the `output_unit` of the intrinsic

--- a/doc/specs/stdlib_logger.md
+++ b/doc/specs/stdlib_logger.md
@@ -75,14 +75,16 @@ significant events encountered during the execution of a program.
 
 ### Private attributes
 
-| Attribute        | Type          | Description                                     | Initial value
-|------------------|---------------|-------------------------------------------------|--------------
-| `add_blank_line` | Logical       | Flag to precede output with a blank line        | `.false.`
-| `indent_lines`   | Logical       | Flag to indent subsequent lines by four columns | `.true.`
-| `log_units`      | Integer array | List of I/O units used for output               | empty
-| `max_width`      | Integer       | Maximum column width of output                  | 0
-| `time_stamp`     | Logical       | Flag to precede output by a time stamp          | `.true.`
-| `units`          | Integer       | Count of the number of active output units      | 0
+| Attribute        | Type          | Description                                     | Initial value |
+|------------------|---------------|-------------------------------------------------|--------------|
+| `add_blank_line` | Logical       | Flag to precede output with a blank line        | `.false.`    |
+|`buffer`          | Character(:)  | Buffer to build output string                   | Unallocated  |
+| `indent_lines`   | Logical       | Flag to indent subsequent lines by four columns | `.true.`     |
+| `len_buffer`     | Integer       | Number of valid characters in buffer            | 0            |
+| `log_units`      | Integer array | List of I/O units used for output               | Unallocated  |
+| `max_width`      | Integer       | Maximum column width of output                  | 0            |
+| `time_stamp`     | Logical       | Flag to precede output by a time stamp          | `.true.`     |
+| `units`          | Integer       | Count of the number of active output units      | 0            |
 
 ## The `stdlib_logger` variable
 
@@ -285,7 +287,7 @@ Pure subroutine
 
 #### Arguments
 
-`self`: shall be a scalar variable of type `logger_type`. It is an
+`self`: shall be a scalar expression of type `logger_type`. It is an
 `intent(in)` argument. It shall be the logger whose configuration is reported.
 
 `add_blank_line` (optional): shall be a scalar default logical
@@ -415,11 +417,13 @@ Subroutine
 
 #### Arguments
 
-`self`: shall be a scalar expression of type `logger_type`. It is an
-`intent(in)` argument. It is the logger used to send the message.
+`self`: shall be a scalar variable of type `logger_type`. It is an
+`intent(inout)` argument. It is the logger used to send the message.
 
 `message`: shall be a scalar default character expression. It is an
-  `intent(in)` argument.
+`intent(in)` argument.
+
+* Note `message` may have embedded new_line calls. 
 
 `module` (optional): shall be a scalar default character
   expression. It is an `intent(in)` argument. It should be the name of
@@ -496,11 +500,13 @@ Subroutine
 
 #### Arguments
 
-`self`: shall be a scalar expression of type `logger_type`. It is an
-`intent(in)` argument. It is the logger used to send the message.
+`self`: shall be a scalar variable of type `logger_type`. It is an
+`intent(inout)` argument. It is the logger used to send the message.
 
 `message`: shall be a scalar default character expression. It is an
   `intent(in)` argument.
+
+* Note `message` may have embedded new_line calls. 
 
 `module` (optional): shall be a scalar default character
   expression. It is an `intent(in)` argument. It should be the name of
@@ -565,11 +571,13 @@ written.
 Subroutine
 
 #### Arguments
-`self`: shall be a scalar expression of type `logger_type`. It is an
-`intent(in)` argument. It is the logger used to send the message.
+`self`: shall be a scalar variable of type `logger_type`. It is an
+`intent(inout)` argument. It is the logger used to send the message.
 
 `message`: shall be a scalar default character expression. It is an
   `intent(in)` argument.
+
+* Note `message` may have embedded new_line calls. 
 
 `module` (optional): shall be a scalar default character
   expression. It is an `intent(in)` argument. It should be the name of
@@ -641,11 +649,13 @@ Subroutine
 
 #### Arguments
 
-`self`: shall be a scalar expression of type `logger_type`. It is an
-`intent(in)` argument. It is the logger used to send the message.
+`self`: shall be a scalar variable of type `logger_type`. It is an
+`intent(inout)` argument. It is the logger used to send the message.
 
 `message`: shall be a scalar default character expression. It is an
   `intent(in)` argument.
+
+* Note `message` may have embedded new_line calls. 
 
 `module` (optional): shall be a scalar default character
   expression. It is an `intent(in)` argument. It should be the name of
@@ -715,8 +725,8 @@ Subroutine
 
 #### Arguments
 
-`self`: shall be a scalar expression of type `logger_type`. It is an
-`intent(in)` argument. It is the logger used to send the message.
+`self`: shall be a scalar variable of type `logger_type`. It is an
+`intent(inout)` argument. It is the logger used to send the message.
 
 `line`: shall be a scalar default character expression. It is an
   `intent(in)` argument. It should be the line of text in which the
@@ -861,11 +871,13 @@ Subroutine
 
 #### Arguments
 
-`self`: shall be a scalar expression of type `logger_type`. It is an
-`intent(in)` argument. It is the logger used to send the message.
+`self`: shall be a scalar variable of type `logger_type`. It is an
+`intent(inout)` argument. It is the logger used to send the message.
 
 `message`: shall be a scalar default character expression. It is an
   `intent(in)` argument.
+
+* Note `message` may have embedded new_line calls. 
 
 `module`: (optional) shall be a scalar default character
   expression. It is an `intent(in)` argument. It should be the name of
@@ -924,7 +936,7 @@ Subroutine
 
 #### Arguments
 
-`self`: shall be a scalar expression of type `logger_type`. It is an
+`self`: shall be a scalar variable of type `logger_type`. It is an
 `intent(inout)` argument. It is the logger whose `log_units` is to be
 modified.
 

--- a/doc/specs/stdlib_logger.md
+++ b/doc/specs/stdlib_logger.md
@@ -34,9 +34,11 @@ The logger variables have the option to:
 * indent subsequent lines of the messages; and
 * format the text to fit within a maximum column width.
 
-While every effort has been made to make the code thread and
+While every effort has been made to make the code process and
 asynchronous I/O safe, it is always best to have each process write to
 its own dedicated logger file.
+For thread parallelism (e.g., with OpenMP), it is advised to put the
+logger call in a guarding region (e.g., in an OpenMP critical region).
 
 Note: Loggers of type `logger_type` normally report their messages to I/O
 units in the internal list termed `log_units`. However if `log_units`

--- a/doc/specs/stdlib_logger.md
+++ b/doc/specs/stdlib_logger.md
@@ -78,7 +78,7 @@ significant events encountered during the execution of a program.
 | Attribute        | Type          | Description                                     | Initial value |
 |------------------|---------------|-------------------------------------------------|--------------|
 | `add_blank_line` | Logical       | Flag to precede output with a blank line        | `.false.`    |
-|`buffer`          | Character(:)  | Buffer to build output string                   | Unallocated  |
+| `buffer`         | Character(:)  | Buffer to build output string                   | Unallocated  |
 | `indent_lines`   | Logical       | Flag to indent subsequent lines by four columns | `.true.`     |
 | `len_buffer`     | Integer       | Number of valid characters in buffer            | 0            |
 | `log_units`      | Integer array | List of I/O units used for output               | Unallocated  |

--- a/src/stdlib_logger.f90
+++ b/src/stdlib_logger.f90
@@ -523,8 +523,7 @@ contains
         character(*), intent(in)          :: string
         character(*), intent(in)          :: col_indent
 
-        integer :: count, indent_len, index_, iostat, length, remain
-        character(256) :: iomsg
+        integer :: count, indent_len, index_, length, remain
         integer, parameter :: new_len = len(new_line('a'))
 
         length = len_trim(string)
@@ -1064,24 +1063,24 @@ contains
             if ( self % add_blank_line ) then
                 write( output_unit, '(a)', err=999, iostat=iostat, &
                         iomsg=iomsg) &
-                    new_line('a') // self % buffer(0:self % len_buffer)
+                    new_line('a') // self % buffer(1:self % len_buffer)
             else
                 write( output_unit, '(a)', err=999, iostat=iostat, &
                         iomsg=iomsg ) &
-                    self % buffer(0:self % len_buffer)
+                    self % buffer(1:self % len_buffer)
             end if
         else
             if ( self % add_blank_line ) then
                 do unit=1, self % units
                     write( output_unit, '(a)', err=999, iostat=iostat, &
-                        iomsg=iomsg ) &
-                        new_line('a') // self % buffer(0:self % len_buffer)
+                        iomsg=iomsg ) new_line('a') // &
+                        self % buffer(1:self % len_buffer)
                 end do
             else
                 do unit=1, self % units
                     write( output_unit, '(a)', err=999, iostat=iostat, &
                         iomsg=iomsg ) &
-                        self % buffer(0:self % len_buffer)
+                        self % buffer(1:self % len_buffer)
                 end do
             end if
         end if
@@ -1157,8 +1156,6 @@ contains
 !! statements has failed.
 
         character(1)              :: acaret
-        character(5)              :: num
-        character(:), allocatable :: fmt
         character(128)            :: iomsg
         integer                   :: iostat
         integer                   :: lun

--- a/src/stdlib_logger.f90
+++ b/src/stdlib_logger.f90
@@ -1072,13 +1072,13 @@ contains
         else
             if ( self % add_blank_line ) then
                 do unit=1, self % units
-                    write( output_unit, '(a)', err=999, iostat=iostat, &
+                    write( self % log_units(unit), '(a)', err=999, iostat=iostat, &
                         iomsg=iomsg ) new_line('a') // &
                         self % buffer(1:self % len_buffer)
                 end do
             else
                 do unit=1, self % units
-                    write( output_unit, '(a)', err=999, iostat=iostat, &
+                    write( self % log_units(unit), '(a)', err=999, iostat=iostat, &
                         iomsg=iomsg ) &
                         self % buffer(1:self % len_buffer)
                 end do

--- a/src/stdlib_logger.f90
+++ b/src/stdlib_logger.f90
@@ -240,7 +240,7 @@ contains
 
 !! Adds `unit` to the log file units in `log_units`. `unit` must be an `open`
 !! file, of `form` `"formatted"`, with `"sequential"` `access`, and an `action`
-!! of `"write"` or `"readwrite"`, otherwise either `stat`, if preseent, has a
+!! of `"write"` or `"readwrite"`, otherwise either `stat`, if present, has a
 !! value other than `success` and `unit` is not entered into `log_units`,
 !! or, if `stat` is not presecn, processing stops.
 !!([Specification](../page/specs/stdlib_logger.html#add_log_unit-add-a-unit-to-the-array-self-log_units))

--- a/src/stdlib_logger.f90
+++ b/src/stdlib_logger.f90
@@ -808,32 +808,38 @@ contains
         character(len=*), intent(in), optional  :: errmsg
 !! The value of the `errmsg` specifier returned by a Fortran statement
 
-        integer :: unit
         integer :: iostat
+        character(28) :: dummy
+        character(256) :: iomsg
         character(*), parameter :: procedure_name = 'log_error'
-        character(256) :: iomsg, suffix
+        character(:), allocatable :: suffix
 
         if ( present(stat) ) then
-            write( suffix, '(a, i0)', err=999, iostat=iostat, iomsg=iomsg ) &
+            write( dummy, '(a, i0)', err=999, iostat=iostat, iomsg=iomsg ) &
                 new_line('a') // "With stat = ", stat
+        else
+            dummy = ' '
         end if
 
         if ( present(errmsg) ) then
             if ( len_trim(errmsg) > 0 ) then
-                suffix( len_trim(suffix)+1: ) = &
+                suffix = trim(dummy) // &
                     new_line('a') // 'With errmsg = "' // trim(errmsg) // '"'
+            else
+                suffix = dummy
             end if
+        else
+            suffix = dummy
         end if
 
-        call self % log_message( trim(message) // trim(suffix), &
-                                 module = module,               &
-                                 procedure = procedure,         &
+        call self % log_message( trim(message) // suffix, &
+                                 module = module,         &
+                                 procedure = procedure,   &
                                  prefix = 'ERROR')
 
         return
 
-        unit = -999
-999     call handle_write_failure( unit, procedure_name, iostat, iomsg )
+999     call handle_write_failure( -999, procedure_name, iostat, iomsg )
 
     end subroutine log_error
 
@@ -944,32 +950,38 @@ contains
         character(len=*), intent(in), optional  :: iomsg
 !! The value of the IOMSG specifier returned by a Fortran I/O statement
 
-        integer :: unit
+        character(28) :: dummy
+        character(256) :: iomsg2
         integer :: iostat2
-        character(*), parameter :: procedure_name = 'log_error'
-        character(256) :: iomsg2, suffix
+        character(*), parameter :: procedure_name = 'log_io_error'
+        character(:), allocatable :: suffix
 
         if ( present(iostat) ) then
-            write( suffix, '(a, i0)', err=999, iostat=iostat2, iomsg=iomsg2 ) &
+            write( dummy, '(a, i0)', err=999, iostat=iostat2, iomsg=iomsg2 ) &
                 new_line('a') // "With iostat = ", iostat
+        else
+            dummy = ' '
         end if
 
         if ( present(iomsg) ) then
             if ( len_trim(iomsg) > 0 ) then
-                suffix( len_trim(suffix)+1: ) = &
+                suffix = trim(dummy) // &
                     new_line('a') // 'With iomsg = "' // trim(iomsg) // '"'
+            else
+                suffix = trim(dummy)
             end if
+        else
+            suffix = trim(dummy)
         end if
 
-        call self % log_message( trim(message) // trim(suffix), &
-                                 module = module,               &
-                                 procedure = procedure,         &
+        call self % log_message( trim(message) // suffix, &
+                                 module = module,         &
+                                 procedure = procedure,   &
                                  prefix = 'I/O ERROR' )
 
         return
 
-        unit = -999
-999     call handle_write_failure( unit, procedure_name, iostat, iomsg )
+999     call handle_write_failure( -999, procedure_name, iostat2, iomsg2 )
 
     end subroutine log_io_error
 

--- a/src/stdlib_logger.f90
+++ b/src/stdlib_logger.f90
@@ -649,17 +649,15 @@ contains
 
             if ( index( string(count+1:length), new_line('a')) == 0 .and. &
                 remain <= self % max_width - indent_len ) then
-                new_len_buffer = self % len_buffer + index_ - 1 &
+                new_len_buffer = self % len_buffer + length &
                     - count + new_len + indent_len
                 if ( new_len_buffer > len( self % buffer ) ) then
                     allocate( character( 2*len( self % buffer ) ) :: dummy )
                     dummy = self % buffer
                     call move_alloc( dummy, self % buffer )
                 end if
-                self % buffer( self % len_buffer+1: &
-                    self % len_buffer + length - count + new_len &
-                    + indent_len ) = &
-                    new_line('a') // col_indent // string(count+1:index_-1)
+                self % buffer( self % len_buffer+1:new_len_buffer ) = &
+                    new_line('a') // col_indent // string(count+1:length)
                 self % len_buffer = new_len_buffer
                 count = length
                 remain = 0

--- a/src/tests/logger/test_stdlib_logger.f90
+++ b/src/tests/logger/test_stdlib_logger.f90
@@ -47,7 +47,7 @@ program test_stdlib_logger
     print *
     print *, 'running log_text_error'
     call global % log_text_error( 'This text should be written to UNIT1' // &
-                                  'and UNIT3 and not to OUTPUT_UNIT.',      &
+                                  ' and UNIT3 and not to OUTPUT_UNIT.',     &
                                   column = 25,                              &
                                   summary = 'There is no real error here.', &
                                   filename = 'dummy.txt',                   &


### PR DESCRIPTION
Changes in four files:
* `doc/specs/index.md` - added `stdlib_logger.html` to the index;
* `doc/specs/stdlib_logger.md` - described the changes in `stdlib_logger.f90`;
* `src/tests/logger/test-stdlib_logger.f90` - added a blank after a comma in the output;
* `src/stdlib_logger.f90` - numerous changes
   - the code handles `new_line` calls in the message string properly (added by @jvdp1, but undocumented in `stdlib_logger.md`)
   - a character string buffer was added to `logger_type` and a`len_buffer` integer to track the number of active characters in the buffer;
   - the code replaced multiple calls to write statements with single calls with line breaks generated by inserting `new_line` in the output string, in order to make the output thread and asynchronous IO safe;
   - shortened a number of lines most of them 80+ characters long
   - changed `Rrea_only_error` to `read_only_error`