### PR TITLE
implemented move_alloc for string_type

### DIFF
--- a/doc/specs/stdlib_string_type.md
+++ b/doc/specs/stdlib_string_type.md
@@ -1972,3 +1972,58 @@ program demo
   close(io)
 end program demo
 ```
+
+
+<!-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -->
+### move
+
+#### Description
+
+Moves the allocation from `from` to `to`, consequently deallocating `from` in this process.  
+If `from` is not allocated before execution, `to` gets deallocated by the process.  
+An unallocated string is equivalent to an empty string.
+
+#### Syntax
+
+`call [[stdlib_string_type(module):move(interface)]] (from, to)`
+
+#### Status
+
+Experimental
+
+#### Class
+
+Pure Subroutine.
+
+#### Argument
+
+- `from`: Character scalar or [[stdlib_string_type(module):string_type(type)]].
+  This argument is `intent(inout)`.
+- `to`: Character scalar or [[stdlib_string_type(module):string_type(type)]].
+  This argument is `intent(out)`.
+
+#### Example
+
+```fortran
+program demo
+  use stdlib_string_type, only : string_type, assignment(=), move
+  implicit none
+  type(string_type) :: from_string, to_string
+  character(len=:), allocatable :: from_char
+
+  from_string = "move this string"
+  from_char = "move this char"
+  ! from_string <-- "move this string"
+  ! from_char   <-- "move this char"
+  ! to_string   <-- "" (unallocated)
+
+  call move(from_string, to_string)
+  ! from_string <-- "" (unallocated)
+  ! to_string   <-- "move this string"
+
+  call move(from_char, to_string)
+  ! from_char <-- (unallocated)
+  ! to_string <-- "move this char"
+
+end program demo
+```

--- a/src/stdlib_string_type.fypp
+++ b/src/stdlib_string_type.fypp
@@ -206,6 +206,16 @@ module stdlib_string_type
         module procedure :: verify_char_string
     end interface verify
 
+    !> Version: experimental
+    !>
+    !> Moves the allocated character scalar from 'from' to 'to'
+    !> [Specifications](../page/specs/stdlib_string_type.html#move)
+    interface move
+        module procedure :: move_string_string
+        module procedure :: move_string_char
+        module procedure :: move_char_string
+    end interface move
+
     !> Lexically compare the order of two character sequences being greater,
     !> The left-hand side, the right-hand side or both character sequences can
     !> be represented by a string.
@@ -721,6 +731,35 @@ contains
 
     end function verify_char_string
 
+    !> Moves the allocated character scalar from 'from' to 'to'
+    !> No output
+    subroutine move_string_string(from, to)
+        type(string_type), intent(inout) :: from
+        type(string_type), intent(out) :: to
+
+        call move_alloc(from%raw, to%raw)
+
+    end subroutine move_string_string
+
+    !> Moves the allocated character scalar from 'from' to 'to'
+    !> No output
+    subroutine move_string_char(from, to)
+        type(string_type), intent(inout) :: from
+        character(len=:), intent(out), allocatable :: to
+
+        call move_alloc(from%raw, to)
+
+    end subroutine move_string_char
+
+    !> Moves the allocated character scalar from 'from' to 'to'
+    !> No output
+    subroutine move_char_string(from, to)
+        character(len=:), intent(inout), allocatable :: from
+        type(string_type), intent(out) :: to
+
+        call move_alloc(from, to%raw)
+
+    end subroutine move_char_string
 
     !> Compare two character sequences for being greater.
     !> In this version both character sequences are by a string.

--- a/src/stdlib_string_type.fypp
+++ b/src/stdlib_string_type.fypp
@@ -22,7 +22,7 @@ module stdlib_string_type
     public :: string_type
     public :: len, len_trim, trim, index, scan, verify, repeat, adjustr, adjustl
     public :: lgt, lge, llt, lle, char, ichar, iachar
-    public :: to_lower, to_upper, to_title, to_sentence, reverse
+    public :: to_lower, to_upper, to_title, to_sentence, reverse, move
     public :: assignment(=)
     public :: operator(>), operator(>=), operator(<), operator(<=)
     public :: operator(==), operator(/=), operator(//)

--- a/src/tests/string/test_string_intrinsic.f90
+++ b/src/tests/string/test_string_intrinsic.f90
@@ -463,6 +463,40 @@ contains
         call check(code == iachar("F"))
     end subroutine test_iachar
 
+    subroutine test_move
+        type(string_type) :: from_string
+        type(string_type) :: to_string
+        character(len=:), allocatable :: from_char
+
+        from_string = "Move This String"
+        from_char = "Move This Char"
+        call check(from_string == "Move This String" .and. to_string == "" .and. &
+                    & from_char == "Move This Char", "move: test_case 1")
+
+        ! string_type (allocated) --> string_type (not allocated)
+        call move(from_string, to_string)
+        call check(from_string == "" .and. to_string == "Move This String", "move: test_case 2")
+
+        ! character (allocated) --> string_type (not allocated)
+        call move(from_char, from_string)
+        call check(.not. allocated(from_char) .and. from_string == "Move This Char", &
+                    & "move: test_case 3")
+
+        ! string_type (allocated) --> character (not allocated)
+        call move(to_string, from_char)
+        call check(to_string == "" .and. from_char == "Move This String", "move: test_case 4")
+
+        ! character (allocated) --> string_type (allocated)
+        call move(from_char, from_string)
+        call check(.not. allocated(from_char) .and. from_string == "Move This String", &
+                    & "move: test_case 5")
+
+        ! character (allocated) --> string_type (allocated)
+        call move(from_char, from_string)
+        call check(.not. allocated(from_char) .and. from_string == "", "move: test_case 6")
+
+    end subroutine test_move
+
 end module test_string_intrinsic
 
 program tester
@@ -485,5 +519,6 @@ program tester
     call test_char
     call test_ichar
     call test_iachar
+    call test_move
 
 end program tester


### PR DESCRIPTION
Closes #449 

Tasks:

- [x] Implemented move
- [x] added test cases for move
- [x] documented newly created function
- [ ] Pure vs Elemental?
- [ ] Name of the function?: as of now it is named as `move`
- [ ] `move` if both arguments are of type `character(len=:)`?: `move_alloc` does the same thing **OR** should we consider renaming it from `move` to `move_alloc`.