### PR TITLE
Bug fix: Allocatable argument 'x' is not allocated #472

### DIFF
--- a/src/stdlib_math.fypp
+++ b/src/stdlib_math.fypp
@@ -50,7 +50,7 @@ module stdlib_math
         ${t1}$, intent(in) :: end
         integer, intent(in) :: n
 
-        ${t1}$ :: res(merge(n, 0, n > 0))
+        ${t1}$ :: res(max(n, 0))
       end function ${RName}$
     #:endfor
 
@@ -77,7 +77,7 @@ module stdlib_math
         ${t1}$, intent(in) :: end
         integer, intent(in) :: n
 
-        real(dp) :: res(merge(n, 0, n > 0))
+        real(dp) :: res(max(n, 0))
       end function ${RName}$
     #:endfor
 
@@ -127,7 +127,7 @@ module stdlib_math
       ${t1}$, intent(in) :: end
       integer, intent(in) :: n
 
-      ${t1}$ :: res(merge(n, 0, n > 0))
+      ${t1}$ :: res(max(n, 0))
     end function ${RName}$
   #:endfor
   #! Integer support
@@ -159,7 +159,7 @@ module stdlib_math
       integer, intent(in) :: n
       ${t1}$, intent(in) :: base
       ! real(${k1}$) endpoints + real(${k1}$) base = real(${k1}$) result
-      ${t1}$ :: res(merge(n, 0, n > 0))
+      ${t1}$ :: res(max(n, 0))
     end function ${RName}$
 
     #:set RName = rname("logspace", 1, t1, k1, "n_cbase")
@@ -169,7 +169,7 @@ module stdlib_math
       integer, intent(in) :: n
       complex(${k1}$), intent(in) :: base
       ! real(${k1}$) endpoints + complex(${k1}$) base = complex(${k1}$) result
-      ${t1}$ :: res(merge(n, 0, n > 0))
+      ${t1}$ :: res(max(n, 0))
     end function ${RName}$
 
     #:set RName = rname("logspace", 1, t1, k1, "n_ibase")
@@ -179,7 +179,7 @@ module stdlib_math
       integer, intent(in) :: n
       integer, intent(in) :: base
       ! real(${k1}$) endpoints + integer base = real(${k1}$) result
-      ${t1}$ :: res(merge(n, 0, n > 0))
+      ${t1}$ :: res(max(n, 0))
     end function ${RName}$
   #:endfor
   #! ========================================================
@@ -196,7 +196,7 @@ module stdlib_math
       integer, intent(in) :: n
       real(${k1}$), intent(in) :: base
       ! complex(${k1}$) endpoints + real(${k1}$) base = complex(${k1}$) result
-      ${t1}$ :: res(merge(n, 0, n > 0))
+      ${t1}$ :: res(max(n, 0))
     end function ${RName}$
 
     #:set RName = rname("logspace", 1, t1, k1, "n_cbase")
@@ -206,7 +206,7 @@ module stdlib_math
       integer, intent(in) :: n
       complex(${k1}$), intent(in) :: base
       ! complex(${k1}$) endpoints + complex(${k1}$) base = complex(${k1}$) result
-      ${t1}$ :: res(merge(n, 0, n > 0))
+      ${t1}$ :: res(max(n, 0))
     end function ${RName}$
 
     #:set RName = rname("logspace", 1, t1, k1, "n_ibase")
@@ -216,7 +216,7 @@ module stdlib_math
       integer, intent(in) :: n
       integer, intent(in) :: base
       ! complex(${k1}$) endpoints + integer base = complex(${k1}$) result
-      ${t1}$ :: res(merge(n, 0, n > 0))
+      ${t1}$ :: res(max(n, 0))
     end function ${RName}$
   #:endfor
   #! ========================================================
@@ -234,7 +234,7 @@ module stdlib_math
       integer, intent(in) :: n
       real(${k1}$), intent(in) :: base
       ! integer endpoints + real(${k1}$) base = real(${k1}$) result
-      real(${k1}$) :: res(merge(n, 0, n > 0))
+      real(${k1}$) :: res(max(n, 0))
     end function ${RName}$
 
     #:set RName = rname("logspace", 1, "integer(int32)", "int32", "n_c" + str(k1) + "base")
@@ -244,7 +244,7 @@ module stdlib_math
       integer, intent(in) :: n
       complex(${k1}$), intent(in) :: base
       ! integer endpoints + complex(${k1}$) base = complex(${k1}$) result
-      complex(${k1}$) :: res(merge(n, 0, n > 0))
+      complex(${k1}$) :: res(max(n, 0))
     end function ${RName}$
   #:endfor
 
@@ -255,7 +255,7 @@ module stdlib_math
       integer, intent(in) :: n
       integer, intent(in) :: base
       ! integer endpoints + integer base = integer result
-      integer :: res(merge(n, 0, n > 0))
+      integer :: res(max(n, 0))
     end function ${RName}$
 
 

--- a/src/stdlib_math.fypp
+++ b/src/stdlib_math.fypp
@@ -50,7 +50,7 @@ module stdlib_math
         ${t1}$, intent(in) :: end
         integer, intent(in) :: n
 
-        ${t1}$ :: res(n)
+        ${t1}$ :: res(merge(n, 0, n > 0))
       end function ${RName}$
     #:endfor
 
@@ -77,7 +77,7 @@ module stdlib_math
         ${t1}$, intent(in) :: end
         integer, intent(in) :: n
 
-        real(dp) :: res(n)
+        real(dp) :: res(merge(n, 0, n > 0))
       end function ${RName}$
     #:endfor
 
@@ -127,7 +127,7 @@ module stdlib_math
       ${t1}$, intent(in) :: end
       integer, intent(in) :: n
 
-      ${t1}$ :: res(n)
+      ${t1}$ :: res(merge(n, 0, n > 0))
     end function ${RName}$
   #:endfor
   #! Integer support
@@ -159,7 +159,7 @@ module stdlib_math
       integer, intent(in) :: n
       ${t1}$, intent(in) :: base
       ! real(${k1}$) endpoints + real(${k1}$) base = real(${k1}$) result
-      ${t1}$ :: res(n)
+      ${t1}$ :: res(merge(n, 0, n > 0))
     end function ${RName}$
 
     #:set RName = rname("logspace", 1, t1, k1, "n_cbase")
@@ -169,7 +169,7 @@ module stdlib_math
       integer, intent(in) :: n
       complex(${k1}$), intent(in) :: base
       ! real(${k1}$) endpoints + complex(${k1}$) base = complex(${k1}$) result
-      ${t1}$ :: res(n)
+      ${t1}$ :: res(merge(n, 0, n > 0))
     end function ${RName}$
 
     #:set RName = rname("logspace", 1, t1, k1, "n_ibase")
@@ -179,7 +179,7 @@ module stdlib_math
       integer, intent(in) :: n
       integer, intent(in) :: base
       ! real(${k1}$) endpoints + integer base = real(${k1}$) result
-      ${t1}$ :: res(n)
+      ${t1}$ :: res(merge(n, 0, n > 0))
     end function ${RName}$
   #:endfor
   #! ========================================================
@@ -196,7 +196,7 @@ module stdlib_math
       integer, intent(in) :: n
       real(${k1}$), intent(in) :: base
       ! complex(${k1}$) endpoints + real(${k1}$) base = complex(${k1}$) result
-      ${t1}$ :: res(n)
+      ${t1}$ :: res(merge(n, 0, n > 0))
     end function ${RName}$
 
     #:set RName = rname("logspace", 1, t1, k1, "n_cbase")
@@ -206,7 +206,7 @@ module stdlib_math
       integer, intent(in) :: n
       complex(${k1}$), intent(in) :: base
       ! complex(${k1}$) endpoints + complex(${k1}$) base = complex(${k1}$) result
-      ${t1}$ :: res(n)
+      ${t1}$ :: res(merge(n, 0, n > 0))
     end function ${RName}$
 
     #:set RName = rname("logspace", 1, t1, k1, "n_ibase")
@@ -216,7 +216,7 @@ module stdlib_math
       integer, intent(in) :: n
       integer, intent(in) :: base
       ! complex(${k1}$) endpoints + integer base = complex(${k1}$) result
-      ${t1}$ :: res(n)
+      ${t1}$ :: res(merge(n, 0, n > 0))
     end function ${RName}$
   #:endfor
   #! ========================================================
@@ -234,7 +234,7 @@ module stdlib_math
       integer, intent(in) :: n
       real(${k1}$), intent(in) :: base
       ! integer endpoints + real(${k1}$) base = real(${k1}$) result
-      real(${k1}$) :: res(n)
+      real(${k1}$) :: res(merge(n, 0, n > 0))
     end function ${RName}$
 
     #:set RName = rname("logspace", 1, "integer(int32)", "int32", "n_c" + str(k1) + "base")
@@ -244,7 +244,7 @@ module stdlib_math
       integer, intent(in) :: n
       complex(${k1}$), intent(in) :: base
       ! integer endpoints + complex(${k1}$) base = complex(${k1}$) result
-      complex(${k1}$) :: res(n)
+      complex(${k1}$) :: res(merge(n, 0, n > 0))
     end function ${RName}$
   #:endfor
 
@@ -255,7 +255,7 @@ module stdlib_math
       integer, intent(in) :: n
       integer, intent(in) :: base
       ! integer endpoints + integer base = integer result
-      integer :: res(n)
+      integer :: res(merge(n, 0, n > 0))
     end function ${RName}$
 
 

--- a/src/stdlib_math_linspace.fypp
+++ b/src/stdlib_math_linspace.fypp
@@ -25,7 +25,7 @@ contains
       ${t1}$, intent(in) :: end
       integer, intent(in) :: n
 
-      ${t1}$ :: res(merge(n, 0, n > 0))
+      ${t1}$ :: res(max(n, 0))
 
       integer :: i    ! Looping index
       ${t1}$ :: interval ! Difference between adjacent elements

--- a/src/stdlib_math_linspace.fypp
+++ b/src/stdlib_math_linspace.fypp
@@ -25,7 +25,7 @@ contains
       ${t1}$, intent(in) :: end
       integer, intent(in) :: n
 
-      ${t1}$ :: res(n)
+      ${t1}$ :: res(merge(n, 0, n > 0))
 
       integer :: i    ! Looping index
       ${t1}$ :: interval ! Difference between adjacent elements

--- a/src/stdlib_math_linspace.fypp
+++ b/src/stdlib_math_linspace.fypp
@@ -65,8 +65,8 @@ contains
       #:set RName = rname("linspace_n", 1, t1, k1)
       module procedure ${RName}$
 
-        real(${k1}$) :: x(n) ! array of the real part of complex number
-        real(${k1}$) :: y(n) ! array of the imaginary part of the complex number
+        real(${k1}$) :: x(max(n, 0)) ! array of the real part of complex number
+        real(${k1}$) :: y(max(n, 0)) ! array of the imaginary part of the complex number
 
         x = linspace(start%re, end%re, n)
         y = linspace(start%im, end%im, n)

--- a/src/stdlib_math_logspace.fypp
+++ b/src/stdlib_math_logspace.fypp
@@ -43,21 +43,21 @@ contains
   #:for k1, t1 in RC_KINDS_TYPES
     #:set RName = rname("logspace", 1, t1, k1, "n_rbase")
     module procedure ${RName}$
-      ${t1}$ :: exponents(n)
+      ${t1}$ :: exponents(merge(n, 0, n > 0))
       exponents = linspace(start, end, n)
       res = base ** exponents
     end procedure
 
     #:set RName = rname("logspace", 1, t1, k1, "n_cbase")
     module procedure ${RName}$
-      ${t1}$ :: exponents(n)
+      ${t1}$ :: exponents(merge(n, 0, n > 0))
       exponents = linspace(start, end, n)
       res = base ** exponents
     end procedure
 
     #:set RName = rname("logspace", 1, t1, k1, "n_ibase")
     module procedure ${RName}$
-      ${t1}$ :: exponents(n)
+      ${t1}$ :: exponents(merge(n, 0, n > 0))
       exponents = linspace(start, end, n)
       res = base ** exponents
     end procedure
@@ -69,14 +69,14 @@ contains
   #:for k1 in REAL_KINDS
     #:set RName = rname("logspace", 1, "integer(int32)", "int32", "n_r" + str(k1) + "base")
     module procedure ${RName}$
-      integer :: exponents(n)
+      integer :: exponents(merge(n, 0, n > 0))
       exponents = linspace(start, end, n)
       res = base ** exponents
     end procedure
 
     #:set RName = rname("logspace", 1, "integer(int32)", "int32", "n_c" + str(k1) + "base")
     module procedure ${RName}$
-      integer :: exponents(n)
+      integer :: exponents(merge(n, 0, n > 0))
       exponents = linspace(start, end, n)
       res = base ** exponents
     end procedure
@@ -84,7 +84,7 @@ contains
 
     #:set RName = rname("logspace", 1, "integer(int32)", "int32", "n_ibase")
     module procedure ${RName}$
-      integer :: exponents(n)
+      integer :: exponents(merge(n, 0, n > 0))
       exponents = linspace(start, end, n)
       res = base ** exponents
     end procedure

--- a/src/stdlib_math_logspace.fypp
+++ b/src/stdlib_math_logspace.fypp
@@ -43,21 +43,21 @@ contains
   #:for k1, t1 in RC_KINDS_TYPES
     #:set RName = rname("logspace", 1, t1, k1, "n_rbase")
     module procedure ${RName}$
-      ${t1}$ :: exponents(merge(n, 0, n > 0))
+      ${t1}$ :: exponents(max(n, 0))
       exponents = linspace(start, end, n)
       res = base ** exponents
     end procedure
 
     #:set RName = rname("logspace", 1, t1, k1, "n_cbase")
     module procedure ${RName}$
-      ${t1}$ :: exponents(merge(n, 0, n > 0))
+      ${t1}$ :: exponents(max(n, 0))
       exponents = linspace(start, end, n)
       res = base ** exponents
     end procedure
 
     #:set RName = rname("logspace", 1, t1, k1, "n_ibase")
     module procedure ${RName}$
-      ${t1}$ :: exponents(merge(n, 0, n > 0))
+      ${t1}$ :: exponents(max(n, 0))
       exponents = linspace(start, end, n)
       res = base ** exponents
     end procedure
@@ -69,14 +69,14 @@ contains
   #:for k1 in REAL_KINDS
     #:set RName = rname("logspace", 1, "integer(int32)", "int32", "n_r" + str(k1) + "base")
     module procedure ${RName}$
-      integer :: exponents(merge(n, 0, n > 0))
+      integer :: exponents(max(n, 0))
       exponents = linspace(start, end, n)
       res = base ** exponents
     end procedure
 
     #:set RName = rname("logspace", 1, "integer(int32)", "int32", "n_c" + str(k1) + "base")
     module procedure ${RName}$
-      integer :: exponents(merge(n, 0, n > 0))
+      integer :: exponents(max(n, 0))
       exponents = linspace(start, end, n)
       res = base ** exponents
     end procedure
@@ -84,7 +84,7 @@ contains
 
     #:set RName = rname("logspace", 1, "integer(int32)", "int32", "n_ibase")
     module procedure ${RName}$
-      integer :: exponents(merge(n, 0, n > 0))
+      integer :: exponents(max(n, 0))
       exponents = linspace(start, end, n)
       res = base ** exponents
     end procedure


### PR DESCRIPTION
There is a unreliable behaviour when dealing with negative size at runtime in GCC 11, this bug fix is addressing this issue.
```f90
program main
    implicit none
    real, allocatable :: x(:)

    x = compile_time()
    print*, allocated(x) ! T
    print*, size(x)      ! 0

    x = runtime(100)
    print*, allocated(x) ! T
    print*, size(x)      ! 100

    x = runtime(-100)
    print*, allocated(x) ! F -> this is a problem!
    print*, size(x)      ! 0

    x = runtime(0)
    print*, allocated(x) ! T
    print*, size(x)      ! 0

    x = fix_runtime(-100)
    print*, allocated(x) ! T
    print*, size(x)      ! 0

contains

    function compile_time() result(res)
        real :: res(-100)
    end function

    function runtime(n) result(res)
        integer, intent(in) :: n
        real :: res(n)
    end function

    function fix_runtime(n) result(res)
        integer, intent(in) :: n
        real :: res(merge(n, 0, n > 0))
    end function

end program
```