### PR TITLE
Use distinct file names

### DIFF
--- a/src/tests/bitsets/test_stdlib_bitset_64.f90
+++ b/src/tests/bitsets/test_stdlib_bitset_64.f90
@@ -147,13 +147,13 @@ contains
             'write_bitset'
 
         call set2 % from_string( bitstring_33 )
-        open( newunit=unit, file='test.txt', status='replace', &
+        open( newunit=unit, file='test64_1.txt', status='replace', &
             form='formatted', action='write' )
         call set2 % write_bitset(unit)
         call set1 % write_bitset(unit)
         call set0 % write_bitset(unit)
         close( unit )
-        open( newunit=unit, file='test.txt', status='old', &
+        open( newunit=unit, file='test64_1.txt', status='old', &
             form='formatted', action='read' )
         call set3 % read_bitset(unit)
         call set5 % read_bitset(unit)
@@ -169,13 +169,13 @@ contains
 
         close( unit )
 
-        open( newunit=unit, file='test.txt', status='replace', &
+        open( newunit=unit, file='test64_2.txt', status='replace', &
             form='formatted', action='write' )
         call set2 % write_bitset(unit, advance='no')
         call set1 % write_bitset(unit, advance='no')
         call set0 % write_bitset(unit)
         close( unit )
-        open( newunit=unit, file='test.txt', status='old', &
+        open( newunit=unit, file='test64_2.txt', status='old', &
             form='formatted', action='read' )
         call set3 % read_bitset(unit, advance='no')
         call set4 % read_bitset(unit, advance='no')

--- a/src/tests/bitsets/test_stdlib_bitset_large.f90
+++ b/src/tests/bitsets/test_stdlib_bitset_large.f90
@@ -254,13 +254,13 @@ contains
             'write_bitset'
 
         call set2 % from_string( bitstring_33 )
-        open( newunit=unit, file='test.txt', status='replace', &
+        open( newunit=unit, file='test1.txt', status='replace', &
             form='formatted', action='write' )
         call set2 % write_bitset(unit)
         call set1 % write_bitset(unit)
         call set0 % write_bitset(unit)
         close( unit )
-        open( newunit=unit, file='test.txt', status='old', &
+        open( newunit=unit, file='test1.txt', status='old', &
             form='formatted', action='read' )
         call set3 % read_bitset(unit)
         call set5 % read_bitset(unit)
@@ -276,13 +276,13 @@ contains
         close( unit )
 
         call set12 % from_string( bitstring_33 // bitstring_33 )
-        open( newunit=unit, file='test.txt', status='replace', &
+        open( newunit=unit, file='test2.txt', status='replace', &
             form='formatted', action='write' )
         call set12 % write_bitset(unit)
         call set11 % write_bitset(unit)
         call set10 % write_bitset(unit)
         close( unit )
-        open( newunit=unit, file='test.txt', status='old', &
+        open( newunit=unit, file='test2.txt', status='old', &
             form='formatted', action='read' )
         call set13 % read_bitset(unit)
         call set15 % read_bitset(unit)
@@ -297,13 +297,13 @@ contains
 
         close( unit )
 
-        open( newunit=unit, file='test.txt', status='replace', &
+        open( newunit=unit, file='test3.txt', status='replace', &
             form='formatted', action='write' )
         call set2 % write_bitset(unit, advance='no')
         call set1 % write_bitset(unit, advance='no')
         call set0 % write_bitset(unit)
         close( unit )
-        open( newunit=unit, file='test.txt', status='old', &
+        open( newunit=unit, file='test3.txt', status='old', &
             form='formatted', action='read' )
         call set3 % read_bitset(unit, advance='no')
         call set4 % read_bitset(unit, advance='no')
@@ -319,13 +319,13 @@ contains
 
         close( unit )
 
-        open( newunit=unit, file='test.txt', status='replace', &
+        open( newunit=unit, file='test4.txt', status='replace', &
             form='formatted', action='write' )
         call set12 % write_bitset(unit, advance='no')
         call set11 % write_bitset(unit, advance='no')
         call set10 % write_bitset(unit)
         close( unit )
-        open( newunit=unit, file='test.txt', status='old', &
+        open( newunit=unit, file='test4.txt', status='old', &
             form='formatted', action='read' )
         call set13 % read_bitset(unit, advance='no')
         call set14 % read_bitset(unit, advance='no')


### PR DESCRIPTION
This seems to avoid a filename race conditions on macOS.

Fixes #264.