### PR TITLE
Issue with logger s configuration subroutine

### DIFF
--- a/doc/specs/stdlib_logger.md
+++ b/doc/specs/stdlib_logger.md
@@ -309,7 +309,8 @@ Pure subroutine
 `log_units` (optional): shall be a rank one allocatable array
   variable of type default integer. It is an `intent(out)`
   argument. On return it shall be the elements of the `self`'s `log_units`
-  array.
+  array. If there were no elements in `self`'s `log_units`, a
+  zero-sized array is returned.
 
 #### Example
 

--- a/src/stdlib_logger.f90
+++ b/src/stdlib_logger.f90
@@ -434,7 +434,11 @@ contains
         if ( present(indent) ) indent = self % indent_lines
         if ( present(max_width) ) max_width = self % max_width
         if ( present(time_stamp) ) time_stamp = self % time_stamp
-        if ( present(log_units) ) log_units = self % log_units(1:self % units)
+        if ( present(log_units) .and. self % units .gt. 0 ) then
+            log_units = self % log_units(1:self % units)
+        else
+            allocate(log_units(0))
+        end if
 
     end subroutine configuration
 


### PR DESCRIPTION
@wclodius2 
I found a small issue within `stdlib_logger`. If the subroutine `configuration` is called and no units are associated with the logger, `self % log_units` is not allocated, and leads to a segfault (in debug mode) when the program tries to use it for allocating `log_units`.
With my proposition, `log_units` will be a zero-sized array in such situations (as it is tested like that in the tests). 