### PR TITLE
Simplify test makefile

### DIFF
--- a/src/tests/Makefile.manual
+++ b/src/tests/Makefile.manual
@@ -1,30 +1,11 @@
 .PHONY: all clean test
 
-all:
-	$(MAKE) -f Makefile.manual --directory=ascii
-	$(MAKE) -f Makefile.manual --directory=bitsets
-	$(MAKE) -f Makefile.manual --directory=io
-	$(MAKE) -f Makefile.manual --directory=logger
-	$(MAKE) -f Makefile.manual --directory=optval
-	$(MAKE) -f Makefile.manual --directory=quadrature
-	$(MAKE) -f Makefile.manual --directory=stats
-	$(MAKE) -f Makefile.manual --directory=string
-
-test:
-	$(MAKE) -f Makefile.manual --directory=ascii test
-	$(MAKE) -f Makefile.manual --directory=bitsets test
-	$(MAKE) -f Makefile.manual --directory=io test
-	$(MAKE) -f Makefile.manual --directory=logger test
-	$(MAKE) -f Makefile.manual --directory=optval test
-	$(MAKE) -f Makefile.manual --directory=quadrature test
-	$(MAKE) -f Makefile.manual --directory=stats test
-	$(MAKE) -f Makefile.manual --directory=string test
-
-clean:
-	$(MAKE) -f Makefile.manual --directory=ascii clean
-	$(MAKE) -f Makefile.manual --directory=bitsets clean
-	$(MAKE) -f Makefile.manual --directory=io clean
-	$(MAKE) -f Makefile.manual --directory=logger clean
-	$(MAKE) -f Makefile.manual --directory=optval clean
-	$(MAKE) -f Makefile.manual --directory=stats clean
-	$(MAKE) -f Makefile.manual --directory=string clean
+all test clean:
+	$(MAKE) -f Makefile.manual --directory=ascii $@
+	$(MAKE) -f Makefile.manual --directory=bitsets $@
+	$(MAKE) -f Makefile.manual --directory=io $@
+	$(MAKE) -f Makefile.manual --directory=logger $@
+	$(MAKE) -f Makefile.manual --directory=optval $@
+	$(MAKE) -f Makefile.manual --directory=quadrature $@
+	$(MAKE) -f Makefile.manual --directory=stats $@
+	$(MAKE) -f Makefile.manual --directory=string $@


### PR DESCRIPTION
- use a single target for all, test and clean
- makes it easier to add a new subdirectory without having to modify multiple entries