### PR TITLE
Add all three MSYS2 systems to Windows CI

### DIFF
--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -41,3 +41,82 @@ jobs:
       with:
         name: WindowsCMakeTestlog
         path: build/Testing/Temporary/LastTest.log
+
+  msys2-build:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include: [
+          { msystem: MSYS,    arch: x86_64 },
+          { msystem: MINGW64, arch: x86_64 },
+          { msystem: MINGW32, arch: i686   }
+        ]
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup MinGW native environment
+      uses: msys2/setup-msys2@v2
+      if: contains(matrix.msystem, 'MINGW')
+      with:
+        msystem: ${{ matrix.msystem }}
+        update: false
+        install: >-
+          git
+          mingw-w64-${{ matrix.arch }}-gcc
+          mingw-w64-${{ matrix.arch }}-gcc-fortran
+          mingw-w64-${{ matrix.arch }}-python
+          mingw-w64-${{ matrix.arch }}-python-pip
+          mingw-w64-${{ matrix.arch }}-cmake
+          mingw-w64-${{ matrix.arch }}-ninja
+
+    - name: Setup msys POSIX environment
+      uses: msys2/setup-msys2@v2
+      if: contains(matrix.msystem, 'MSYS')
+      with:
+        msystem: MSYS
+        update: false
+        install: >-
+          git
+          gcc
+          gcc-fortran
+          python
+          python-pip
+          cmake
+          ninja
+
+    - name: Install fypp
+      run: pip install fypp
+
+    - run: >-
+        cmake -G Ninja
+        -DCMAKE_SH="CMAKE_SH-NOTFOUND"
+        -Wdev
+        -B build
+        -DCMAKE_BUILD_TYPE=Debug
+        -DCMAKE_Fortran_FLAGS_DEBUG="-Wall -Wextra -Wimplicit-interface -fPIC -g -fcheck=all -fbacktrace"
+        -DCMAKE_MAXIMUM_RANK=4
+      env:
+        FC: gfortran
+        CC: gcc
+        CXX: g++
+
+    - name: CMake build
+      run: cmake --build build --parallel
+
+    - name: catch build fail
+      run: cmake --build build --verbose --parallel 1
+      if: failure()
+
+    - name: CTest
+      run: ctest --output-on-failure --parallel -V -LE quadruple_precision
+      working-directory: build
+
+    - uses: actions/upload-artifact@v1
+      if: failure()
+      with:
+        name: WindowsCMakeTestlog
+        path: build/Testing/Temporary/LastTest.log

--- a/src/tests/stats/test_mean.f90
+++ b/src/tests/stats/test_mean.f90
@@ -7,7 +7,7 @@ use,intrinsic :: ieee_arithmetic, only : ieee_is_nan
 implicit none
 
 real(sp), parameter :: sptol = 1000 * epsilon(1._sp)
-real(dp), parameter :: dptol = 1000 * epsilon(1._dp)
+real(dp), parameter :: dptol = 2000 * epsilon(1._dp)
 
 real(sp) :: s1(3) = [1.0_sp, 2.0_sp, 3.0_sp]
 


### PR DESCRIPTION
Windows testing is currently limited to the MinGW version preinstalled by choco (GCC 8.1). This PR uses the MSYS2 toolchains to test for the latest GCC/MinGW versions as well.

In total three new CI tests are added:
1. GCC in MSYS POSIX environment
2. native MinGW64 compiler
3. native MinGW32 compiler (see #274 regarding test failure)

With the adjustment of the thresholds in test_mean, this PR also fixes #274 