### PR TITLE
Issue with stdlib_sorting

### DIFF
--- a/src/stdlib_sorting_ord_sort.fypp
+++ b/src/stdlib_sorting_ord_sort.fypp
@@ -158,7 +158,8 @@ contains
             do j=1, size(array, kind=int_size)-1
                 key = array(j)
                 i = j - 1
-                do while( i >= 0 .and. array(i) ${signt}$ key )
+                do while( i >= 0 )
+                    if ( array(i) ${signoppt}$= key ) exit
                     array(i+1) = array(i)
                     i = i - 1
                 end do
@@ -518,7 +519,8 @@ contains
             do j=1, size(array, kind=int_size)-1
                 key = array(j)
                 i = j - 1
-                do while( i >= 0 .and. array(i) ${signt}$ key )
+                do while( i >= 0 )
+                    if ( array(i) ${signoppt}$= key ) exit
                     array(i+1) = array(i)
                     i = i - 1
                 end do

--- a/src/stdlib_sorting_sort_index.fypp
+++ b/src/stdlib_sorting_sort_index.fypp
@@ -177,7 +177,8 @@ contains
                 key = array(j)
                 key_index = index(j)
                 i = j - 1
-                do while( i >= 0 .and. array(i) > key )
+                do while( i >= 0 )
+                    if ( array(i) <= key ) exit
                     array(i+1) = array(i)
                     index(i+1) = index(i)
                     i = i - 1
@@ -585,7 +586,8 @@ contains
                 key = array(j)
                 key_index = index(j)
                 i = j - 1
-                do while( i >= 0 .and. array(i) > key )
+                do while( i >= 0 )
+                    if ( array(i) <= key ) exit
                     array(i+1) = array(i)
                     index(i+1) = index(i)
                     i = i - 1

--- a/src/tests/sorting/test_sorting.f90
+++ b/src/tests/sorting/test_sorting.f90
@@ -14,7 +14,7 @@ program test_sorting
     integer(int32), parameter :: char_size = 26**4
     integer(int32), parameter :: string_size = 26**3
     integer(int32), parameter :: block_size = test_size/6
-    integer, parameter        :: repeat = 1
+    integer, parameter        :: repeat = 8
 
     integer(int32) ::             &
         blocks(0:test_size-1),    &

--- a/src/tests/sorting/test_sorting.f90
+++ b/src/tests/sorting/test_sorting.f90
@@ -179,7 +179,9 @@ contains
     subroutine test_int_ord_sorts( ltest )
         logical, intent(out) :: ltest
 
-        logical :: ldummy
+        integer(int64)       :: i
+        integer, allocatable :: d1(:)
+        logical              :: ldummy
 
         ltest = .true.
 
@@ -202,15 +204,11 @@ contains
         call test_int_ord_sort( rand10, "Random 10", ldummy )
         ltest = (ltest .and. ldummy)
 
-
-        block
-        integer(int64) :: i
-        integer, allocatable :: d1(:)
+        !triggered an issue in insertion_sort
         d1 = [10, 2, -3, -4, 6, -6, 7, -8, 9, 0, 1, 20]
-        call ord_sort( d1)
+        call ord_sort( d1 )
         call verify_sort( d1, ldummy, i )
         ltest = (ltest .and. ldummy)
-        end block
 
 
     end subroutine test_int_ord_sorts
@@ -429,7 +427,9 @@ contains
     subroutine test_int_sorts( ltest )
         logical, intent(out) :: ltest
 
-        logical :: ldummy
+        integer(int64)       :: i
+        integer, allocatable :: d1(:)
+        logical              :: ldummy
 
         ltest = .true.
 
@@ -450,6 +450,12 @@ contains
         call test_int_sort( rand3, "Random 3", ldummy )
         ltest = (ltest .and. ldummy)
         call test_int_sort( rand10, "Random 10", ldummy )
+        ltest = (ltest .and. ldummy)
+
+        !triggered an issue in  insertion
+        d1 = [10, 2, -3, -4, 6, -6, 7, -8, 9, 0, 1, 20]
+        call sort( d1 )
+        call verify_sort( d1, ldummy, i )
         ltest = (ltest .and. ldummy)
 
     end subroutine test_int_sorts
@@ -634,7 +640,10 @@ contains
     subroutine test_int_sort_indexes( ltest )
         logical, intent(out) :: ltest
 
-        logical :: ldummy
+        integer(int64)              :: i
+        integer(int32), allocatable :: d1(:)
+        integer(int64), allocatable :: index(:)
+        logical                     :: ldummy
 
         ltest = .true.
 
@@ -655,6 +664,12 @@ contains
         call test_int_sort_index( rand3, "Random 3", ldummy )
         ltest = (ltest .and. ldummy)
         call test_int_sort_index( rand10, "Random 10", ldummy )
+        ltest = (ltest .and. ldummy)
+
+        d1 = [10, 2, -3, -4, 6, -6, 7, -8, 9, 0, 1, 20]
+        allocate( index(size(d1)) )
+        call sort_index( d1, index )
+        call verify_sort( d1, ldummy, i )
         ltest = (ltest .and. ldummy)
 
     end subroutine test_int_sort_indexes

--- a/src/tests/sorting/test_sorting.f90
+++ b/src/tests/sorting/test_sorting.f90
@@ -14,7 +14,7 @@ program test_sorting
     integer(int32), parameter :: char_size = 26**4
     integer(int32), parameter :: string_size = 26**3
     integer(int32), parameter :: block_size = test_size/6
-    integer, parameter        :: repeat = 8
+    integer, parameter        :: repeat = 1
 
     integer(int32) ::             &
         blocks(0:test_size-1),    &
@@ -201,6 +201,17 @@ contains
         ltest = (ltest .and. ldummy)
         call test_int_ord_sort( rand10, "Random 10", ldummy )
         ltest = (ltest .and. ldummy)
+
+
+        block
+        integer(int64) :: i
+        integer, allocatable :: d1(:)
+        d1 = [10, 2, -3, -4, 6, -6, 7, -8, 9, 0, 1, 20]
+        call ord_sort( d1)
+        call verify_sort( d1, ldummy, i )
+        ltest = (ltest .and. ldummy)
+        end block
+
 
     end subroutine test_int_ord_sorts
 


### PR DESCRIPTION
The option `-fcheck=all` of gfortran triggered a problem with the suboutine `insertion_sort`, when `i` becomes equal to `0`, and tried to access `array( i-1 )` (while the lower bound of `array` is `0`.

The solution copied what was already implemented in `stdlib_sorting_sort.fypp`.