### PR TITLE
stdlib_hash: waterhash algorithm

### DIFF
--- a/doc/specs/index.md
+++ b/doc/specs/index.md
@@ -14,6 +14,7 @@ This is and index/directory of the specifications (specs) for each new module/fe
  - [ascii](./stdlib_ascii.html) - Procedures for handling ASCII characters
  - [bitsets](./stdlib_bitsets.html) - Bitset data types and procedures
  - [error](./stdlib_error.html) - Catching and handling errors
+ - [hash](./stdlib_hash.html) - Hashing algorithms
  - [IO](./stdlib_io.html) - Input/output helper & convenience
  - [kinds](./stdlib_kinds.html) - Kind parameters
  - [linalg](./stdlib_linalg.html) - Linear Algebra

--- a/doc/specs/stdlib_hash.md
+++ b/doc/specs/stdlib_hash.md
@@ -1,0 +1,68 @@
+---
+title: Hashing algorithms
+...
+
+# The `stdlib_hash` module
+
+[TOC]
+
+
+## Introduction
+
+Hash functions to obtain a hashed value of the provided variable.
+
+
+## Available procedures
+
+
+#### `waterhash`
+
+Portation of the [waterhash algorithm](https://github.com/tommyettinger/waterhash) from C to Fortran.
+Waterhash provides a 32 bit hash using a single 64 bit seed.
+The original waterhash implementation is available under the terms of the Unlicense (public domain).
+
+#### Status
+
+Experimental
+
+#### Description
+
+Calculates the hash of an array of chars.
+
+#### Syntax
+
+`res = [[stdlib_hash(module):waterhash(interface)]] (var, seed)`
+
+#### Class
+
+Pure function.
+
+#### Argument
+
+- `var`: Shall be an rank one array of 8 bit wide integer values.
+         Intrinsic character types and [[stdlib_string_type(module):string_type(type)]]
+         values are implicitly converted with `transfer`.
+         It is an `intent(in)` argument.
+
+- `seed`: Shall be an intrinsic integer 64 bit wide integer. It is an `intent(in)` argument.
+
+#### Result value
+
+The result is an intrinsic integer 32 bit wide integer.
+
+
+#### Example
+
+```fortran
+program demo_waterhash
+    use stdlib_hash, only : waterhash
+    use stdlib_kinds, only : int8, int64
+    implicit none
+    integer(int64), parameter :: seed = 433494437_int64
+    integer(int8), parameter :: array(*) = &
+      [119_int8, 97_int8, 116_int8, 101_int8, 114_int8, &
+      &104_int8, 97_int8, 115_int8, 104_int8]
+    print '(z0.8)', waterhash(array, seed)  ! return "55EB744D"
+    print '(z0.8)', waterhash("Value", seed)  ! return "B5E5E913"
+ end program demo_waterhash
+```

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,6 +53,8 @@ fypp_f90("${fyppFlags}" "${fppFiles}" outFiles)
 
 set(SRC
     stdlib_error.f90
+    stdlib_hash.f90
+    stdlib_hash_waterhash.f90
     stdlib_kinds.f90
     stdlib_logger.f90
     stdlib_system.F90

--- a/src/Makefile.manual
+++ b/src/Makefile.manual
@@ -37,6 +37,8 @@ SRCFYPP = \
 
 SRC = f18estop.f90 \
       stdlib_error.f90 \
+      stdlib_hash.f90 \
+      stdlib_hash_waterhash.f90 \
       stdlib_specialfunctions.f90 \
       stdlib_specialfunctions_legendre.f90 \
       stdlib_io.f90 \
@@ -170,3 +172,5 @@ stdlib_linalg_outer_product.o: stdlib_linalg.o
 stdlib_stringlist_type.o: stdlib_string_type.o \
     stdlib_math.o \
 	stdlib_optval.o
+stdlib_hash.o: stdlib_kinds.o stdlib_string_type.o
+stdlib_hash_waterhash.o: stdlib_hash.o

--- a/src/stdlib_hash.f90
+++ b/src/stdlib_hash.f90
@@ -1,0 +1,64 @@
+! SPDX-Identifier: MIT
+
+!> Provides interfaces and implementations for hashing algorithms.
+!>
+!> The specification of this module is available [here](../page/specs/stdlib_hash.html).
+module stdlib_hash
+    use stdlib_kinds, only : i1 => int8, i2 => int16, i4 => int32, i8 => int64
+    use stdlib_string_type, only : string_type, char, len
+    implicit none
+    private
+
+    public :: waterhash
+
+
+    !> Version: experimental
+    !>
+    !> Waterhash function to obtain a hashed value of the provided variable
+    interface waterhash
+        pure module function waterhash_impl(p, seed) result(val)
+            integer(i1), intent(in) :: p(:)
+            integer(i8), intent(in) :: seed
+            integer(i4) :: val
+        end function waterhash_impl
+        module procedure :: waterhash_character
+        module procedure :: waterhash_string
+    end interface waterhash
+
+
+contains
+
+
+    !> Interface to the waterhash implementation for character scalars
+    pure function waterhash_character(var, seed) result(val)
+        !> Variable to hash
+        character(len=*), intent(in) :: var
+        !> Seed for the hashing function
+        integer(i8), intent(in) :: seed
+        !> Hash value
+        integer(i4) :: val
+
+        integer(i1), parameter :: t = 0_i1
+
+        val = waterhash(transfer(var, t, len(var)), seed)
+
+    end function waterhash_character
+
+
+    !> Interface to the waterhash implementation for character scalars
+    pure function waterhash_string(var, seed) result(val)
+        !> Variable to hash
+        type(string_type), intent(in) :: var
+        !> Seed for the hashing function
+        integer(i8), intent(in) :: seed
+        !> Hash value
+        integer(i4) :: val
+
+        integer(i1), parameter :: t = 0_i1
+
+        val = waterhash(transfer(char(var), t, len(var)), seed)
+
+    end function waterhash_string
+
+
+end module stdlib_hash

--- a/src/stdlib_hash_waterhash.f90
+++ b/src/stdlib_hash_waterhash.f90
@@ -1,0 +1,158 @@
+! This is free and unencumbered software released into the public domain.
+! SPDX-Identifier: Unlicense
+
+!> Provides implementations for the waterhash algorithm.
+submodule(stdlib_hash) stdlib_hash_waterhash
+    implicit none
+
+
+contains
+
+    !>```c
+    !>uint64_t r = A * B;
+    !>return r - (r >> 32);
+    !>```
+    pure function watermum(a, b) result(r)
+        integer(i8), intent(in) :: a, b
+        integer(i8) :: r
+        r = a * b
+        r = r - (ishft(r, -32))
+    end function watermum
+
+    !>```c
+    !>uint8_t v;
+    !>memcpy(&v, p, 1);
+    !>return v;
+    !>```
+    pure function waterr08(p) result(v)
+        integer(i1), intent(in) :: p(:)
+        integer(i8) :: v
+        integer(i1), parameter :: t = 0_i1
+        v = int(transfer(p(1:1), t), i8)
+    end function waterr08
+
+    !>```c
+    !>uint16_t v;
+    !>memcpy(&v, p, 2);
+    !>return v;
+    !>```
+    pure function waterr16(p) result(v)
+        integer(i1), intent(in) :: p(:)
+        integer(i8) :: v
+        integer(i2), parameter :: t = 0_i2
+        v = int(transfer(p(1:2), t), i8)
+    end function waterr16
+
+    !>```c
+    !>uint32_t v;
+    !>memcpy(&v, p, 4);
+    !>return v;
+    !>```
+    pure function waterr32(p) result(v)
+        integer(i1), intent(in) :: p(:)
+        integer(i8) :: v
+        integer(i4), parameter :: t = 0_i4
+        v = int(transfer(p(1:4), t), i8)
+    end function waterr32
+
+    !> Portation of the waterhash algorithm.
+    pure module function waterhash_impl(p, seed) result(val)
+        integer(i1), intent(in) :: p(:)
+        integer(i8), intent(in) :: seed
+        integer(i4) :: val
+        integer(i8) :: h
+
+        integer(i8), parameter :: waterp0 = int(z'a0761d65', i8), &
+            & waterp1 = int(z'e7037ed1', i8), waterp2 = int(z'8ebc6af1', i8), &
+            & waterp3 = int(z'589965cd', i8), waterp4 = int(z'1d8e4e27', i8), &
+            & waterp5 = int(z'eb44accb', i8)
+        integer :: i
+        integer :: len
+
+        len = size(p)
+        h = seed
+
+        i = 0
+        do
+            if (i + 16 > len) exit
+            h = watermum(watermum(ieor(waterr32(p(i+1:i+4)), waterp1), &
+                &                 ieor(waterr32(p(i+5:i+8)), waterp2)) + h, &
+                &        watermum(ieor(waterr32(p(i+9:i+12)), waterp3), &
+                &                 ieor(waterr32(p(i+13:i+16)), waterp4)))
+            i = i + 16
+        end do
+        h = h + waterp5
+
+        select case(iand(len, 15))
+        case(1)
+            h = watermum(ieor(waterp2, h), &
+                &        ieor(waterr08(p(i+1:i+1)), waterp1))
+        case(2)
+            h = watermum(ieor(waterp3, h), &
+                &        ieor(waterr16(p(i+1:i+2)), waterp4))
+        case(3)
+            h = watermum(ieor(waterr16(p(i+1:i+2)), h), &
+                &        ieor(waterr08(p(i+3:i+3)), waterp2))
+        case(4)
+            h = watermum(ieor(waterr16(p(i+1:i+2)), h), &
+                &        ieor(waterr16(p(i+3:i+4)), waterp3))
+        case(5)
+            h = watermum(ieor(waterr32(p(i+1:i+4)), h), &
+                &        ieor(waterr08(p(i+5:i+5)), waterp1))
+        case(6)
+            h = watermum(ieor(waterr32(p(i+1:i+4)), h), &
+                &        ieor(waterr16(p(i+5:i+6)), waterp1))
+        case(7)
+            h = watermum(ieor(waterr32(p(i+1:i+4)), h), &
+                &        ieor(ior(ishft(waterr16(p(i+5:i+6)), 8), waterr08(p(i+7:i+7))), &
+                &             waterp1))
+        case(8)
+            h = watermum(ieor(waterr32(p(i+1:i+4)), h), &
+                &        ieor(waterr32(p(i+5:i+8)), waterp0))
+        case(9)
+            h = ieor(watermum(ieor(waterr32(p(i+1:i+4)), h), &
+                &             ieor(waterr32(p(i+5:i+8)), waterp2)), &
+                &    watermum(ieor(h, waterp4), &
+                &             ieor(waterr08(p(i+9:i+9)), waterp3)))
+        case(10)
+            h = ieor(watermum(ieor(waterr32(p(i+1:i+4)), h), &
+                &             ieor(waterr32(p(i+5:i+8)), waterp2)), &
+                &    watermum(h, &
+                &             ieor(waterr16(p(i+9:i+10)), waterp3)))
+        case(11)
+            h = ieor(watermum(ieor(waterr32(p(i+1:i+4)), h), &
+                &             ieor(waterr32(p(i+5:i+8)), waterp2)), &
+                &    watermum(h, &
+                &             ieor(ior(ishft(waterr16(p(i+9:i+10)), 8), &
+                &                      waterr08(p(i+11:i+11))), &
+                &                  waterp3)))
+        case(12)
+            h = ieor(watermum(ieor(waterr32(p(i+1:i+4)), h), &
+                &             ieor(waterr32(p(i+5:i+8)), waterp2)), &
+                &    watermum(ieor(h, waterr32(p(i+9:i+12))), &
+                &             waterp4))
+        case(13)
+            h = ieor(watermum(ieor(waterr32(p(i+1:i+4)), h), &
+                &             ieor(waterr32(p(i+5:i+8)), waterp2)), &
+                &    watermum(ieor(h, waterr32(p(i+9:i+12))), &
+                &             ieor(waterr08(p(i+13:i+13)), waterp4)))
+        case(14)
+            h = ieor(watermum(ieor(waterr32(p(i+1:i+4)), h), &
+                &             ieor(waterr32(p(i+5:i+8)), waterp2)), &
+                &    watermum(ieor(h, waterr32(p(i+9:i+12))), &
+                &             ieor(waterr16(p(i+13:i+14)), waterp4)))
+        case(15)
+            h = ieor(watermum(ieor(waterr32(p(i+1:i+4)), h), &
+                &             ieor(waterr32(p(i+5:i+8)), waterp2)), &
+                &    watermum(ieor(h, waterr32(p(i+9:i+12))), &
+                &             ieor(ior(ishft(waterr16(p(i+13:i+14)), 8), &
+                &                      waterr08(p(i+15:i+15))), &
+                &                  waterp4)))
+        end select
+
+        h = ieor(h, ishft(h, 16)) * ieor(int(len, i8), waterp0)
+        val = transfer(h - ishft(h, -32), val)
+
+    end function waterhash_impl
+
+end submodule stdlib_hash_waterhash

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ endmacro(ADDTEST)
 
 add_subdirectory(ascii)
 add_subdirectory(bitsets)
+add_subdirectory(hash)
 add_subdirectory(io)
 add_subdirectory(linalg)
 add_subdirectory(logger)

--- a/src/tests/Makefile.manual
+++ b/src/tests/Makefile.manual
@@ -3,6 +3,7 @@
 all test clean:
 	$(MAKE) -f Makefile.manual --directory=ascii $@
 	$(MAKE) -f Makefile.manual --directory=bitsets $@
+	$(MAKE) -f Makefile.manual --directory=hash $@
 	$(MAKE) -f Makefile.manual --directory=io $@
 	$(MAKE) -f Makefile.manual --directory=logger $@
 	$(MAKE) -f Makefile.manual --directory=optval $@

--- a/src/tests/hash/CMakeLists.txt
+++ b/src/tests/hash/CMakeLists.txt
@@ -1,0 +1,1 @@
+ADDTEST(waterhash)

--- a/src/tests/hash/Makefile.manual
+++ b/src/tests/hash/Makefile.manual
@@ -1,0 +1,4 @@
+PROGS_SRC = test_waterhash.f90
+
+
+include ../Makefile.manual.test.mk

--- a/src/tests/hash/test_waterhash.f90
+++ b/src/tests/hash/test_waterhash.f90
@@ -1,0 +1,55 @@
+module waterhash_testing
+    use stdlib_error, only : check
+    use stdlib_hash, only : waterhash
+    use stdlib_kinds, only : i1 => int8, i4 => int32, i8 => int64
+    use stdlib_strings, only : to_string
+    implicit none
+contains
+
+    subroutine check_eq(actual, expected)
+        integer, intent(in) :: actual
+        integer, intent(in) :: expected
+        logical :: stat
+        character(len=:), allocatable :: message
+        stat = actual == expected
+
+        if (.not.stat) then
+            message = "Expected '"//to_string(expected)//"' but got '"//to_string(actual)//"'"
+        end if
+        call check(stat, msg=message)
+    end subroutine check_eq
+
+    subroutine test_waterhash
+        integer(i8), parameter :: seed = 433494437_i8
+        character(len=*), parameter :: string = "hashable-test-string"
+
+        call check_eq(waterhash("waterhash",  seed),  1441494093)
+        call check_eq(waterhash(string(1: 1), seed), -1365789813)
+        call check_eq(waterhash(string(1: 2), seed),   -54733720)
+        call check_eq(waterhash(string(1: 3), seed), -1376896642)
+        call check_eq(waterhash(string(1: 4), seed),  2049690556)
+        call check_eq(waterhash(string(1: 5), seed),  1902039650)
+        call check_eq(waterhash(string(1: 6), seed),  -125035208)
+        call check_eq(waterhash(string(1: 7), seed), -2091807725)
+        call check_eq(waterhash(string(1: 8), seed),  1300010631)
+        call check_eq(waterhash(string(1: 9), seed),   -65883164)
+        call check_eq(waterhash(string(1:10), seed),  -846809663)
+        call check_eq(waterhash(string(1:11), seed),  -684476212)
+        call check_eq(waterhash(string(1:12), seed),  1042663538)
+        call check_eq(waterhash(string(1:13), seed),  -801644260)
+        call check_eq(waterhash(string(1:14), seed),   657065214)
+        call check_eq(waterhash(string(1:15), seed), -1222082533)
+        call check_eq(waterhash(string(1:16), seed),    28708502)
+        call check_eq(waterhash(string(1:17), seed),   908144547)
+        call check_eq(waterhash(string(1:18), seed), -1615470564)
+        call check_eq(waterhash(string(1:19), seed),  -719426041)
+        call check_eq(waterhash(string(1:20), seed), -1564862690)
+     end subroutine test_waterhash
+end module waterhash_testing
+
+program test_driver
+    use waterhash_testing
+    implicit none
+
+    call test_waterhash
+end program test_driver


### PR DESCRIPTION
Implementation of [waterhash](https://github.com/tommyettinger/waterhash) algorithm. Returns a 32 bit hash using a 64 bit seed.

Fpm project available at [awvwgk/waterhash](https://github.com/awvwgk/waterhash) for review.