### PR TITLE
added stdlib_math to specs/index.md

### DIFF
--- a/doc/specs/index.md
+++ b/doc/specs/index.md
@@ -17,6 +17,7 @@ This is and index/directory of the specifications (specs) for each new module/fe
  - [IO](./stdlib_io.html) - Input/output helper & convenience
  - [linalg](./stdlib_linalg.html) - Linear Algebra
  - [logger](./stdlib_logger.html) - Runtime logging system
+ - [math](./stdlib_math.html) - General purpose mathematical functions
  - [optval](./stdlib_optval.html) - Fallback value for optional arguments
  - [quadrature](./stdlib_quadrature.html) - Numerical integration
  - [stats](./stdlib_stats.html) - Descriptive Statistics


### PR DESCRIPTION
Added missing `stdlb_math` to doc/specs/index.md file.