### PR TITLE
Fix CMake variable usage

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -62,7 +62,7 @@ jobs:
       run: >-
         cmake -Wdev
         -DCMAKE_BUILD_TYPE=Release
-        -DCMAKE_MAXIMUM_RANK=4
+        -DCMAKE_MAXIMUM_RANK:String=4
         -DCMAKE_INSTALL_PREFIX=$PWD/_dist
         -S . -B build
 
@@ -179,7 +179,7 @@ jobs:
       run: >-
          cmake -Wdev
          -DCMAKE_BUILD_TYPE=Release
-         -DCMAKE_MAXIMUM_RANK=4
+         -DCMAKE_MAXIMUM_RANK:String=4
          -DCMAKE_INSTALL_PREFIX=$PWD/_dist
          -S . -B build
 

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -64,7 +64,7 @@ jobs:
         -B build
         -DCMAKE_BUILD_TYPE=Debug
         -DCMAKE_Fortran_FLAGS_DEBUG="-Wall -Wextra -Wimplicit-interface -fPIC -g -fcheck=all -fbacktrace"
-        -DCMAKE_MAXIMUM_RANK=4
+        -DCMAKE_MAXIMUM_RANK:String=4
         -DCMAKE_INSTALL_PREFIX=$PWD/_dist
       env:
         FC: gfortran

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,9 @@ check_fortran_source_runs("i=0; error stop i; end" f18errorstop SRC_EXT f90)
 check_fortran_source_compiles("real, allocatable :: array(:, :, :, :, :, :, :, :, :, :); end" f03rank SRC_EXT f90)
 check_fortran_source_runs("use, intrinsic :: iso_fortran_env, only : real128; real(real128) :: x; x = x+1; end" f03real128)
 
-option(CMAKE_MAXIMUM_RANK "Maximum array rank for generated procedures" 4)
+if(NOT DEFINED CMAKE_MAXIMUM_RANK)
+  set(CMAKE_MAXIMUM_RANK 4 CACHE STRING "Maximum array rank for generated procedures")
+endif()
 
 # --- find preprocessor
 find_program(FYPP fypp)

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Important options are
 For example, to configure a build using the Ninja backend and generating procedures up to rank 7, which is installed to your home directory use
 
 ```sh
-cmake -B build -G Ninja -DCMAKE_MAXIMUM_RANK=7 -DCMAKE_INSTALL_PREFIX=$HOME/.local
+cmake -B build -G Ninja -DCMAKE_MAXIMUM_RANK:String=7 -DCMAKE_INSTALL_PREFIX=$HOME/.local
 ```
 
 To build the standard library run


### PR DESCRIPTION
`CMAKE_MAXIMUM_RANK` is now properly defined as a CMake cache variable of type string (even though it functions as an int). Thus, at configure time, it is passed on as `cmake -DCMAKE_MAXIMUM_RANK:String=7`, for instance.
I only changed the semantics of defining the variable -- use `set` instead of `option` -- and updated the README file and CI workflows accordingly.