### PR TITLE
Add separate logical kind parameters

### DIFF
--- a/doc/specs/index.md
+++ b/doc/specs/index.md
@@ -15,6 +15,7 @@ This is and index/directory of the specifications (specs) for each new module/fe
  - [bitsets](./stdlib_bitsets.html) - Bitset data types and procedures
  - [error](./stdlib_error.html) - Catching and handling errors
  - [IO](./stdlib_io.html) - Input/output helper & convenience
+ - [kinds](./stdlib_kinds.html) - Kind parameters
  - [linalg](./stdlib_linalg.html) - Linear Algebra
  - [logger](./stdlib_logger.html) - Runtime logging system
  - [optval](./stdlib_optval.html) - Fallback value for optional arguments
@@ -24,10 +25,6 @@ This is and index/directory of the specifications (specs) for each new module/fe
  - [stats_distribution_PRNG](./stdlib_stats_distribution_PRNG.html) - Probability Distributions random number generator
  - [string\_type](./stdlib_string_type.html) - Basic string support
  - [strings](./stdlib_strings.html) - String handling and manipulation routines
-
-## Missing specs
-
- - [kinds](https://github.com/fortran-lang/stdlib/blob/master/src/stdlib_kinds.f90)
 
 ## Released/Stable Features & Modules
 

--- a/doc/specs/stdlib_kinds.md
+++ b/doc/specs/stdlib_kinds.md
@@ -49,7 +49,7 @@ Reexported intrinsic named constant `int32` from `iso_fortran_env`.
 Reexported intrinsic named constant `int64` from `iso_fortran_env`.
 
 
-### `lp`
+### `lk`
 
 Kind parameter of the default logical data type.
 

--- a/doc/specs/stdlib_kinds.md
+++ b/doc/specs/stdlib_kinds.md
@@ -1,0 +1,59 @@
+---
+title: kinds
+---
+
+# The `stdlib_kinds` module
+
+[TOC]
+
+## Introduction
+
+The `stdlib_kinds` module provides kind parameters for the Fortran intrinsic data types,
+*integer*, *logical*, *real*, and *complex*.
+
+
+## Constants provided by `stdlib_kinds`
+
+### `sp`
+
+Alias for intrinsic named constant `real32` imported from `iso_fortran_env`.
+
+
+### `dp`
+
+Alias for intrinsic named constant `real64` imported from `iso_fortran_env`.
+
+
+### `qp`
+
+Alias for intrinsic named constant `real128` imported from `iso_fortran_env`.
+
+
+### `int8`
+
+Reexported intrinsic named constant `int8` from `iso_fortran_env`.
+
+
+### `int16`
+
+Reexported intrinsic named constant `int16` from `iso_fortran_env`.
+
+
+### `int32`
+
+Reexported intrinsic named constant `int32` from `iso_fortran_env`.
+
+
+### `int64`
+
+Reexported intrinsic named constant `int64` from `iso_fortran_env`.
+
+
+### `lp`
+
+Kind parameter of the default logical data type.
+
+
+### `c_bool`
+
+Reexported intrinsic named constant `c_bool` from `iso_c_binding`.

--- a/src/common.fypp
+++ b/src/common.fypp
@@ -27,13 +27,13 @@
 #! Collected (kind, type) tuples for integer types
 #:set INT_KINDS_TYPES = list(zip(INT_KINDS, INT_TYPES))
 
-#! Integer kinds to be considered during templating
+#! Logical kinds to be considered during templating
 #:set LOG_KINDS = ["lk", "c_bool"]
 
-#! Integer types to be considered during templating
+#! Logical types to be considered during templating
 #:set LOG_TYPES = ["logical({})".format(k) for k in LOG_KINDS]
 
-#! Collected (kind, type) tuples for integer types
+#! Collected (kind, type) tuples for logical types
 #:set LOG_KINDS_TYPES = list(zip(LOG_KINDS, LOG_TYPES))
 
 #! Derived type string_type

--- a/src/common.fypp
+++ b/src/common.fypp
@@ -28,7 +28,7 @@
 #:set INT_KINDS_TYPES = list(zip(INT_KINDS, INT_TYPES))
 
 #! Integer kinds to be considered during templating
-#:set LOG_KINDS = ["lp", "c_bool"]
+#:set LOG_KINDS = ["lk", "c_bool"]
 
 #! Integer types to be considered during templating
 #:set LOG_TYPES = ["logical({})".format(k) for k in LOG_KINDS]

--- a/src/common.fypp
+++ b/src/common.fypp
@@ -27,6 +27,15 @@
 #! Collected (kind, type) tuples for integer types
 #:set INT_KINDS_TYPES = list(zip(INT_KINDS, INT_TYPES))
 
+#! Integer kinds to be considered during templating
+#:set LOG_KINDS = ["lp", "c_bool"]
+
+#! Integer types to be considered during templating
+#:set LOG_TYPES = ["logical({})".format(k) for k in LOG_KINDS]
+
+#! Collected (kind, type) tuples for integer types
+#:set LOG_KINDS_TYPES = list(zip(LOG_KINDS, LOG_TYPES))
+
 #! Derived type string_type
 #:set STRING_KINDS = ["string_type"]
 

--- a/src/stdlib_ascii.fypp
+++ b/src/stdlib_ascii.fypp
@@ -5,7 +5,7 @@
 !>
 !> The specification of this module is available [here](../page/specs/stdlib_ascii.html).
 module stdlib_ascii
-    use stdlib_kinds, only : int8, int16, int32, int64
+    use stdlib_kinds, only : int8, int16, int32, int64, lk, c_bool
 
     implicit none
     private
@@ -28,6 +28,8 @@ module stdlib_ascii
     interface to_string
     #:for kind in INT_KINDS
         module procedure :: to_string_integer_${kind}$
+    #:endfor
+    #:for kind in LOG_KINDS
         module procedure :: to_string_logical_${kind}$
     #:endfor
     end interface to_string
@@ -396,7 +398,7 @@ contains
     end function to_string_integer_${kind}$
     #:endfor
 
-    #:for kind in INT_KINDS
+    #:for kind in LOG_KINDS
     !> Represent an logical of kind ${kind}$ as character sequence
     pure function to_string_logical_${kind}$(val) result(string)
         integer, parameter :: ik = ${kind}$

--- a/src/stdlib_kinds.f90
+++ b/src/stdlib_kinds.f90
@@ -8,7 +8,7 @@ use iso_c_binding, only: c_bool
 !use iso_c_binding, only: int8=>c_int8_t, int16=>c_int16_t, int32=>c_int32_t, int64=>c_int64_t
 implicit none
 private
-public sp, dp, qp, int8, int16, int32, int64, lp, c_bool
+public sp, dp, qp, int8, int16, int32, int64, lk, c_bool
 
-integer, parameter :: lp = kind(.true.)
+integer, parameter :: lk = kind(.true.)
 end module stdlib_kinds

--- a/src/stdlib_kinds.f90
+++ b/src/stdlib_kinds.f90
@@ -2,10 +2,13 @@ module stdlib_kinds
 !! version: experimental
 use iso_fortran_env, only: sp=>real32, dp=>real64, qp=>real128
 use iso_fortran_env, only: int8, int16, int32, int64
+use iso_c_binding, only: c_bool
 ! If we decide later to use iso_c_binding instead of iso_fortran_env:
 !use iso_c_binding, only: sp=>c_float, dp=>c_double, qp=>c_float128
 !use iso_c_binding, only: int8=>c_int8_t, int16=>c_int16_t, int32=>c_int32_t, int64=>c_int64_t
 implicit none
 private
-public sp, dp, qp, int8, int16, int32, int64
+public sp, dp, qp, int8, int16, int32, int64, lp, c_bool
+
+integer, parameter :: lp = kind(.true.)
 end module stdlib_kinds

--- a/src/stdlib_string_type.fypp
+++ b/src/stdlib_string_type.fypp
@@ -15,7 +15,7 @@
 module stdlib_string_type
     use stdlib_ascii, only: to_lower_ => to_lower, to_upper_ => to_upper, &
        & to_title_ => to_title, to_sentence_ => to_sentence, reverse_ => reverse, to_string
-    use stdlib_kinds, only : int8, int16, int32, int64
+    use stdlib_kinds, only : int8, int16, int32, int64, lk, c_bool
     implicit none
     private
 
@@ -47,6 +47,8 @@ module stdlib_string_type
         module procedure :: new_string
       #:for kind in INT_KINDS
         module procedure :: new_string_from_integer_${kind}$
+      #:endfor
+      #:for kind in LOG_KINDS
         module procedure :: new_string_from_logical_${kind}$
       #:endfor
     end interface string_type
@@ -373,7 +375,7 @@ contains
     end function new_string_from_integer_${kind}$
   #:endfor
 
-  #:for kind in INT_KINDS
+  #:for kind in LOG_KINDS
     !> Constructor for new string instances from a logical of kind ${kind}$.
     elemental function new_string_from_logical_${kind}$(val) result(new)
         logical(${kind}$), intent(in) :: val

--- a/src/tests/ascii/test_ascii.f90
+++ b/src/tests/ascii/test_ascii.f90
@@ -8,7 +8,7 @@ program test_ascii
         is_control, is_punctuation, is_graphical, is_printable, is_ascii, &
         to_lower, to_upper, to_title, to_sentence, reverse, LF, TAB, NUL, DEL, &
         to_string
-     use stdlib_kinds, only : int8, int16, int32, int64
+    use stdlib_kinds, only : int8, int16, int32, int64, lp, c_bool
 
     implicit none
 
@@ -676,11 +676,11 @@ contains
        write(flc, '(g0)') .false.
        call check(to_string(.false.) == trim(flc))
 
-       write(flc, '(g0)') .true._int8
-       call check(to_string(.true._int8) == trim(flc))
+       write(flc, '(g0)') .true._c_bool
+       call check(to_string(.true._c_bool) == trim(flc))
 
-       write(flc, '(g0)') .false._int64
-       call check(to_string(.false._int64) == trim(flc))
+       write(flc, '(g0)') .false._lp
+       call check(to_string(.false._lp) == trim(flc))
     end subroutine test_to_string
 
 end program test_ascii

--- a/src/tests/ascii/test_ascii.f90
+++ b/src/tests/ascii/test_ascii.f90
@@ -8,7 +8,7 @@ program test_ascii
         is_control, is_punctuation, is_graphical, is_printable, is_ascii, &
         to_lower, to_upper, to_title, to_sentence, reverse, LF, TAB, NUL, DEL, &
         to_string
-    use stdlib_kinds, only : int8, int16, int32, int64, lp, c_bool
+    use stdlib_kinds, only : int8, int16, int32, int64, lk, c_bool
 
     implicit none
 
@@ -679,8 +679,8 @@ contains
        write(flc, '(g0)') .true._c_bool
        call check(to_string(.true._c_bool) == trim(flc))
 
-       write(flc, '(g0)') .false._lp
-       call check(to_string(.false._lp) == trim(flc))
+       write(flc, '(g0)') .false._lk
+       call check(to_string(.false._lk) == trim(flc))
     end subroutine test_to_string
 
 end program test_ascii

--- a/src/tests/string/test_string_assignment.f90
+++ b/src/tests/string/test_string_assignment.f90
@@ -1,7 +1,7 @@
 ! SPDX-Identifier: MIT
 module test_string_assignment
     use stdlib_error, only : check
-    use stdlib_kinds, only : int8, int16, int32, int64
+    use stdlib_kinds, only : int8, int16, int32, int64, lk, c_bool
     use stdlib_string_type, only : string_type, assignment(=), operator(==), len
     implicit none
 
@@ -52,11 +52,11 @@ contains
        write(flc, '(g0)') .false.
        call check(string_type(.false.) == trim(flc))
 
-       write(flc, '(g0)') .false._int8
-       call check(string_type(.false._int8) == trim(flc))
+       write(flc, '(g0)') .false._c_bool
+       call check(string_type(.false._c_bool) == trim(flc))
 
-       write(flc, '(g0)') .true._int64
-       call check(string_type(.true._int64) == trim(flc))
+       write(flc, '(g0)') .true._lk
+       call check(string_type(.true._lk) == trim(flc))
     end subroutine test_char_value
 
 end module test_string_assignment


### PR DESCRIPTION
- added logical kind parameters to `stdlib_kinds`:
  - `lp`: logical precision of default logical variables (name open for discussion)
  - `c_bool`: reexport from `iso_c_binding`
- created `LOG_KINDS`, `LOG_TYPES` and `LOG_KINDS_TYPES` macros
- updated `to_string` generator to use `LOG_KINDS`
- documented `stdlib_kinds` module in specification

Closes #423 