### PR TITLE
Fix compilation error for NAG

### DIFF
--- a/src/stdlib_bitsets.fypp
+++ b/src/stdlib_bitsets.fypp
@@ -2006,7 +2006,7 @@ module stdlib_bitsets
 
     end interface operator(<=)
 
-    interface error_handler
+    interface
         module subroutine error_handler( message, error, status, &
             module, procedure )
             character(*), intent(in)           :: message
@@ -2015,7 +2015,7 @@ module stdlib_bitsets
             character(*), intent(in), optional :: module
             character(*), intent(in), optional :: procedure
         end subroutine error_handler
-    end interface error_handler
+    end interface
 
 contains
 


### PR DESCRIPTION
NAG detects a duplicated name for error_handler which is defined as module procedure as well as the name of the interface of said procedure:

    Error: src/stdlib_bitsets.f90, line 2131: ERROR_HANDLER previously declared as a generic procedure name
           detected at ERROR_HANDLER@(

See #108 for discussion on NAG.