### PR TITLE
Add gfortran 10 to CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        gcc_v: [7, 8, 9] # Version of GFortran we want to use.
+        gcc_v: [7, 8, 9, 10] # Version of GFortran we want to use.
     env:
       FC: gfortran-${{ matrix.gcc_v }}
       GCC_V: ${{ matrix.gcc_v }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -73,14 +73,14 @@ jobs:
       working-directory: build
 
     - name: Test in-tree builds
-      if: contains( matrix.gcc_v, '9') # Only test one compiler on each platform
+      if: contains( matrix.gcc_v, '10') # Only test one compiler on each platform
       run: |
           cmake -DCMAKE_MAXIMUM_RANK=4 .
           cmake --build .
           cmake --build . --target test
 
     - name: Test manual makefiles
-      if: contains(matrix.os, 'ubuntu') && contains(matrix.gcc_v, '9')
+      if: contains(matrix.os, 'ubuntu') && contains(matrix.gcc_v, '10')
       run: |
         make -f Makefile.manual FYPPFLAGS="-DMAXRANK=4"
         make -f Makefile.manual test

--- a/.github/workflows/doc-deployment.yml
+++ b/.github/workflows/doc-deployment.yml
@@ -20,19 +20,24 @@ env:
 jobs:
   Build-API-Docs:
     runs-on: macos-latest
+    env:
+      GCC_V: 10
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0 # Full history to get tag and commit info
       - name: Install GFortran macOS
-        run: brew install gcc || brew upgrade gcc || true
+        run: |
+          brew install gcc@${GCC_V} || brew upgrade gcc@${GCC_V} || true
+          brew link gcc@${GCC_V}
+          gfortran-${GCC_V} --version
       - name: Install Dependencies
         run: |
           pip3 install --prefer-binary --no-clean --disable-pip-version-check --progress-bar off lxml fypp
           brew install -f --force-bottle --keep-tmp ford
           type -a ford
           ford --version
-          gfortran --version
+          gfortran-${GCC_V} --version
       - name: Skip graph and search unless deploying
         if: github.ref != 'refs/heads/master' && ! startsWith( github.ref, 'refs/tags/' )
         run: |


### PR DESCRIPTION
To solve issues with Github actions (doc deployment) in #261 and #269.
Apparently `gfortran` (version 10) was renamed `gfortran-10` in MacOS. Therefore, I modified the different scripts to consider it correctly.
I also added `gfortran-10` to the current evaluated versions (7, 8, and 9).