### PR TITLE
Improve check for F18 error stop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ endif()
 # --- compiler feature checks
 include(CheckFortranSourceCompiles)
 include(CheckFortranSourceRuns)
-check_fortran_source_compiles("error stop i; end" f18errorstop SRC_EXT f90)
+check_fortran_source_runs("i=0; error stop i; end" f18errorstop SRC_EXT f90)
 check_fortran_source_compiles("real, allocatable :: array(:, :, :, :, :, :, :, :, :, :); end" f03rank SRC_EXT f90)
 check_fortran_source_runs("use, intrinsic :: iso_fortran_env, only : real128; real(real128) :: x; x = x+1; end" f03real128)
 


### PR DESCRIPTION
This PR improves the Fortran 2018 error stop check by running the example and checking for a correctly reported return code from the program.

The current check gives a false positive result for `ifort` 21.1 BETA 20200827, which compiles F18 error stop syntax but does not propagate the error code correctly. Since this is probably a bug I reported this upstream as well:
https://community.intel.com/t5/Intel-Fortran-Compiler/Fortran-2018-error-stop/m-p/1234424#M153065