### PR TITLE
Fix string concat

### DIFF
--- a/src/stdlib_string_type.fypp
+++ b/src/stdlib_string_type.fypp
@@ -1082,7 +1082,7 @@ contains
         type(string_type), intent(in) :: rhs
         type(string_type) :: string
 
-        string%raw = maybe(rhs) // maybe(lhs)
+        string%raw = maybe(lhs) // maybe(rhs)
 
     end function concat_string_string
 

--- a/src/tests/string/test_string_operator.f90
+++ b/src/tests/string/test_string_operator.f90
@@ -103,9 +103,11 @@ contains
 
         a = "a"
         b = "b"
-        call check("a" //  b  == "ab")
-        call check( a  // "b" == "ab")
-        call check( a  //  b  == "ab")
+        call check( "a" //  b  == "ab" )
+        call check( a  // "b" == "ab" )
+        call check( a  //  b  == "ab" )
+        call check( a  //  ""  == "a" )
+        call check( ""  //  b  == "b" )
     end subroutine test_concat
 
 end module test_string_operator

--- a/src/tests/string/test_string_operator.f90
+++ b/src/tests/string/test_string_operator.f90
@@ -99,11 +99,13 @@ contains
     end subroutine test_ne
 
     subroutine test_concat
-        type(string_type) :: string
+        type(string_type) :: a, b
 
-        string = "Hello, "
-        string = string // "World!"
-        call check(len(string) == 13)
+        a = "a"
+        b = "b"
+        call check("a" //  b  == "ab")
+        call check( a  // "b" == "ab")
+        call check( a  //  b  == "ab")
     end subroutine test_concat
 
 end module test_string_operator


### PR DESCRIPTION
Found a bug in `string_type` concat where `lhs` and `rhs` were the wrong way around. Added proper tests and fixed it.