### PR TITLE
Rename CMake project from stdlib to fortran_stdlib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14.0)
-project(stdlib Fortran)
+project(fortran_stdlib Fortran)
 enable_testing()
 
 # Follow GNU conventions for installation directories
@@ -56,7 +56,7 @@ endif()
 
 add_subdirectory(src)
 
-install(EXPORT fortran_stdlib-targets
-        NAMESPACE fortran_stdlib::
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/fortran_stdlib"
+install(EXPORT ${PROJECT_NAME}-targets
+        NAMESPACE ${PROJECT_NAME}::
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,26 +44,26 @@ set(SRC
     ${outFiles}
 )
 
-add_library(fortran_stdlib ${SRC})
+add_library(${PROJECT_NAME} ${SRC})
 
 set(LIB_MOD_DIR ${CMAKE_CURRENT_BINARY_DIR}/mod_files/)
-set_target_properties(fortran_stdlib PROPERTIES
+set_target_properties(${PROJECT_NAME} PROPERTIES
     Fortran_MODULE_DIRECTORY ${LIB_MOD_DIR})
-target_include_directories(fortran_stdlib PUBLIC
+target_include_directories(${PROJECT_NAME} PUBLIC
     $<BUILD_INTERFACE:${LIB_MOD_DIR}>
     $<INSTALL_INTERFACE:include>
 )
 
 if(f18errorstop)
-  target_sources(fortran_stdlib PRIVATE f18estop.f90)
+  target_sources(${PROJECT_NAME} PRIVATE f18estop.f90)
 else()
-  target_sources(fortran_stdlib PRIVATE f08estop.f90)
+  target_sources(${PROJECT_NAME} PRIVATE f08estop.f90)
 endif()
 
 add_subdirectory(tests)
 
-install(TARGETS fortran_stdlib
-        EXPORT fortran_stdlib-targets
+install(TARGETS ${PROJECT_NAME}
+        EXPORT ${PROJECT_NAME}-targets
         RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
         ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
         LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 macro(ADDTEST name)
     add_executable(test_${name} test_${name}.f90)
-    target_link_libraries(test_${name} fortran_stdlib)
+    target_link_libraries(test_${name} ${PROJECT_NAME})
     add_test(NAME ${name}
              COMMAND $<TARGET_FILE:test_${name}> ${CMAKE_CURRENT_BINARY_DIR}
              WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/tests/system/CMakeLists.txt
+++ b/src/tests/system/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(test_sleep test_sleep.f90)
-target_link_libraries(test_sleep fortran_stdlib)
+target_link_libraries(test_sleep ${PROJECT_NAME})
 
 add_test(NAME Sleep COMMAND $<TARGET_FILE:test_sleep> 350)
 set_tests_properties(Sleep PROPERTIES TIMEOUT 1)


### PR DESCRIPTION
Part 2/3 for #287, status: *optional*. If you do not like this approach we can do #287 without it.

*Changes:*

- rename CMake project from `stdlib` to `fortran_stdlib`
- reuse the `PROJECT_NAME` CMake variable instead of using `fortran_stdlib` directly

*Reasoning:*

- exported CMake targets usually match the project name (`fortran_stdlib` seems less likely to clash with something compared to `stdlib`)
- allows to easily use `PROJECT_NAME` to write reusable/transferable CMake code for different projects (interesting for fpm generated CMake files as well)
- `PROJECT_NAME` is accessible in `configure_file` and can be used to create more general template files