### PR TITLE
Update copyright and remove old artifact

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,1 +1,0 @@
-# Fortran stdlib contributors

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Fortran stdlib developers
+Copyright (c) 2019-2021 stdlib contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Small housekeeping PR.

* Updates the Copyright statement
* Removes an old and unused Markdown file

```
-Copyright (c) 2019 Fortran stdlib developers
+Copyright (c) 2019-2021 stdlib contributors
```

While I initially wrote "Fortran stdlib developers", I think "contributors" is more clear what it means--everybody who contributed code to stdlib.

Alternatively, this could also be just "Fortran-lang" as a whole, but I wasn't sure.

I request reviews because of this uncertainty, otherwise this is a straightforward PR.
