### PR TITLE
Minor fixes to sorting documentation

### DIFF
--- a/doc/specs/stdlib_sorting.md
+++ b/doc/specs/stdlib_sorting.md
@@ -211,7 +211,7 @@ increasing, or decreasing, value.
 
 ##### Syntax
 
-`call [[stdlib_sorting(module):ord_sort(subroutine)]]ord_sort ( array[, work, reverse ] )`
+`call [[stdlib_sorting(module):ord_sort(interface)]]( array[, work, reverse ] )`
 
 ##### Class
 
@@ -286,7 +286,7 @@ decreasing, value.
 
 ##### Syntax
 
-`call [[stdlib_sorting(module):sort(subroutine)]]sort ( array[, reverse] )`
+`call [[stdlib_sorting(module):sort(interface)]]( array[, reverse] )`
 
 ##### Class
 
@@ -349,7 +349,7 @@ sort the input `array` to produce the output `array`.
 
 ##### Syntax
 
-`call [[stdlib_sorting(module):sort_index(subroutine)]]sort_index ( array, index[, work, iwork, reverse ] )`
+`call [[stdlib_sorting(module):sort_index(interface)]]( array, index[, work, iwork, reverse ] )`
 
 ##### Class
 

--- a/src/stdlib_sorting.fypp
+++ b/src/stdlib_sorting.fypp
@@ -3,7 +3,7 @@
 
 !! Licensing:
 !!
-!! This file is subjec† both to the Fortran Standard Library license, and
+!! This file is subject both to the Fortran Standard Library license, and
 !! to additional licensing requirements as it contains translations of
 !! other software.
 !!
@@ -65,8 +65,11 @@
 module stdlib_sorting
 !! This module implements overloaded sorting subroutines named `ORD_SORT`,
 !! `SORT_INDEX`, and `SORT`, that each can be used to sort four kinds
-!! of `INTEGER` arrays, three kinds of `REAL` arrays, character(len=*) arrays,
-!! and arrays of type(string_type). By default sorting is in order of 
+!! of `INTEGER` arrays, three kinds of `REAL` arrays, `character(len=*)` arrays,
+!! and arrays of `type(string_type)`.
+!! ([Specification](../page/specs/stdlib_sorting.html))
+!!
+!! By default sorting is in order of 
 !! increasing value, but there is an option to sort in decreasing order. 
 !! All the subroutines have worst case run time performance of `O(N Ln(N))`, 
 !! but on largely sorted data `ORD_SORT` and `SORT_INDEX` can have a run time 
@@ -341,7 +344,10 @@ module stdlib_sorting
 !! `slice.rs`
 !! https://github.com/rust-lang/rust/blob/90eb44a5897c39e3dff9c7e48e3973671dcd9496/src/liballoc/slice.rs#L2159
 !! `ORD_SORT` is a hybrid stable comparison algorithm combining `merge sort`,
-!! and `insertion sort`. It is always at worst O(N Ln(N)) in sorting random
+!! and `insertion sort`.
+!! ([Specification](../page/specs/stdlib_sorting.html#ord_sort-sorts-an-input-array))
+!!
+!! It is always at worst O(N Ln(N)) in sorting random
 !! data, having a performance about 25% slower than `SORT` on such
 !! data, but has much better performance than `SORT` on partially
 !! sorted data, having O(N) performance on uniformly non-increasing or
@@ -377,6 +383,7 @@ module stdlib_sorting
 !!
 !! The generic subroutine interface implementing the `SORT` algorithm, based
 !! on the `introsort` of David Musser.
+!! ([Specification](../page/specs/stdlib_sorting.html#sort-sorts-an-input-array))
 
 #:for k1, t1 in IRS_KINDS_TYPES
         pure module subroutine ${k1}$_sort( array, reverse )
@@ -414,7 +421,10 @@ module stdlib_sorting
 !! based on the `"Rust" sort` algorithm found in `slice.rs`
 !! https://github.com/rust-lang/rust/blob/90eb44a5897c39e3dff9c7e48e3973671dcd9496/src/liballoc/slice.rs#L2159
 !! but modified to return an array of indices that would provide a stable
-!! sort of the rank one `ARRAY` input. The indices by default correspond to a
+!! sort of the rank one `ARRAY` input.
+!! ([Specification](../page/specs/stdlib_sorting.html#sort_index-creates-an-array-of-sorting-indices-for-an-input-array-while-also-sorting-the-array))
+!!
+!! The indices by default correspond to a
 !! non-decreasing sort, but if the optional argument `REVERSE` is present
 !! with a value of `.TRUE.` the indices correspond to a non-increasing sort.
 

--- a/src/stdlib_sorting.fypp
+++ b/src/stdlib_sorting.fypp
@@ -65,11 +65,12 @@
 module stdlib_sorting
 !! This module implements overloaded sorting subroutines named `ORD_SORT`,
 !! `SORT_INDEX`, and `SORT`, that each can be used to sort four kinds
-!! of `INTEGER` arrays and three kinds of `REAL` arrays. By default, sorting
-!! is in order of increasing value, though `SORT_INDEX` has the option of
-!! sorting in order of decresasing value. All the subroutines have worst
-!! case run time performance of `O(N Ln(N))`, but on largely sorted data
-!! `ORD_SORT` and `SORT_INDEX` can have a run time performance of `O(N)`.
+!! of `INTEGER` arrays, three kinds of `REAL` arrays, character(len=*) arrays,
+!! and arrays of type(string_type). By default sorting is in order of 
+!! increasing value, but there is an option to sort in decreasing order. 
+!! All the subroutines have worst case run time performance of `O(N Ln(N))`, 
+!! but on largely sorted data `ORD_SORT` and `SORT_INDEX` can have a run time 
+!! performance of `O(N)`.
 !!
 !! `ORD_SORT` is a translation of the `"Rust" sort` sorting algorithm in
 !! `slice.rs`:
@@ -149,10 +150,10 @@ module stdlib_sorting
 !! * array: the rank 1 array to be sorted. It is an `intent(inout)`
 !!   argument of any of the types `integer(int8)`, `integer(int16)`,
 !!   `integer(int32)`, `integer(int64)`, `real(real32)`, `real(real64)`,
-!!   `real(real128)`, or `character(*)`. If both the type of `array` is
-!!   real and at least one of the elements is a `NaN`, then the ordering
-!!   of the result is undefined. Otherwise it is defined to be the
-!!   original elements in non-decreasing order.
+!!   `real(real128)`, `character(*)`, `type(string_type)`. If both the 
+!!   type of `array` is real and at least one of the elements is a 
+!!   `NaN`, then the ordering of the result is undefined. Otherwise it 
+!!   is defined to be the original elements in non-decreasing order.
 !!
 !! * work (optional): shall be a rank 1 array of the same type as
 !!   `array`, and shall have at least `size(array)/2` elements. It is an
@@ -199,9 +200,9 @@ module stdlib_sorting
 !! * array: the rank 1 array to be sorted. It is an `intent(inout)`
 !!   argument of any of the types `integer(int8)`, `integer(int16)`,
 !!   `integer(int32)`, `integer(int64)`, `real(real32)`, `real(real64)`,
-!!   `real(real128)`, or `character(*)`. If both the type of `array` is
-!!   real and at least one of the elements is a `NaN`, then the ordering
-!!   of the result is undefined. Otherwise it is defined to be the
+!!   `real(real128)`, `character(*)`, `type(string_type)`. If both the type
+!!   of `array` is real and at least one of the elements is a `NaN`, then
+!!   the ordering of the result is undefined. Otherwise it is defined to be the
 !!   original elements in non-decreasing order.
 !! * `reverse` (optional): shall be a scalar of type default logical. It
 !!   is an `intent(in)` argument. If present with a value of `.true.` then
@@ -238,10 +239,10 @@ module stdlib_sorting
 !! * array: the rank 1 array to be sorted. It is an `intent(inout)`
 !!   argument of any of the types `integer(int8)`, `integer(int16)`,
 !!   `integer(int32)`, `integer(int64)`, `real(real32)`, `real(real64)`,
-!!   `real(real128)`, or `character(*)`. If both the type of `array` is
-!!   real and at least one of the elements is a `NaN`, then the ordering
-!!   of the `array` and `index` results is undefined. Otherwise it is
-!!   defined to be as specified by reverse.
+!!   `real(real128)`, `character(*)`, `type(string_type)`. If both the 
+!!   type of `array` is real and at least one of the elements is a `NaN`, 
+!!   then the ordering of the `array` and `index` results is undefined. 
+!!   Otherwise it is defined to be as specified by reverse.
 !!
 !! * index: a rank 1 array of sorting indices. It is an `intent(out)`
 !!   argument of the type `integer(int_size)`. Its size shall be the


### PR DESCRIPTION
Some parts of the documentation were missing references to sorting character(len=*) or type(string_type) -- but these are supported.