### PR TITLE
Minor update `pure/elemental` in `string_type` module

### DIFF
--- a/doc/specs/stdlib_string_type.md
+++ b/doc/specs/stdlib_string_type.md
@@ -528,7 +528,7 @@ Return the character sequence represented by the string.
 
 #### Class
 
-Elemental function.
+Pure function.
 
 #### Argument
 
@@ -618,7 +618,7 @@ Return a substring from the character sequence of the string.
 
 #### Class
 
-Elemental function.
+Pure function.
 
 #### Argument
 

--- a/doc/specs/stdlib_string_type.md
+++ b/doc/specs/stdlib_string_type.md
@@ -528,7 +528,7 @@ Return the character sequence represented by the string.
 
 #### Class
 
-Pure function.
+Elemental function.
 
 #### Argument
 
@@ -618,7 +618,7 @@ Return a substring from the character sequence of the string.
 
 #### Class
 
-Pure function.
+Elemental function.
 
 #### Argument
 
@@ -1993,7 +1993,7 @@ An unallocated `string_type` instance is equivalent to an empty string.
 
 #### Class
 
-Pure Subroutine.
+Pure subroutine (Elemental subroutine, only when both `from` and `to` are `type(string_type)`)
 
 #### Argument
 

--- a/src/stdlib_string_type.fypp
+++ b/src/stdlib_string_type.fypp
@@ -438,7 +438,7 @@ contains
 
 
     !> Return the character sequence represented by the string.
-    elemental function char_string(string) result(character_string)
+    pure function char_string(string) result(character_string)
         type(string_type), intent(in) :: string
         character(len=len(string)) :: character_string
 
@@ -457,7 +457,7 @@ contains
     end function char_string_pos
 
     !> Return the character sequence represented by the string.
-    elemental function char_string_range(string, start, last) result(character_string)
+    pure function char_string_range(string, start, last) result(character_string)
         type(string_type), intent(in) :: string
         integer, intent(in) :: start
         integer, intent(in) :: last
@@ -1233,7 +1233,7 @@ contains
 
 
     !> Safely return the character sequences represented by the string
-    elemental function maybe(string) result(maybe_string)
+    pure function maybe(string) result(maybe_string)
         type(string_type), intent(in) :: string
         character(len=len(string)) :: maybe_string
         if (allocated(string%raw)) then

--- a/src/stdlib_string_type.fypp
+++ b/src/stdlib_string_type.fypp
@@ -52,18 +52,18 @@ module stdlib_string_type
 
     !> Constructor for new string instances
     interface string_type
-        pure elemental module function new_string(string) result(new)
+        elemental module function new_string(string) result(new)
             character(len=*), intent(in), optional :: string
             type(string_type) :: new
         end function new_string
         #:for kind in INT_KINDS
-        pure elemental module function new_string_from_integer_${kind}$(val) result(new)
+        elemental module function new_string_from_integer_${kind}$(val) result(new)
             integer(${kind}$), intent(in) :: val
             type(string_type) :: new
         end function new_string_from_integer_${kind}$
         #:endfor
         #:for kind in LOG_KINDS
-        pure elemental module function new_string_from_logical_${kind}$(val) result(new)
+        elemental module function new_string_from_logical_${kind}$(val) result(new)
             logical(${kind}$), intent(in) :: val
             type(string_type) :: new
         end function new_string_from_logical_${kind}$
@@ -438,7 +438,7 @@ contains
 
 
     !> Return the character sequence represented by the string.
-    pure function char_string(string) result(character_string)
+    elemental function char_string(string) result(character_string)
         type(string_type), intent(in) :: string
         character(len=len(string)) :: character_string
 
@@ -457,7 +457,7 @@ contains
     end function char_string_pos
 
     !> Return the character sequence represented by the string.
-    pure function char_string_range(string, start, last) result(character_string)
+    elemental function char_string_range(string, start, last) result(character_string)
         type(string_type), intent(in) :: string
         integer, intent(in) :: start
         integer, intent(in) :: last
@@ -678,7 +678,7 @@ contains
 
     !> Moves the allocated character scalar from 'from' to 'to'
     !> No output
-    subroutine move_string_string(from, to)
+    elemental subroutine move_string_string(from, to)
         type(string_type), intent(inout) :: from
         type(string_type), intent(out) :: to
 
@@ -688,7 +688,7 @@ contains
 
     !> Moves the allocated character scalar from 'from' to 'to'
     !> No output
-    subroutine move_string_char(from, to)
+    pure subroutine move_string_char(from, to)
         type(string_type), intent(inout) :: from
         character(len=:), intent(out), allocatable :: to
 
@@ -698,7 +698,7 @@ contains
 
     !> Moves the allocated character scalar from 'from' to 'to'
     !> No output
-    subroutine move_char_string(from, to)
+    pure subroutine move_char_string(from, to)
         character(len=:), intent(inout), allocatable :: from
         type(string_type), intent(out) :: to
 
@@ -708,7 +708,7 @@ contains
 
     !> Moves the allocated character scalar from 'from' to 'to'
     !> No output
-    subroutine move_char_char(from, to)
+    pure subroutine move_char_char(from, to)
         character(len=:), intent(inout), allocatable :: from
         character(len=:), intent(out), allocatable :: to
 
@@ -1233,7 +1233,7 @@ contains
 
 
     !> Safely return the character sequences represented by the string
-    pure function maybe(string) result(maybe_string)
+    elemental function maybe(string) result(maybe_string)
         type(string_type), intent(in) :: string
         character(len=len(string)) :: maybe_string
         if (allocated(string%raw)) then

--- a/src/tests/string/test_string_intrinsic.f90
+++ b/src/tests/string/test_string_intrinsic.f90
@@ -667,9 +667,11 @@ contains
         !> Error handling
         type(error_type), allocatable, intent(out) :: error
         type(string_type) :: from_string, to_string
+        type(string_type) :: from_strings(2), to_strings(2)
         character(len=:), allocatable :: from_char, to_char
 
         from_string = "Move This String"
+        from_strings = "Move This String"
         from_char = "Move This Char"
         call check(error, from_string == "Move This String" .and. to_string == "" .and. &
             & from_char == "Move This Char" .and. .not. allocated(to_char), &
@@ -713,7 +715,11 @@ contains
         ! string_type (allocated) --> string_type (allocated)
         call move(from_string, from_string)
         call check(error, from_string == "", "move: test_case 8")
-
+        if (allocated(error)) return
+        
+        ! elemental: string_type (allocated) --> string_type (not allocated)
+        call move(from_strings, to_strings)
+        call check(error, all(from_strings(:) == "") .and. all(to_strings(:) == "Move This String"), "move: test_case 9")
     end subroutine test_move
 
 end module test_string_intrinsic


### PR DESCRIPTION
- [x] `pure elemental -> elemental`: ✔
- interface `string_type` procedure
  - `new_string`
  - `new_string_from_integer`
  - `new_string_from_logical`
- [x] ~~`pure -> elemental`: ❓(Update: ❌)~~
- ~~interface `char` procedure~~
  - ~~`char_string`~~
  - ~~`char_string_range`~~
- ~~private function `maybe`~~
- [x] add `elemental`: ❓(Update: ✔)
- interface `move` procedure
  - `move_string_string`
- [x] add `pure`: ✔
- interface `move` procedure
  - `move_char_string`
  - `move_char_string`
  - `move_char_char`

#### Description
Here I have updated the elemental attributes of the routine. There are two areas that are doubtful ❓, but I think they can be `elemental`.

#### Another proposal

There is another issue. 
`string_type` interface relies on the `to_string` routine, it can convert `character`, `integer`, and `logical` variables into strings and **be elemental** because `type(string_type)` can be non-allocatable, but it does not support the `format` argument. 
While `to_string` supports `integer`, `real`, `complex` and `logical` types, support `format` argument, but not elemental.

`string_type` seems to have a **elemental advantage** to construct strings. It seems that we can take advantage of this and let `string_type` add support for `real` and `complex` types, and support the `format` argument?