### PR TITLE
Small fix to issue #245

### DIFF
--- a/.github/workflows/doc-deployment.yml
+++ b/.github/workflows/doc-deployment.yml
@@ -37,7 +37,7 @@ jobs:
         if: github.ref != 'refs/heads/master' && ! startsWith( github.ref, 'refs/tags/' )
         run: |
             sed -i .bak 's/^[[:blank:]]*graph:  *[Tt]rue/graph: false/' "${FORD_FILE}"
-            echo "::set-env name=MAYBE_SKIP_SEARCH::--no-search"
+            echo "MAYBE_SKIP_SEARCH=--no-search" >> $GITHUB_ENV
       - name: Build Docs
         run: |
           git fetch --all --tags


### PR DESCRIPTION
It seems the command `set-env` is deprecated (since it is exploitable), so the Ford CI is failing.
I believe this small fix solves the issue: [GH Workflow environment files](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files)