### PR TITLE
Export package files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,18 @@
 cmake_minimum_required(VERSION 3.14.0)
-project(fortran_stdlib Fortran)
+project(fortran_stdlib
+        LANGUAGES Fortran
+        VERSION 0
+        DESCRIPTION "Community driven and agreed upon de facto standard library for Fortran"
+)
 enable_testing()
 
 # Follow GNU conventions for installation directories
 include(GNUInstallDirs)
 
 include(${PROJECT_SOURCE_DIR}/cmake/stdlib.cmake)
+
+# --- CMake specific configuration and package data export
+add_subdirectory(config)
 
 # --- compiler options
 if(CMAKE_Fortran_COMPILER_ID STREQUAL GNU)

--- a/README.md
+++ b/README.md
@@ -158,6 +158,36 @@ make -f Makefile.manual FYPPFLAGS=-DMAXRANK=4
 ```
 
 
+
+## Using stdlib in your project
+
+The stdlib projects exports CMake package files and pkg-config files to make stdlib usable for other projects.
+The package files are located in the library directory in the installation prefix.
+
+For CMake builds of stdlib you can find a local installation with
+
+```cmake
+find_package(fortran_stdlib REQUIRED)
+...
+target_link_libraries(
+  ${PROJECT_NAME}
+  PRIVATE
+  fortran_stdlib::fortran_stdlib
+)
+```
+
+to make the installed stdlib project discoverable add the stdlib directory to the ``CMAKE_PREFIX_PATH``.
+The usual install localtion of the package files is ``$PREFIX/lib/cmake/fortran_stdlib``.
+
+For non-CMake build systems (like make) you can use the exported pkg-config file by setting ``PKG_CONFIG_PATH`` to include the directory containing the exported pc-file.
+The usual install location of the pc-file is ``$PREFIX/lib/pkgconfig``.
+In make you can obtain the required compile and link arguments with
+
+```make
+STDLIB_CFLAGS := $(shell pkg-config --cflags fortran_stdlib)
+STDLIB_LIBS := $(shell pkg-config --libs fortran_stdlib)
+```
+
 ## Documentation
 
 Documentation is a work in progress (see issue [#4](https://github.com/fortran-lang/stdlib/issues/4)) but already available at [stdlib.fortran-lang.org](https://stdlib.fortran-lang.org).

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ make -f Makefile.manual FYPPFLAGS=-DMAXRANK=4
 
 ## Using stdlib in your project
 
-The stdlib projects exports CMake package files and pkg-config files to make stdlib usable for other projects.
+The stdlib project exports CMake package files and pkg-config files to make stdlib usable for other projects.
 The package files are located in the library directory in the installation prefix.
 
 For CMake builds of stdlib you can find a local installation with
@@ -176,7 +176,7 @@ target_link_libraries(
 )
 ```
 
-to make the installed stdlib project discoverable add the stdlib directory to the ``CMAKE_PREFIX_PATH``.
+To make the installed stdlib project discoverable add the stdlib directory to the ``CMAKE_PREFIX_PATH``.
 The usual install localtion of the package files is ``$PREFIX/lib/cmake/fortran_stdlib``.
 
 For non-CMake build systems (like make) you can use the exported pkg-config file by setting ``PKG_CONFIG_PATH`` to include the directory containing the exported pc-file.

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -19,12 +19,12 @@ configure_package_config_file(
   "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
   INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
 )
-if(BUILD_SHARED_LIBS)
+if(BUILD_SHARED_LIBS OR PROJECT_VERSION_MAJOR EQUAL 0)
   # Due to the uncertain ABI compatibility of Fortran shared libraries
   # limit compatibility for dynamic linking to same minor version.
   set(COMPATIBILITY SameMinorVersion)
 else()
-  # Require API compatibility via semantic versioning for static linking,
+  # Require API compatibility via semantic versioning for static linking.
   set(COMPATIBILITY SameMajorVersion)
 endif()
 write_basic_package_version_file(

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -1,0 +1,40 @@
+# SPDX-Identifier: MIT
+
+# Export a pkg-config file
+configure_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/template.pc"
+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
+  @ONLY
+)
+install(
+  FILES
+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+)
+
+# Export CMake package file
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/template.cmake"
+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+  INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+)
+if(BUILD_SHARED_LIBS)
+  # Due to the uncertain ABI compatibility of Fortran shared libraries
+  # limit compatibility for dynamic linking to same minor version.
+  set(COMPATIBILITY SameMinorVersion)
+else()
+  # Require API compatibility via semantic versioning for static linking,
+  set(COMPATIBILITY SameMajorVersion)
+endif()
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake"
+  VERSION "${PROJECT_VERSION}"
+  COMPATIBILITY ${COMPATIBILITY}
+)
+install(
+  FILES
+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+)

--- a/config/template.cmake
+++ b/config/template.cmake
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+if(NOT TARGET "@PROJECT_NAME@::@PROJECT_NAME@")
+  include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
+endif()

--- a/config/template.pc
+++ b/config/template.pc
@@ -1,0 +1,9 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: @PROJECT_NAME@
+Description: @PROJECT_DESCRIPTION@
+Version: @PROJECT_VERSION@
+Libs: -L${libdir} -l@PROJECT_NAME@
+Cflags: -I${includedir}


### PR DESCRIPTION
Part 3/3 for #287, status: *required*.

*Changes:*

- set project version (just 0 as dummy) and project description in CMake (required to generate a valid pc-file)
- export CMake package fortran_lang-config.cmake for CMake projects
- export pkg-config file fortran_lang.pc for non-CMake projects

**Important:** *This PR defines a version number for stdlib. This should be considered carefully (see #292).*