### PR TITLE
Make it clearer how the user can control compiler optimization

### DIFF
--- a/Makefile.manual
+++ b/Makefile.manual
@@ -1,8 +1,8 @@
 # Fortran stdlib Makefile
 
-FC = gfortran
-FFLAGS = -Wall -Wextra -Wimplicit-interface -fPIC -g -fcheck=all
-FYPPFLAGS=
+FC ?= gfortran
+FFLAGS ?= -Wall -Wextra -Wimplicit-interface -fPIC -g -fcheck=all
+FYPPFLAGS ?=
 
 export FC
 export FFLAGS

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ cmake -B build
 You can pass additional options to CMake to customize the build.
 Important options are
 
-- `-G Ninja` to use the Ninja backend instead of the default Make backend. This makes it easy to specify compiler flags for the build. Other build backends are available with a similar syntax.
+- `-G Ninja` to use the Ninja backend instead of the default Make backend. Other build backends are available with a similar syntax.
 - `-DCMAKE_INSTALL_PREFIX` is used to provide the install location for the library. If not provided the defaults will depend on your operating system, [see here](https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_PREFIX.html). 
 - `-DCMAKE_MAXIMUM_RANK` the maximum array rank procedures should be generated for.
   The default value is chosen as 4.

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Important options are
 For example, to configure a build using the Ninja backend while specifying compiler flags `FFLAGS`, generating procedures up to rank 7, and installing to your home directory, use
 
 ```sh
-export FFLAGS="-O3 -flto"
+export FFLAGS="-O3"
 cmake -B build -G Ninja -DCMAKE_MAXIMUM_RANK:String=7 -DCMAKE_INSTALL_PREFIX=$HOME/.local
 ```
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,10 @@ You can limit the maximum rank by setting ``-DMAXRANK=<num>`` in the ``FYPPFLAGS
 make -f Makefile.manual FYPPFLAGS=-DMAXRANK=4
 ```
 
-You can edit the compiler and its optimization flags by specifying the `FC` and `FFLAGS` variables in Makefile.manual. The default `FFLAGS` does not include any optimization, and you may want to add `-O3 -flto` to its definition. 
+You can also specify the compiler and compiler-flags by setting the ``FC`` and ``FFLAGS`` environmental variables. Among other things, this facilitates use of compiler optimizations that are not specified in the Makefile.manual defaults.
+```sh
+make -f Makefile.manual FYPPFLAGS=-DMAXRANK=4 FC=gfortran FFLAGS="-O3 -flto"
+```
 
 ### Build with [fortran-lang/fpm](https://github.com/fortran-lang/fpm)
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ cmake -B build
 You can pass additional options to CMake to customize the build.
 Important options are
 
-- `-G Ninja` to use the Ninja backend instead of the default Make backend. Other build backends are available with a similar syntax.
+- `-G Ninja` to use the Ninja backend instead of the default Make backend. This makes it easy to specify compiler flags for the build. Other build backends are available with a similar syntax.
 - `-DCMAKE_INSTALL_PREFIX` is used to provide the install location for the library. If not provided the defaults will depend on your operating system, [see here](https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_PREFIX.html). 
 - `-DCMAKE_MAXIMUM_RANK` the maximum array rank procedures should be generated for.
   The default value is chosen as 4.
@@ -134,9 +134,10 @@ Important options are
   Compiling with maximum rank 15 can be resource intensive and requires at least 16 GB of memory to allow parallel compilation or 4 GB memory for sequential compilation.
 - `-DBUILD_SHARED_LIBS` set to `on` in case you want link your application dynamically against the standard library (default: `off`).
 
-For example, to configure a build using the Ninja backend and generating procedures up to rank 7, which is installed to your home directory use
+For example, to configure a build using the Ninja backend while specifying compiler flags `FFLAGS`, generating procedures up to rank 7, and installing to your home directory, use
 
 ```sh
+export FFLAGS="-O3 -flto -fPIC"
 cmake -B build -G Ninja -DCMAKE_MAXIMUM_RANK:String=7 -DCMAKE_INSTALL_PREFIX=$HOME/.local
 ```
 
@@ -176,6 +177,8 @@ You can limit the maximum rank by setting ``-DMAXRANK=<num>`` in the ``FYPPFLAGS
 ```sh
 make -f Makefile.manual FYPPFLAGS=-DMAXRANK=4
 ```
+
+You can edit the compiler and its optimization flags by specifying the `FC` and `FFLAGS` variables in Makefile.manual. The default `FFLAGS` does not include any optimization, and you may want to add `-O3 -flto` to its definition. 
 
 ### Build with [fortran-lang/fpm](https://github.com/fortran-lang/fpm)
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ cmake --install build
 
 Now you have a working version of stdlib you can use for your project.
 
-If at some point you wish to recompile stdlib with different options, you might
+If at some point you wish to recompile `stdlib` with different options, you might
 want to delete the `build` folder. This will ensure that cached variables from
 earlier builds do not affect the new build.
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Important options are
 For example, to configure a build using the Ninja backend while specifying compiler flags `FFLAGS`, generating procedures up to rank 7, and installing to your home directory, use
 
 ```sh
-export FFLAGS="-O3 -flto -fPIC"
+export FFLAGS="-O3 -flto"
 cmake -B build -G Ninja -DCMAKE_MAXIMUM_RANK:String=7 -DCMAKE_INSTALL_PREFIX=$HOME/.local
 ```
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ cmake --install build
 
 Now you have a working version of stdlib you can use for your project.
 
+If at some point you wish to recompile stdlib with different options, you might
+want to delete the `build` folder. This will ensure that cached variables from
+earlier builds do not affect the new build.
+
 
 ### Build with make
 


### PR DESCRIPTION
These edits to the README attempt to offer simple guidance on compiling stdlib with optimization flags.

In this discussion [here](https://github.com/fortran-lang/stdlib/issues/524) it became clear that not everyone understands how to apply compiler optimizations to stdlib, although the discussion shows that is quite important for performance. 

I think some simple pointers would help users who do not have much experience with build tools (like me!).  