### PR TITLE
Corrected Ubuntu version

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The following combinations are tested on the default branch of stdlib:
 
 Name | Version | Platform | Architecture
 --- | --- | --- | ---
-GCC Fortran | 7, 8, 9, 10 | Ubuntu 18.04 | x86_64
+GCC Fortran | 7, 8, 9, 10 | Ubuntu 20.04 | x86_64
 GCC Fortran | 7, 8, 9, 10 | MacOS Catalina 10.15 | x86_64
 GCC Fortran | 8 | Windows Server 2019 | x86_64
 GCC Fortran (MSYS) | 10 | Windows Server 2019 | x86_64


### PR DESCRIPTION
The Ubuntu version used in CI is 20.04, instead of 18.04 as mentioned in the README.md