### PR TITLE
Add test_string_functions to CMakeLists and fix to_title test

### DIFF
--- a/src/tests/string/CMakeLists.txt
+++ b/src/tests/string/CMakeLists.txt
@@ -2,4 +2,5 @@ ADDTEST(string_assignment)
 ADDTEST(string_operator)
 ADDTEST(string_intrinsic)
 ADDTEST(string_derivedtype_io)
+ADDTEST(string_functions)
 

--- a/src/tests/string/Makefile.manual
+++ b/src/tests/string/Makefile.manual
@@ -1,5 +1,6 @@
 PROGS_SRC = test_string_assignment.f90 \
             test_string_derivedtype_io.f90 \
+            test_string_functions.f90 \
             test_string_intrinsic.f90 \
             test_string_operator.f90
 

--- a/src/tests/string/test_string_functions.f90
+++ b/src/tests/string/test_string_functions.f90
@@ -28,7 +28,7 @@ contains
     subroutine test_to_title_string
         type(string_type) :: test_string, compare_string
         test_string = "_#To tiTlE !$%-az09AZ"
-        compare_string = "_#To title !$%-a09az"
+        compare_string = "_#To title !$%-az09az"
 
         call check(to_title(test_string) == compare_string)
 


### PR DESCRIPTION
I was just updating my [`stdlib-fpm`](https://github.com/LKedward/stdlib-fpm) mirror from #346 and I got [a test failure](https://github.com/LKedward/stdlib-fpm/pull/12/checks?check_run_id=2164452169#step:10:1902) in `test_string_functions.f90`; I checked the CI here and noticed the new test wasn't added to the `src/test/CMakeLists.txt` in this repo and so isn't tested in the CI.

- I've added the new test to the CMakeLists file and manual makefile, and;
- Fixed the test by adding a missing 'z' in the compare_string

(A nice demonstration of the benefits of auto-discovery of tests in *fpm*)

