### PR TITLE
Install setuptools for MinGW builds

### DIFF
--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -70,6 +70,7 @@ jobs:
           mingw-w64-${{ matrix.arch }}-gcc-fortran
           mingw-w64-${{ matrix.arch }}-python
           mingw-w64-${{ matrix.arch }}-python-pip
+          mingw-w64-${{ matrix.arch }}-python-setuptools
           mingw-w64-${{ matrix.arch }}-cmake
           mingw-w64-${{ matrix.arch }}-ninja
 


### PR DESCRIPTION
Fixes recent build failure when installing fypp in the MinGW terminals of the MSYS2 environment.

See: https://github.com/fortran-lang/stdlib/runs/1919864726?check_suite_focus=true