### PR TITLE
Bump stdlib version to 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Unreleased
 
+
+# Version 0.1.0
+
+Full release notes available at [v0.1.0] tag.
+
+[v0.1.0]: https://github.com/fortran-lang/stdlib/releases/tag/v0.1.0
+
 - new module `stdlib_ascii`
   [#32](https://github.com/fortran-lang/stdlib/pull/32)
 - new module `stdlib_bitsets`
@@ -20,19 +27,21 @@
 - new module `stdlib_linalg`
   - new procedures `diag`, `eye` and `trace`
     [#170](https://github.com/fortran-lang/stdlib/pull/170)
-  - new procedures `linspace` and `logspace`
-    [#420](https://github.com/fortran-lang/stdlib/pull/420)
   - new procedure `outer_product`
     [#432](https://github.com/fortran-lang/stdlib/pull/432)
-  - new procedure `arange`
-    [#480](https://github.com/fortran-lang/stdlib/pull/480)
 - new module `stdlib_logger`
-  - new derived type: `logger_type`
+  - new derived type `logger_type`
     [#228](https://github.com/fortran-lang/stdlib/pull/228)
     [#261](https://github.com/fortran-lang/stdlib/pull/261)
 - new module `stdlib_math`
   - new procedure `clip`
     [#355](https://github.com/fortran-lang/stdlib/pull/355)
+  - new procedures `linspace` and `logspace`
+    [#420](https://github.com/fortran-lang/stdlib/pull/420)
+  - new procedure `arange`
+    [#480](https://github.com/fortran-lang/stdlib/pull/480)
+  - new procedure `gcd`
+    [#539](https://github.com/fortran-lang/stdlib/pull/539)
 - new module `stdlib_optval`
   [#73](https://github.com/fortran-lang/stdlib/pull/73)
   [#96](https://github.com/fortran-lang/stdlib/pull/96)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14.0)
 project(fortran_stdlib
         LANGUAGES Fortran
-        VERSION 0
+        VERSION 0.1.0
         DESCRIPTION "Community driven and agreed upon de facto standard library for Fortran"
 )
 enable_testing()

--- a/ci/fpm.toml
+++ b/ci/fpm.toml
@@ -1,5 +1,5 @@
 name = "stdlib"
-version = "0.0.0"
+version = "0.1.0"
 license = "MIT"
 author = "stdlib contributors"
 maintainer = "@fortran-lang/stdlib"

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,0 +1,5 @@
+---
+title: Changelog
+---
+
+{!CHANGELOG.md!}


### PR DESCRIPTION
Create first release for stdlib. The release notes will be build from the current changelogs entries, feel free to suggests additions to the changelog. After this patch is merged, a new release will be tagged with `v0.1.0`.

*Features, proposals, and fixes that should be included in the first release of the Fortran standard library (0.1.0) should be added to the milestone [v0.1.0](https://github.com/fortran-lang/stdlib/milestone/1).*

Closes #292 
~~Requires #537~~