### PR TITLE
Improved support for NAG

### DIFF
--- a/src/stdlib_logger.f90
+++ b/src/stdlib_logger.f90
@@ -352,8 +352,8 @@ contains
             end if
 
 ! Check that unit is opened
-            inquire( unit, opened=question, iostat=istat, iomsg=msgtxt)
-            if(istat/=0) question=.false.
+            inquire( unit, opened=question, iostat=istat, iomsg=msgtxt )
+            if(istat /= 0) question = .false.
             if ( .not. question ) then
                 if ( present(stat) ) then
                     stat = unopened_in_error

--- a/src/stdlib_logger.f90
+++ b/src/stdlib_logger.f90
@@ -309,7 +309,6 @@ contains
         character(12) :: specifier
         logical :: question
         integer :: istat
-        character(len=80) :: msgtxt
 
         call validate_unit()
         if ( present(stat) ) then
@@ -352,7 +351,7 @@ contains
             end if
 
 ! Check that unit is opened
-            inquire( unit, opened=question, iostat=istat, iomsg=msgtxt )
+            inquire( unit, opened=question, iostat=istat )
             if(istat /= 0) question = .false.
             if ( .not. question ) then
                 if ( present(stat) ) then

--- a/src/stdlib_logger.f90
+++ b/src/stdlib_logger.f90
@@ -308,6 +308,8 @@ contains
         integer :: lun
         character(12) :: specifier
         logical :: question
+        integer :: istat
+        character(len=80) :: msgtxt
 
         call validate_unit()
         if ( present(stat) ) then
@@ -350,7 +352,8 @@ contains
             end if
 
 ! Check that unit is opened
-            inquire( unit, opened=question )
+            inquire( unit, opened=question, iostat=istat, iomsg=msgtxt)
+            if(istat/=0) question=.false.
             if ( .not. question ) then
                 if ( present(stat) ) then
                     stat = unopened_in_error

--- a/src/stdlib_string_type.fypp
+++ b/src/stdlib_string_type.fypp
@@ -571,11 +571,11 @@ contains
         logical, intent(in), optional :: back
         integer :: pos
 
-        if(present(back))then
-          pos = index(maybe(string), maybe(substring),back)
+        if (present(back)) then
+          pos = index(maybe(string), maybe(substring), back)
         else
-          pos = index(maybe(string), maybe(substring),.false.)
-        endif
+          pos = index(maybe(string), maybe(substring), .false.)
+        end if
 
     end function index_string_string
 
@@ -587,11 +587,11 @@ contains
         logical, intent(in), optional :: back
         integer :: pos
 
-        if(present(back))then
-          pos = index(maybe(string), substring,back)
+        if (present(back)) then
+          pos = index(maybe(string), substring, back)
         else
-          pos = index(maybe(string), substring,.false.)
-        endif
+          pos = index(maybe(string), substring, .false.)
+        end if
 
     end function index_string_char
 
@@ -603,11 +603,11 @@ contains
         logical, intent(in), optional :: back
         integer :: pos
 
-        if(present(back))then
-          pos = index(string, maybe(substring),back)
+        if (present(back)) then
+          pos = index(string, maybe(substring), back)
         else
-          pos = index(string, maybe(substring),.false.)
-        endif
+          pos = index(string, maybe(substring), .false.)
+        end if
 
     end function index_char_string
 
@@ -621,11 +621,11 @@ contains
         logical, intent(in), optional :: back
         integer :: pos
 
-        if(present(back))then
-          pos = scan(maybe(string), maybe(set),back)
+        if (present(back)) then
+          pos = scan(maybe(string), maybe(set), back)
         else
-          pos = scan(maybe(string), maybe(set),.false.)
-        endif
+          pos = scan(maybe(string), maybe(set), .false.)
+        end if
 
     end function scan_string_string
 
@@ -637,11 +637,11 @@ contains
         logical, intent(in), optional :: back
         integer :: pos
 
-        if(present(back))then
-          pos = scan(maybe(string), set,back)
+        if (present(back)) then
+          pos = scan(maybe(string), set, back)
         else
-          pos = scan(maybe(string), set,.false.)
-        endif
+          pos = scan(maybe(string), set, .false.)
+        end if
 
     end function scan_string_char
 
@@ -653,11 +653,11 @@ contains
         logical, intent(in), optional :: back
         integer :: pos
 
-        if(present(back))then
-          pos = scan(string, maybe(set),back)
+        if (present(back)) then
+          pos = scan(string, maybe(set), back)
         else
-          pos = scan(string, maybe(set),.false.)
-        endif
+          pos = scan(string, maybe(set), .false.)
+        end if
 
     end function scan_char_string
 
@@ -671,11 +671,11 @@ contains
         logical, intent(in), optional :: back
         integer :: pos
 
-        if(present(back))then
-          pos = verify(maybe(string), maybe(set),back)
+        if (present(back)) then
+          pos = verify(maybe(string), maybe(set), back)
         else
-          pos = verify(maybe(string), maybe(set),.false.)
-        endif
+          pos = verify(maybe(string), maybe(set), .false.)
+        end if
 
     end function verify_string_string
 
@@ -688,11 +688,11 @@ contains
         logical, intent(in), optional :: back
         integer :: pos
 
-        if(present(back))then
-          pos = verify(maybe(string), set,back)
+        if (present(back)) then
+          pos = verify(maybe(string), set, back)
         else
-          pos = verify(maybe(string), set,.false.)
-        endif
+          pos = verify(maybe(string), set, .false.)
+        end if
 
     end function verify_string_char
 
@@ -705,11 +705,11 @@ contains
         logical, intent(in), optional :: back
         integer :: pos
 
-        if(present(back))then
-          pos = verify(string, maybe(set),back)
+        if (present(back)) then
+          pos = verify(string, maybe(set), back)
         else
-          pos = verify(string, maybe(set),.false.)
-        endif
+          pos = verify(string, maybe(set), .false.)
+        end if
 
     end function verify_char_string
 

--- a/src/stdlib_string_type.fypp
+++ b/src/stdlib_string_type.fypp
@@ -421,7 +421,7 @@ contains
         type(string_type), intent(in) :: string
         integer :: ich
 
-        ich = merge(ichar(string%raw), 0, allocated(string%raw))
+        ich = merge(ichar(string%raw(1:1)), 0, allocated(string%raw))
 
     end function ichar_string
 
@@ -431,7 +431,7 @@ contains
         type(string_type), intent(in) :: string
         integer :: ich
 
-        ich = merge(iachar(string%raw), 0, allocated(string%raw))
+        ich = merge(iachar(string%raw(1:1)), 0, allocated(string%raw))
 
     end function iachar_string
 
@@ -571,8 +571,11 @@ contains
         logical, intent(in), optional :: back
         integer :: pos
 
-        pos = index(maybe(string), maybe(substring), &
-            merge(back, .false., present(back)))
+        if(present(back))then
+          pos = index(maybe(string), maybe(substring),back)
+        else
+          pos = index(maybe(string), maybe(substring),.false.)
+        endif
 
     end function index_string_string
 
@@ -584,8 +587,11 @@ contains
         logical, intent(in), optional :: back
         integer :: pos
 
-        pos = index(maybe(string), substring, &
-            merge(back, .false., present(back)))
+        if(present(back))then
+          pos = index(maybe(string), substring,back)
+        else
+          pos = index(maybe(string), substring,.false.)
+        endif
 
     end function index_string_char
 
@@ -597,8 +603,11 @@ contains
         logical, intent(in), optional :: back
         integer :: pos
 
-        pos = index(string, maybe(substring), &
-            merge(back, .false., present(back)))
+        if(present(back))then
+          pos = index(string, maybe(substring),back)
+        else
+          pos = index(string, maybe(substring),.false.)
+        endif
 
     end function index_char_string
 
@@ -612,8 +621,11 @@ contains
         logical, intent(in), optional :: back
         integer :: pos
 
-        pos = scan(maybe(string), maybe(set), &
-            merge(back, .false., present(back)))
+        if(present(back))then
+          pos = scan(maybe(string), maybe(set),back)
+        else
+          pos = scan(maybe(string), maybe(set),.false.)
+        endif
 
     end function scan_string_string
 
@@ -625,8 +637,11 @@ contains
         logical, intent(in), optional :: back
         integer :: pos
 
-        pos = scan(maybe(string), set, &
-            merge(back, .false., present(back)))
+        if(present(back))then
+          pos = scan(maybe(string), set,back)
+        else
+          pos = scan(maybe(string), set,.false.)
+        endif
 
     end function scan_string_char
 
@@ -638,8 +653,11 @@ contains
         logical, intent(in), optional :: back
         integer :: pos
 
-        pos = scan(string, maybe(set), &
-            merge(back, .false., present(back)))
+        if(present(back))then
+          pos = scan(string, maybe(set),back)
+        else
+          pos = scan(string, maybe(set),.false.)
+        endif
 
     end function scan_char_string
 
@@ -653,8 +671,11 @@ contains
         logical, intent(in), optional :: back
         integer :: pos
 
-        pos = verify(maybe(string), maybe(set), &
-            merge(back, .false., present(back)))
+        if(present(back))then
+          pos = verify(maybe(string), maybe(set),back)
+        else
+          pos = verify(maybe(string), maybe(set),.false.)
+        endif
 
     end function verify_string_string
 
@@ -667,8 +688,11 @@ contains
         logical, intent(in), optional :: back
         integer :: pos
 
-        pos = verify(maybe(string), set, &
-            merge(back, .false., present(back)))
+        if(present(back))then
+          pos = verify(maybe(string), set,back)
+        else
+          pos = verify(maybe(string), set,.false.)
+        endif
 
     end function verify_string_char
 
@@ -681,8 +705,11 @@ contains
         logical, intent(in), optional :: back
         integer :: pos
 
-        pos = verify(string, maybe(set), &
-            merge(back, .false., present(back)))
+        if(present(back))then
+          pos = verify(string, maybe(set),back)
+        else
+          pos = verify(string, maybe(set),.false.)
+        endif
 
     end function verify_char_string
 

--- a/src/stdlib_string_type.fypp
+++ b/src/stdlib_string_type.fypp
@@ -421,7 +421,7 @@ contains
         type(string_type), intent(in) :: string
         integer :: ich
 
-        if (allocated(string%raw) .and. len_trim(string%raw) > 0) then
+        if (allocated(string%raw) .and. len(string) > 0) then
           ich = ichar(string%raw(1:1))
         else
           ich = 0
@@ -435,7 +435,7 @@ contains
         type(string_type), intent(in) :: string
         integer :: ich
 
-        if (allocated(string%raw) .and. len_trim(string%raw) > 0) then
+        if (allocated(string%raw) .and. len(string) > 0) then
           ich = iachar(string%raw(1:1))
         else
           ich = 0

--- a/src/stdlib_string_type.fypp
+++ b/src/stdlib_string_type.fypp
@@ -421,7 +421,11 @@ contains
         type(string_type), intent(in) :: string
         integer :: ich
 
-        ich = merge(ichar(string%raw(1:1)), 0, allocated(string%raw))
+        if (allocated(string%raw) .and. len_trim(string%raw) > 0) then
+          ich = ichar(string%raw(1:1))
+        else
+          ich = 0
+        end if
 
     end function ichar_string
 
@@ -431,7 +435,11 @@ contains
         type(string_type), intent(in) :: string
         integer :: ich
 
-        ich = merge(iachar(string%raw(1:1)), 0, allocated(string%raw))
+        if (allocated(string%raw) .and. len_trim(string%raw) > 0) then
+          ich = iachar(string%raw(1:1))
+        else
+          ich = 0
+        end if
 
     end function iachar_string
 

--- a/src/tests/logger/test_stdlib_logger.f90
+++ b/src/tests/logger/test_stdlib_logger.f90
@@ -417,6 +417,8 @@ contains
     subroutine test_removing_log_units()
 
         logical :: opened
+        integer :: istat
+        character(len=80) :: msgtxt
 
         print *
         print *, 'running test_removing_log_units'
@@ -462,7 +464,8 @@ contains
 
         end if
 
-        inquire( unit4, opened=opened )
+        inquire( unit4, opened=opened ,iostat=istat,iomsg=msgtxt)
+        if(istat/=0) opened=.false.
         if ( opened ) then
             error stop 'UNIT4 is opened contrary to expectations.'
 

--- a/src/tests/logger/test_stdlib_logger.f90
+++ b/src/tests/logger/test_stdlib_logger.f90
@@ -418,7 +418,6 @@ contains
 
         logical :: opened
         integer :: istat
-        character(len=80) :: msgtxt
 
         print *
         print *, 'running test_removing_log_units'
@@ -464,7 +463,7 @@ contains
 
         end if
 
-        inquire( unit4, opened=opened, iostat=istat, iomsg=msgtxt )
+        inquire( unit4, opened=opened, iostat=istat )
         if(istat /= 0) opened = .false.
         if ( opened ) then
             error stop 'UNIT4 is opened contrary to expectations.'

--- a/src/tests/logger/test_stdlib_logger.f90
+++ b/src/tests/logger/test_stdlib_logger.f90
@@ -464,8 +464,8 @@ contains
 
         end if
 
-        inquire( unit4, opened=opened ,iostat=istat,iomsg=msgtxt)
-        if(istat/=0) opened=.false.
+        inquire( unit4, opened=opened, iostat=istat, iomsg=msgtxt )
+        if(istat /= 0) opened = .false.
         if ( opened ) then
             error stop 'UNIT4 is opened contrary to expectations.'
 

--- a/src/tests/stats/test_mean_f03.f90
+++ b/src/tests/stats/test_mean_f03.f90
@@ -20,7 +20,7 @@ call check( sum( abs( mean(d,1) - sum(d,1)/real(size(d,1), dp) )) < dptol)
 call check( sum( abs( mean(d,2) - sum(d,2)/real(size(d,2), dp) )) < dptol)
 
 !dp rank 8
-allocate(d8(size(d,1), size(d,2), 3, 4, 5, 6, 7, 8),source=0.0_dp)
+allocate(d8(size(d,1), size(d,2), 3, 4, 5, 6, 7, 8), source=0.0_dp)
 d8(:, :, 1, 4, 5 ,6 ,7 ,8)=d;
 d8(:, :, 2, 4, 5 ,6 ,7 ,8)=d * 1.5_dp;
 d8(:, :, 3, 4, 5 ,6 ,7 ,8)=d * 4._dp;

--- a/src/tests/stats/test_mean_f03.f90
+++ b/src/tests/stats/test_mean_f03.f90
@@ -20,7 +20,7 @@ call check( sum( abs( mean(d,1) - sum(d,1)/real(size(d,1), dp) )) < dptol)
 call check( sum( abs( mean(d,2) - sum(d,2)/real(size(d,2), dp) )) < dptol)
 
 !dp rank 8
-allocate(d8(size(d,1), size(d,2), 3, 4, 5, 6, 7, 8))
+allocate(d8(size(d,1), size(d,2), 3, 4, 5, 6, 7, 8),source=0.0_dp)
 d8(:, :, 1, 4, 5 ,6 ,7 ,8)=d;
 d8(:, :, 2, 4, 5 ,6 ,7 ,8)=d * 1.5_dp;
 d8(:, :, 3, 4, 5 ,6 ,7 ,8)=d * 4._dp;


### PR DESCRIPTION
Because of nagfor's strict error checking characteristics, execution is halted by default when a floating point exception occurs. Some of the runtime errors can be resolved by adding the option '-ieee=full'.
Other errors have been corrected to conform more strictly to the fortran standard.
These commit still leaves the one runtime error 'string_derivedtype_io'.
#108 