### PR TITLE
oneapi package name change

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -121,7 +121,7 @@ jobs:
     - name: Install Intel oneAPI compiler
       if: contains(matrix.os, 'ubuntu')
       run: |
-        sudo apt-get install intel-oneapi-ifort
+        sudo apt-get install intel-oneapi-compiler-fortran
         source /opt/intel/oneapi/setvars.sh
         printenv >> $GITHUB_ENV
 


### PR DESCRIPTION
```
rscohn2@rscohn1-MOBL:Debug$ sudo apt-get install intel-oneapi-ifort
[sudo] password for rscohn2:
Reading package lists... Done
Building dependency tree
Reading state information... Done
Note, selecting 'intel-oneapi-compiler-fortran' instead of 'intel-oneapi-ifort'
intel-oneapi-compiler-fortran is already the newest version (2021.1.1-189).
intel-oneapi-compiler-fortran set to manually installed.
0 upgraded, 0 newly installed, 0 to remove and 18 not upgraded.
rscohn2@rscohn1-MOBL:Debug$
```