### PR TITLE
Improve compilation load by splitting stdlib_stats_moment submodule

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,8 @@ set(fppFiles
     stdlib_stats_cov.fypp
     stdlib_stats_mean.fypp
     stdlib_stats_moment.fypp
+    stdlib_stats_moment_all.fypp
+    stdlib_stats_moment_scalar.fypp
     stdlib_stats_var.fypp
     stdlib_quadrature.fypp
     stdlib_quadrature_trapz.fypp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,7 @@ set(fppFiles
     stdlib_stats_mean.fypp
     stdlib_stats_moment.fypp
     stdlib_stats_moment_all.fypp
+    stdlib_stats_moment_mask.fypp
     stdlib_stats_moment_scalar.fypp
     stdlib_stats_var.fypp
     stdlib_quadrature.fypp

--- a/src/Makefile.manual
+++ b/src/Makefile.manual
@@ -15,6 +15,8 @@ SRC = f18estop.f90 \
       stdlib_stats.f90 \
       stdlib_stats_mean.f90 \
       stdlib_stats_moment.f90 \
+      stdlib_stats_moment_all.f90 \
+      stdlib_stats_moment_scalar.f90 \
       stdlib_stats_var.f90
 
 LIB = libstdlib.a
@@ -79,4 +81,6 @@ stdlib_quadrature.f90: stdlib_quadrature.fypp
 stdlib_stats.f90: stdlib_stats.fypp
 stdlib_stats_mean.f90: stdlib_stats_mean.fypp
 stdlib_stats_moment.f90: stdlib_stats_moment.fypp
+stdlib_stats_moment_all.f90: stdlib_stats_moment_all.fypp
+stdlib_stats_moment_scalar.f90: stdlib_stats_moment_scalar.fypp
 stdlib_stats_var.f90: stdlib_stats_var.fypp

--- a/src/Makefile.manual
+++ b/src/Makefile.manual
@@ -16,6 +16,7 @@ SRC = f18estop.f90 \
       stdlib_stats_mean.f90 \
       stdlib_stats_moment.f90 \
       stdlib_stats_moment_all.f90 \
+      stdlib_stats_moment_mask.f90 \
       stdlib_stats_moment_scalar.f90 \
       stdlib_stats_var.f90
 
@@ -82,5 +83,6 @@ stdlib_stats.f90: stdlib_stats.fypp
 stdlib_stats_mean.f90: stdlib_stats_mean.fypp
 stdlib_stats_moment.f90: stdlib_stats_moment.fypp
 stdlib_stats_moment_all.f90: stdlib_stats_moment_all.fypp
+stdlib_stats_moment_mask.f90: stdlib_stats_moment_mask.fypp
 stdlib_stats_moment_scalar.f90: stdlib_stats_moment_scalar.fypp
 stdlib_stats_var.f90: stdlib_stats_var.fypp

--- a/src/stdlib_stats_moment.fypp
+++ b/src/stdlib_stats_moment.fypp
@@ -13,93 +13,6 @@ contains
 
   #:for k1, t1 in RC_KINDS_TYPES
     #:for rank in RANKS
-      #:set RName = rname("moment_all",rank, t1, k1)
-      module function ${RName}$(x, order, center, mask) result(res)
-        ${t1}$, intent(in) :: x${ranksuffix(rank)}$
-        integer, intent(in) :: order
-        ${t1}$, intent(in), optional :: center
-        logical, intent(in), optional :: mask
-        ${t1}$ :: res
-
-        real(${k1}$) :: n
-
-        if (.not.optval(mask, .true.)) then
-          res = ieee_value(1._${k1}$, ieee_quiet_nan)
-          return
-        end if
-
-        n = real(size(x, kind = int64), ${k1}$)
-
-        if (present(center)) then
-         res = sum((x - center)**order) / n
-        else
-         res = sum((x - mean(x))**order) / n
-        end if
-
-      end function ${RName}$
-    #:endfor
-  #:endfor
-
-
-  #:for k1, t1 in INT_KINDS_TYPES
-    #:for rank in RANKS
-      #:set RName = rname("moment_all",rank, t1, k1, 'dp')
-      module function ${RName}$(x, order, center, mask) result(res)
-        ${t1}$, intent(in) :: x${ranksuffix(rank)}$
-        integer, intent(in) :: order
-        real(dp), intent(in), optional :: center
-        logical, intent(in), optional :: mask
-        real(dp) :: res
-
-        real(dp) :: n
-
-        if (.not.optval(mask, .true.)) then
-          res = ieee_value(1._dp, ieee_quiet_nan)
-          return
-        end if
-
-        n = real(size(x, kind = int64), dp)
-
-        if (present(center)) then
-         res = sum((real(x, dp) - center)**order) / n
-        else
-         res = sum((real(x, dp) - mean(x))**order) / n
-        end if
-
-      end function ${RName}$
-    #:endfor
-  #:endfor
-
-
-  #:for k1, t1 in RC_KINDS_TYPES
-    #:for rank in REDRANKS
-      #:set RName = rname("moment_scalar",rank, t1, k1)
-      module function ${RName}$(x, order, dim, center, mask) result(res)
-        ${t1}$, intent(in) :: x${ranksuffix(rank)}$
-        integer, intent(in) :: order
-        integer, intent(in) :: dim
-        ${t1}$, intent(in) :: center
-        logical, intent(in), optional :: mask
-        ${t1}$ :: res${reduced_shape('x', rank, 'dim')}$
-
-        if (.not.optval(mask, .true.)) then
-          res = ieee_value(1._${k1}$, ieee_quiet_nan)
-          return
-        end if
-
-        if (dim >= 1 .and. dim <= ${rank}$) then
-          res = sum((x - center)**order, dim) / size(x, dim)
-        else
-          call error_stop("ERROR (moment): wrong dimension")
-        end if
-
-      end function ${RName}$
-    #:endfor
-  #:endfor
-
-
-  #:for k1, t1 in RC_KINDS_TYPES
-    #:for rank in RANKS
       #:set RName = rname("moment",rank, t1, k1)
       module function ${RName}$(x, order, dim, center, mask) result(res)
         ${t1}$, intent(in) :: x${ranksuffix(rank)}$
@@ -140,33 +53,6 @@ contains
             call error_stop("ERROR (moment): wrong dimension")
         end select
         res = res / n
-
-      end function ${RName}$
-    #:endfor
-  #:endfor
-
-
-  #:for k1, t1 in INT_KINDS_TYPES
-    #:for rank in REDRANKS
-      #:set RName = rname("moment_scalar",rank, t1, k1, 'dp')
-      module function ${RName}$(x, order, dim, center, mask) result(res)
-        ${t1}$, intent(in) :: x${ranksuffix(rank)}$
-        integer, intent(in) :: order
-        integer, intent(in) :: dim
-        real(dp),intent(in) :: center
-        logical, intent(in), optional :: mask
-        real(dp) :: res${reduced_shape('x', rank, 'dim')}$
-
-        if (.not.optval(mask, .true.)) then
-          res = ieee_value(1._dp, ieee_quiet_nan)
-          return
-        end if
-
-        if (dim >= 1 .and. dim <= ${rank}$) then
-          res = sum( (real(x, dp) - center)**order, dim) / size(x, dim)
-        else
-          call error_stop("ERROR (moment): wrong dimension")
-        end if
 
       end function ${RName}$
     #:endfor
@@ -224,78 +110,6 @@ contains
 
   #:for k1, t1 in RC_KINDS_TYPES
     #:for rank in RANKS
-      #:set RName = rname("moment_mask_all",rank, t1, k1)
-      module function ${RName}$(x, order, center, mask) result(res)
-        ${t1}$, intent(in) :: x${ranksuffix(rank)}$
-        integer, intent(in) :: order
-        ${t1}$, intent(in), optional :: center
-        logical, intent(in) :: mask${ranksuffix(rank)}$
-        ${t1}$ :: res
-
-        real(${k1}$) :: n
-
-        n = real(count(mask, kind = int64), ${k1}$)
-
-        if (present(center)) then
-         res = sum((x - center)**order, mask) / n
-        else
-         res = sum((x - mean(x, mask))**order, mask) / n
-        end if
-
-      end function ${RName}$
-    #:endfor
-  #:endfor
-
-
-  #:for k1, t1 in INT_KINDS_TYPES
-    #:for rank in RANKS
-      #:set RName = rname("moment_mask_all",rank, t1, k1, 'dp')
-      module function ${RName}$(x, order, center, mask) result(res)
-        ${t1}$, intent(in) :: x${ranksuffix(rank)}$
-        integer, intent(in) :: order
-        real(dp),intent(in), optional :: center
-        logical, intent(in) :: mask${ranksuffix(rank)}$
-        real(dp) :: res
-
-        real(dp) :: n
-
-        n = real(count(mask, kind = int64), dp)
-
-        if (present(center)) then
-         res = sum((real(x, dp) - center)**order, mask) / n
-        else
-         res = sum((real(x, dp) - mean(x,mask))**order, mask) / n
-        end if
-
-      end function ${RName}$
-    #:endfor
-  #:endfor
-
-
-  #:for k1, t1 in RC_KINDS_TYPES
-    #:for rank in REDRANKS
-      #:set RName = rname("moment_mask_scalar",rank, t1, k1)
-      module function ${RName}$(x, order, dim, center, mask) result(res)
-        ${t1}$, intent(in) :: x${ranksuffix(rank)}$
-        integer, intent(in) :: order
-        integer, intent(in) :: dim
-        ${t1}$, intent(in) :: center
-        logical, intent(in) :: mask${ranksuffix(rank)}$
-        ${t1}$ :: res${reduced_shape('x', rank, 'dim')}$
-
-        if (dim >= 1 .and. dim <= ${rank}$) then
-          res = sum((x - center)**order, dim, mask) / count(mask, dim)
-        else
-          call error_stop("ERROR (moment): wrong dimension")
-        end if
-
-      end function ${RName}$
-    #:endfor
-  #:endfor
-
-
-  #:for k1, t1 in RC_KINDS_TYPES
-    #:for rank in RANKS
       #:set RName = rname("moment_mask",rank, t1, k1)
       module function ${RName}$(x, order, dim, center, mask) result(res)
         ${t1}$, intent(in) :: x${ranksuffix(rank)}$
@@ -344,28 +158,6 @@ contains
             call error_stop("ERROR (moment): wrong dimension")
         end select
         res = res / n
-
-      end function ${RName}$
-    #:endfor
-  #:endfor
-
-
-  #:for k1, t1 in INT_KINDS_TYPES
-    #:for rank in REDRANKS
-      #:set RName = rname("moment_mask_scalar",rank, t1, k1, 'dp')
-      module function ${RName}$(x, order, dim, center, mask) result(res)
-        ${t1}$, intent(in) :: x${ranksuffix(rank)}$
-        integer, intent(in) :: order
-        integer, intent(in) :: dim
-        real(dp), intent(in) :: center
-        logical, intent(in) :: mask${ranksuffix(rank)}$
-        real(dp) :: res${reduced_shape('x', rank, 'dim')}$
-
-        if (dim >= 1 .and. dim <= ${rank}$) then
-          res = sum(( real(x, dp) - center)**order, dim, mask) / count(mask, dim)
-        else
-          call error_stop("ERROR (moment): wrong dimension")
-        end if
 
       end function ${RName}$
     #:endfor

--- a/src/stdlib_stats_moment_all.fypp
+++ b/src/stdlib_stats_moment_all.fypp
@@ -1,0 +1,123 @@
+#:include "common.fypp"
+#:set RANKS = range(1, MAXRANK + 1)
+#:set REDRANKS = range(2, MAXRANK + 1)
+#:set RC_KINDS_TYPES = REAL_KINDS_TYPES + CMPLX_KINDS_TYPES
+submodule (stdlib_stats) stdlib_stats_moment_all
+
+  use, intrinsic:: ieee_arithmetic, only: ieee_value, ieee_quiet_nan
+  use stdlib_error, only: error_stop
+  use stdlib_optval, only: optval
+  implicit none
+
+contains
+
+  #:for k1, t1 in RC_KINDS_TYPES
+    #:for rank in RANKS
+      #:set RName = rname("moment_all",rank, t1, k1)
+      module function ${RName}$(x, order, center, mask) result(res)
+        ${t1}$, intent(in) :: x${ranksuffix(rank)}$
+        integer, intent(in) :: order
+        ${t1}$, intent(in), optional :: center
+        logical, intent(in), optional :: mask
+        ${t1}$ :: res
+
+        real(${k1}$) :: n
+
+        if (.not.optval(mask, .true.)) then
+          res = ieee_value(1._${k1}$, ieee_quiet_nan)
+          return
+        end if
+
+        n = real(size(x, kind = int64), ${k1}$)
+
+        if (present(center)) then
+         res = sum((x - center)**order) / n
+        else
+         res = sum((x - mean(x))**order) / n
+        end if
+
+      end function ${RName}$
+    #:endfor
+  #:endfor
+
+
+  #:for k1, t1 in INT_KINDS_TYPES
+    #:for rank in RANKS
+      #:set RName = rname("moment_all",rank, t1, k1, 'dp')
+      module function ${RName}$(x, order, center, mask) result(res)
+        ${t1}$, intent(in) :: x${ranksuffix(rank)}$
+        integer, intent(in) :: order
+        real(dp), intent(in), optional :: center
+        logical, intent(in), optional :: mask
+        real(dp) :: res
+
+        real(dp) :: n
+
+        if (.not.optval(mask, .true.)) then
+          res = ieee_value(1._dp, ieee_quiet_nan)
+          return
+        end if
+
+        n = real(size(x, kind = int64), dp)
+
+        if (present(center)) then
+         res = sum((real(x, dp) - center)**order) / n
+        else
+         res = sum((real(x, dp) - mean(x))**order) / n
+        end if
+
+      end function ${RName}$
+    #:endfor
+  #:endfor
+
+
+  #:for k1, t1 in RC_KINDS_TYPES
+    #:for rank in RANKS
+      #:set RName = rname("moment_mask_all",rank, t1, k1)
+      module function ${RName}$(x, order, center, mask) result(res)
+        ${t1}$, intent(in) :: x${ranksuffix(rank)}$
+        integer, intent(in) :: order
+        ${t1}$, intent(in), optional :: center
+        logical, intent(in) :: mask${ranksuffix(rank)}$
+        ${t1}$ :: res
+
+        real(${k1}$) :: n
+
+        n = real(count(mask, kind = int64), ${k1}$)
+
+        if (present(center)) then
+         res = sum((x - center)**order, mask) / n
+        else
+         res = sum((x - mean(x, mask))**order, mask) / n
+        end if
+
+      end function ${RName}$
+    #:endfor
+  #:endfor
+
+
+  #:for k1, t1 in INT_KINDS_TYPES
+    #:for rank in RANKS
+      #:set RName = rname("moment_mask_all",rank, t1, k1, 'dp')
+      module function ${RName}$(x, order, center, mask) result(res)
+        ${t1}$, intent(in) :: x${ranksuffix(rank)}$
+        integer, intent(in) :: order
+        real(dp),intent(in), optional :: center
+        logical, intent(in) :: mask${ranksuffix(rank)}$
+        real(dp) :: res
+
+        real(dp) :: n
+
+        n = real(count(mask, kind = int64), dp)
+
+        if (present(center)) then
+         res = sum((real(x, dp) - center)**order, mask) / n
+        else
+         res = sum((real(x, dp) - mean(x,mask))**order, mask) / n
+        end if
+
+      end function ${RName}$
+    #:endfor
+  #:endfor
+
+end submodule

--- a/src/stdlib_stats_moment_mask.fypp
+++ b/src/stdlib_stats_moment_mask.fypp
@@ -2,7 +2,7 @@
 #:set RANKS = range(1, MAXRANK + 1)
 #:set REDRANKS = range(2, MAXRANK + 1)
 #:set RC_KINDS_TYPES = REAL_KINDS_TYPES + CMPLX_KINDS_TYPES
-submodule (stdlib_stats) stdlib_stats_moment
+submodule (stdlib_stats) stdlib_stats_moment_mask
 
   use, intrinsic:: ieee_arithmetic, only: ieee_value, ieee_quiet_nan
   use stdlib_error, only: error_stop
@@ -13,25 +13,20 @@ contains
 
   #:for k1, t1 in RC_KINDS_TYPES
     #:for rank in RANKS
-      #:set RName = rname("moment",rank, t1, k1)
+      #:set RName = rname("moment_mask",rank, t1, k1)
       module function ${RName}$(x, order, dim, center, mask) result(res)
         ${t1}$, intent(in) :: x${ranksuffix(rank)}$
         integer, intent(in) :: order
         integer, intent(in) :: dim
         ${t1}$, intent(in), optional :: center${reduced_shape('x', rank, 'dim')}$
-        logical, intent(in), optional :: mask
+        logical, intent(in) :: mask${ranksuffix(rank)}$
         ${t1}$ :: res${reduced_shape('x', rank, 'dim')}$
 
         integer :: i
-        real(${k1}$) :: n
+        real(${k1}$) :: n${reduced_shape('x', rank, 'dim')}$
         ${t1}$, allocatable :: mean_${ranksuffix(rank-1)}$
 
-        if (.not.optval(mask, .true.)) then
-          res = ieee_value(1._${k1}$, ieee_quiet_nan)
-          return
-        end if
-
-        n = real(size(x, dim), ${k1}$)
+        n = real(count(mask, dim), ${k1}$)
 
         res = 0
         select case(dim)
@@ -39,12 +34,25 @@ contains
           case(${fi}$)
             if (present(center)) then
               do i = 1, size(x, ${fi}$)
-                res = res + (x${select_subarray(rank, [(fi, 'i')])}$ - center)**order
+                res = res + merge( (x${select_subarray(rank, [(fi, 'i')])}$ -&
+                  center)**order,&
+                  #:if t1[0] == 'r'
+                    0._${k1}$,&
+                  #:else
+                    cmplx(0,0,kind=${k1}$),&
+                  #:endif
+                    mask${select_subarray(rank, [(fi, 'i')])}$)
               end do
             else
-              allocate(mean_, source = mean(x, ${fi}$))
+              allocate(mean_, source = mean(x, ${fi}$, mask))
               do i = 1, size(x, ${fi}$)
-                res = res + (x${select_subarray(rank, [(fi, 'i')])}$ - mean_)**order
+                res = res + merge( (x${select_subarray(rank, [(fi, 'i')])}$ - mean_)**order,&
+                  #:if t1[0] == 'r'
+                    0._${k1}$,&
+                  #:else
+                    cmplx(0,0,kind=${k1}$),&
+                  #:endif
+                    mask${select_subarray(rank, [(fi, 'i')])}$)
               end do
               deallocate(mean_)
             end if
@@ -61,25 +69,20 @@ contains
 
   #:for k1, t1 in INT_KINDS_TYPES
     #:for rank in RANKS
-      #:set RName = rname("moment",rank, t1, k1, 'dp')
+      #:set RName = rname("moment_mask",rank, t1, k1, 'dp')
       module function ${RName}$(x, order, dim, center, mask) result(res)
         ${t1}$, intent(in) :: x${ranksuffix(rank)}$
         integer, intent(in) :: order
         integer, intent(in) :: dim
-        real(dp),intent(in), optional :: center${reduced_shape('x', rank, 'dim')}$
-        logical, intent(in), optional :: mask
+        real(dp), intent(in), optional :: center${reduced_shape('x', rank, 'dim')}$
+        logical, intent(in) :: mask${ranksuffix(rank)}$
         real(dp) :: res${reduced_shape('x', rank, 'dim')}$
 
         integer :: i
-        real(dp) :: n
+        real(dp) :: n${reduced_shape('x', rank, 'dim')}$
         real(dp), allocatable :: mean_${ranksuffix(rank-1)}$
 
-        if (.not.optval(mask, .true.)) then
-          res = ieee_value(1._dp, ieee_quiet_nan)
-          return
-        end if
-
-        n = real(size(x, dim), dp)
+        n = real(count(mask, dim), dp)
 
         res = 0
         select case(dim)
@@ -87,13 +90,16 @@ contains
           case(${fi}$)
             if (present(center)) then
               do i = 1, size(x, ${fi}$)
-                res = res + (real(x${select_subarray(rank, [(fi, 'i')])}$, dp) -&
-                  center)**order
+                res = res + merge((real(x${select_subarray(rank, [(fi, 'i')])}$, dp) -&
+                                    center)**order,&
+                                    0._dp, mask${select_subarray(rank, [(fi, 'i')])}$)
               end do
             else
-              allocate(mean_, source = mean(x, ${fi}$))
+              allocate(mean_, source = mean(x, ${fi}$, mask))
               do i = 1, size(x, ${fi}$)
-                res = res + (real(x${select_subarray(rank, [(fi, 'i')])}$, dp) - mean_)**order
+                res = res + merge((real(x${select_subarray(rank, [(fi, 'i')])}$, dp) - mean_)&
+                                    **order,&
+                                    0._dp, mask${select_subarray(rank, [(fi, 'i')])}$)
               end do
               deallocate(mean_)
             end if

--- a/src/stdlib_stats_moment_scalar.fypp
+++ b/src/stdlib_stats_moment_scalar.fypp
@@ -1,0 +1,110 @@
+#:include "common.fypp"
+#:set RANKS = range(1, MAXRANK + 1)
+#:set REDRANKS = range(2, MAXRANK + 1)
+#:set RC_KINDS_TYPES = REAL_KINDS_TYPES + CMPLX_KINDS_TYPES
+submodule (stdlib_stats) stdlib_stats_moment_scalar
+
+  use, intrinsic:: ieee_arithmetic, only: ieee_value, ieee_quiet_nan
+  use stdlib_error, only: error_stop
+  use stdlib_optval, only: optval
+  implicit none
+
+contains
+
+  #:for k1, t1 in RC_KINDS_TYPES
+    #:for rank in REDRANKS
+      #:set RName = rname("moment_scalar",rank, t1, k1)
+      module function ${RName}$(x, order, dim, center, mask) result(res)
+        ${t1}$, intent(in) :: x${ranksuffix(rank)}$
+        integer, intent(in) :: order
+        integer, intent(in) :: dim
+        ${t1}$, intent(in) :: center
+        logical, intent(in), optional :: mask
+        ${t1}$ :: res${reduced_shape('x', rank, 'dim')}$
+
+        if (.not.optval(mask, .true.)) then
+          res = ieee_value(1._${k1}$, ieee_quiet_nan)
+          return
+        end if
+
+        if (dim >= 1 .and. dim <= ${rank}$) then
+          res = sum((x - center)**order, dim) / size(x, dim)
+        else
+          call error_stop("ERROR (moment): wrong dimension")
+        end if
+
+      end function ${RName}$
+    #:endfor
+  #:endfor
+
+  #:for k1, t1 in INT_KINDS_TYPES
+    #:for rank in REDRANKS
+      #:set RName = rname("moment_scalar",rank, t1, k1, 'dp')
+      module function ${RName}$(x, order, dim, center, mask) result(res)
+        ${t1}$, intent(in) :: x${ranksuffix(rank)}$
+        integer, intent(in) :: order
+        integer, intent(in) :: dim
+        real(dp),intent(in) :: center
+        logical, intent(in), optional :: mask
+        real(dp) :: res${reduced_shape('x', rank, 'dim')}$
+
+        if (.not.optval(mask, .true.)) then
+          res = ieee_value(1._dp, ieee_quiet_nan)
+          return
+        end if
+
+        if (dim >= 1 .and. dim <= ${rank}$) then
+          res = sum( (real(x, dp) - center)**order, dim) / size(x, dim)
+        else
+          call error_stop("ERROR (moment): wrong dimension")
+        end if
+
+      end function ${RName}$
+    #:endfor
+  #:endfor
+
+
+  #:for k1, t1 in RC_KINDS_TYPES
+    #:for rank in REDRANKS
+      #:set RName = rname("moment_mask_scalar",rank, t1, k1)
+      module function ${RName}$(x, order, dim, center, mask) result(res)
+        ${t1}$, intent(in) :: x${ranksuffix(rank)}$
+        integer, intent(in) :: order
+        integer, intent(in) :: dim
+        ${t1}$, intent(in) :: center
+        logical, intent(in) :: mask${ranksuffix(rank)}$
+        ${t1}$ :: res${reduced_shape('x', rank, 'dim')}$
+
+        if (dim >= 1 .and. dim <= ${rank}$) then
+          res = sum((x - center)**order, dim, mask) / count(mask, dim)
+        else
+          call error_stop("ERROR (moment): wrong dimension")
+        end if
+
+      end function ${RName}$
+    #:endfor
+  #:endfor
+
+
+  #:for k1, t1 in INT_KINDS_TYPES
+    #:for rank in REDRANKS
+      #:set RName = rname("moment_mask_scalar",rank, t1, k1, 'dp')
+      module function ${RName}$(x, order, dim, center, mask) result(res)
+        ${t1}$, intent(in) :: x${ranksuffix(rank)}$
+        integer, intent(in) :: order
+        integer, intent(in) :: dim
+        real(dp), intent(in) :: center
+        logical, intent(in) :: mask${ranksuffix(rank)}$
+        real(dp) :: res${reduced_shape('x', rank, 'dim')}$
+
+        if (dim >= 1 .and. dim <= ${rank}$) then
+          res = sum(( real(x, dp) - center)**order, dim, mask) / count(mask, dim)
+        else
+          call error_stop("ERROR (moment): wrong dimension")
+        end if
+
+      end function ${RName}$
+    #:endfor
+  #:endfor
+
+end submodule


### PR DESCRIPTION
This is an attempt to reduce the memory usage when compiling stdlib with default max rank of 15. Tested with ninja generator (`-G Ninja`) and GCC 10.2 on a laptop with two physical cores and 8GB RAM.

The first commit on this branch allows compilation with *one* ninja job and peak memory usage of ~7GB. The second commit on this branch allows compilation with *two* ninja jobs and peak memory usage of ~7GB.