### PR TITLE
Fix dependencies in manual Makefile

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -82,7 +82,7 @@ jobs:
     - name: Test manual makefiles
       if: contains(matrix.os, 'ubuntu') && contains(matrix.gcc_v, '10')
       run: |
-        make -f Makefile.manual FYPPFLAGS="-DMAXRANK=4"
+        make -f Makefile.manual FYPPFLAGS="-DMAXRANK=4" -j
         make -f Makefile.manual test
         make -f Makefile.manual clean
 

--- a/src/Makefile.manual
+++ b/src/Makefile.manual
@@ -54,6 +54,8 @@ stdlib_io.o: \
 	stdlib_error.o \
 	stdlib_optval.o \
 	stdlib_kinds.o
+stdlib_linalg.o: \
+	stdlib_kinds.o
 stdlib_linalg_diag.o: \
 	stdlib_linalg.o \
 	stdlib_kinds.o

--- a/src/Makefile.manual
+++ b/src/Makefile.manual
@@ -54,10 +54,16 @@ stdlib_io.o: \
 	stdlib_error.o \
 	stdlib_optval.o \
 	stdlib_kinds.o
-stdlib_linalg_diag.o: stdlib_kinds.o
+stdlib_linalg_diag.o: \
+	stdlib_linalg.o \
+	stdlib_kinds.o
 stdlib_logger.o: stdlib_ascii.o stdlib_optval.o
 stdlib_optval.o: stdlib_kinds.o
 stdlib_quadrature.o: stdlib_kinds.o
+stdlib_quadrature_trapzd.o: \
+	stdlib_error.o \
+	stdlib_quadrature.o \
+	stdlib_kinds.o
 stdlib_stats_mean.o: \
 	stdlib_optval.o \
 	stdlib_kinds.o \
@@ -66,6 +72,12 @@ stdlib_stats_moment.o: \
 	stdlib_optval.o \
 	stdlib_kinds.o \
 	stdlib_stats.o
+stdlib_stats_moment_all.o: \
+	stdlib_stats_moment.o
+stdlib_stats_moment_mask.o: \
+	stdlib_stats_moment.o
+stdlib_stats_moment_scalar.o: \
+	stdlib_stats_moment.o
 stdlib_stats_var.o: \
 	stdlib_optval.o \
 	stdlib_kinds.o \

--- a/src/Makefile.manual
+++ b/src/Makefile.manual
@@ -60,9 +60,11 @@ stdlib_linalg_diag.o: \
 stdlib_logger.o: stdlib_ascii.o stdlib_optval.o
 stdlib_optval.o: stdlib_kinds.o
 stdlib_quadrature.o: stdlib_kinds.o
-stdlib_quadrature_trapzd.o: \
-	stdlib_error.o \
+stdlib_quadrature_trapz.o: \
 	stdlib_quadrature.o \
+	stdlib_error.o \
+	stdlib_kinds.o
+stdlib_stats.o: \
 	stdlib_kinds.o
 stdlib_stats_mean.o: \
 	stdlib_optval.o \
@@ -82,19 +84,3 @@ stdlib_stats_var.o: \
 	stdlib_optval.o \
 	stdlib_kinds.o \
 	stdlib_stats.o
-
-# Fortran sources that are built from fypp templates
-stdlib_bitsets_64.f90: stdlib_bitsets_64.fypp
-stdlib_bitsets_large.f90: stdlib_bitsets_large.fypp
-stdlib_bitsets.f90: stdlib_bitsets.fypp
-stdlib_io.f90: stdlib_io.fypp
-stdlib_linalg.f90: stdlib_linalg.fypp
-stdlib_linalg_diag.f90: stdlib_linalg_diag.fypp
-stdlib_quadrature.f90: stdlib_quadrature.fypp
-stdlib_stats.f90: stdlib_stats.fypp
-stdlib_stats_mean.f90: stdlib_stats_mean.fypp
-stdlib_stats_moment.f90: stdlib_stats_moment.fypp
-stdlib_stats_moment_all.f90: stdlib_stats_moment_all.fypp
-stdlib_stats_moment_mask.f90: stdlib_stats_moment_mask.fypp
-stdlib_stats_moment_scalar.f90: stdlib_stats_moment_scalar.fypp
-stdlib_stats_var.f90: stdlib_stats_var.fypp


### PR DESCRIPTION
This PR fixes the manual Makefile by including the correct dependencies. The manual Makefile build could fail in full parallel builds due to missing dependencies.

To test this use a slow computer and let make create as many build jobs as allowed by the dependency network with:

```sh
make -f Makefile.manual FYPPFLAGS=-DMAXRANK=4 -j
```

This error might be hard to catch in a sequential CI build due to the correct ordering of the source files in `SRC` variable.