### PR TITLE
Make `linspace` and `logspace` pure functions

### DIFF
--- a/doc/specs/stdlib_math.md
+++ b/doc/specs/stdlib_math.md
@@ -152,7 +152,7 @@ Experimental
 
 #### Class
 
-Function.
+Pure function.
 
 #### Argument(s)
 
@@ -224,7 +224,7 @@ Experimental
 
 #### Class
 
-Function.
+Pure function.
 
 #### Argument(s)
 

--- a/src/stdlib_math.fypp
+++ b/src/stdlib_math.fypp
@@ -47,7 +47,7 @@ module stdlib_math
     !!([Specification](../page/specs/stdlib_math.html#linspace-create-a-linearly-spaced-rank-one-array))
     #:for k1, t1 in RC_KINDS_TYPES
       #:set RName = rname("linspace_default", 1, t1, k1)
-      module function ${RName}$(start, end) result(res)
+      pure module function ${RName}$(start, end) result(res)
         ${t1}$, intent(in) :: start
         ${t1}$, intent(in) :: end
 
@@ -57,7 +57,7 @@ module stdlib_math
 
     #:for k1, t1 in RC_KINDS_TYPES
       #:set RName = rname("linspace_n", 1, t1, k1)
-      module function ${RName}$(start, end, n) result(res)
+      pure module function ${RName}$(start, end, n) result(res)
         ${t1}$, intent(in) :: start
         ${t1}$, intent(in) :: end
         integer, intent(in) :: n
@@ -74,7 +74,7 @@ module stdlib_math
       #:set RName = rname("linspace_default", 1, t1, k1)
       #! The interface for INT_KINDS_TYPES cannot be combined with RC_KINDS_TYPES
       #! because the output for integer types is always a real with dp.
-      module function ${RName}$(start, end) result(res)
+      pure module function ${RName}$(start, end) result(res)
         ${t1}$, intent(in) :: start
         ${t1}$, intent(in) :: end
 
@@ -84,7 +84,7 @@ module stdlib_math
 
     #:for k1, t1 in INT_KINDS_TYPES
       #:set RName = rname("linspace_n", 1, t1, k1)
-      module function ${RName}$(start, end, n) result(res)
+      pure module function ${RName}$(start, end, n) result(res)
         ${t1}$, intent(in) :: start
         ${t1}$, intent(in) :: end
         integer, intent(in) :: n
@@ -109,7 +109,7 @@ module stdlib_math
   #!=========================================================
   #:for k1, t1 in RC_KINDS_TYPES
     #:set RName = rname("logspace", 1, t1, k1, "default")
-    module function ${RName}$(start, end) result(res)
+    pure module function ${RName}$(start, end) result(res)
 
       ${t1}$, intent(in) :: start
       ${t1}$, intent(in) :: end
@@ -120,7 +120,7 @@ module stdlib_math
   #:endfor
   #! Integer support
   #:set RName = rname("logspace", 1, "integer(int32)", "int32", "default")
-    module function ${RName}$(start, end) result(res)
+    pure module function ${RName}$(start, end) result(res)
 
       integer, intent(in) :: start
       integer, intent(in) :: end
@@ -134,7 +134,7 @@ module stdlib_math
   #!=========================================================
   #:for k1, t1 in RC_KINDS_TYPES
     #:set RName = rname("logspace", 1, t1, k1, "n")
-    module function ${RName}$(start, end, n) result(res)
+    pure module function ${RName}$(start, end, n) result(res)
       ${t1}$, intent(in) :: start
       ${t1}$, intent(in) :: end
       integer, intent(in) :: n
@@ -144,7 +144,7 @@ module stdlib_math
   #:endfor
   #! Integer support
   #:set RName = rname("logspace", 1, "integer(int32)", "int32", "n")
-    module function ${RName}$(start, end, n) result(res)
+    pure module function ${RName}$(start, end, n) result(res)
       integer, intent(in) :: start
       integer, intent(in) :: end
       integer, intent(in) :: n
@@ -165,7 +165,7 @@ module stdlib_math
     ! Different combinations of parameter types will lead to different result types.
     ! Those combinations are indicated in the body of each function.
     #:set RName = rname("logspace", 1, t1, k1, "n_rbase")
-    module function ${RName}$(start, end, n, base) result(res)
+    pure module function ${RName}$(start, end, n, base) result(res)
       ${t1}$, intent(in) :: start
       ${t1}$, intent(in) :: end
       integer, intent(in) :: n
@@ -175,7 +175,7 @@ module stdlib_math
     end function ${RName}$
 
     #:set RName = rname("logspace", 1, t1, k1, "n_cbase")
-    module function ${RName}$(start, end, n, base) result(res)
+    pure module function ${RName}$(start, end, n, base) result(res)
       ${t1}$, intent(in) :: start
       ${t1}$, intent(in) :: end
       integer, intent(in) :: n
@@ -185,7 +185,7 @@ module stdlib_math
     end function ${RName}$
 
     #:set RName = rname("logspace", 1, t1, k1, "n_ibase")
-    module function ${RName}$(start, end, n, base) result(res)
+    pure module function ${RName}$(start, end, n, base) result(res)
       ${t1}$, intent(in) :: start
       ${t1}$, intent(in) :: end
       integer, intent(in) :: n
@@ -202,7 +202,7 @@ module stdlib_math
     ! Different combinations of parameter types will lead to different result types.
     ! Those combinations are indicated in the body of each function.
     #:set RName = rname("logspace", 1, t1, k1, "n_rbase")
-    module function ${RName}$(start, end, n, base) result(res)
+    pure module function ${RName}$(start, end, n, base) result(res)
       ${t1}$, intent(in) :: start
       ${t1}$, intent(in) :: end
       integer, intent(in) :: n
@@ -212,7 +212,7 @@ module stdlib_math
     end function ${RName}$
 
     #:set RName = rname("logspace", 1, t1, k1, "n_cbase")
-    module function ${RName}$(start, end, n, base) result(res)
+    pure module function ${RName}$(start, end, n, base) result(res)
       ${t1}$, intent(in) :: start
       ${t1}$, intent(in) :: end
       integer, intent(in) :: n
@@ -222,7 +222,7 @@ module stdlib_math
     end function ${RName}$
 
     #:set RName = rname("logspace", 1, t1, k1, "n_ibase")
-    module function ${RName}$(start, end, n, base) result(res)
+    pure module function ${RName}$(start, end, n, base) result(res)
       ${t1}$, intent(in) :: start
       ${t1}$, intent(in) :: end
       integer, intent(in) :: n
@@ -240,7 +240,7 @@ module stdlib_math
     ! Those combinations are indicated in the body of each function.
   #:for k1 in REAL_KINDS
     #:set RName = rname("logspace", 1, "integer(int32)", "int32", "n_r" + str(k1) + "base")
-    module function ${RName}$(start, end, n, base) result(res)
+    pure module function ${RName}$(start, end, n, base) result(res)
       integer, intent(in) :: start
       integer, intent(in) :: end
       integer, intent(in) :: n
@@ -250,7 +250,7 @@ module stdlib_math
     end function ${RName}$
 
     #:set RName = rname("logspace", 1, "integer(int32)", "int32", "n_c" + str(k1) + "base")
-    module function ${RName}$(start, end, n, base) result(res)
+    pure module function ${RName}$(start, end, n, base) result(res)
       integer, intent(in) :: start
       integer, intent(in) :: end
       integer, intent(in) :: n
@@ -261,7 +261,7 @@ module stdlib_math
   #:endfor
 
     #:set RName = rname("logspace", 1, "integer(int32)", "int32", "n_ibase")
-    module function ${RName}$(start, end, n, base) result(res)
+    pure module function ${RName}$(start, end, n, base) result(res)
       integer, intent(in) :: start
       integer, intent(in) :: end
       integer, intent(in) :: n

--- a/src/stdlib_math_linspace.fypp
+++ b/src/stdlib_math_linspace.fypp
@@ -7,7 +7,7 @@ contains
 
   #:for k1, t1 in REAL_KINDS_TYPES
     #:set RName = rname("linspace_default", 1, t1, k1)
-    module function ${RName}$(start, end) result(res)
+    pure module function ${RName}$(start, end) result(res)
       ${t1}$, intent(in) :: start
       ${t1}$, intent(in) :: end
 
@@ -20,7 +20,7 @@ contains
 
   #:for k1, t1 in REAL_KINDS_TYPES
     #:set RName = rname("linspace_n", 1, t1, k1)
-    module function ${RName}$(start, end, n) result(res)
+    pure module function ${RName}$(start, end, n) result(res)
       ${t1}$, intent(in) :: start
       ${t1}$, intent(in) :: end
       integer, intent(in) :: n


### PR DESCRIPTION
While working on #504 I noticed that `linspace` and `logspace` in `stdlib_math` aren't declared as `pure`, even though they don't have side effects. This PR makes them `pure`.