### PR TITLE
Hotfix for fpm deployment and manual makefile

### DIFF
--- a/ci/fpm.toml
+++ b/ci/fpm.toml
@@ -7,3 +7,4 @@ copyright = "2019-2021 stdlib contributors"
 
 [dev-dependencies]
 test-drive.git = "https://github.com/fortran-lang/test-drive"
+test-drive.rev = "6f56c059c26715eab56f0ac85b400c1a6007fb88"

--- a/src/tests/Makefile.manual
+++ b/src/tests/Makefile.manual
@@ -9,7 +9,7 @@ FETCH = curl -L
 all test:: $(LIB)
 
 testdrive.F90:
-	$(FETCH) https://github.com/fortran-lang/test-drive/raw/main/src/testdrive.F90 > $@
+	$(FETCH) https://github.com/fortran-lang/test-drive/raw/6f56c059c26715eab56f0ac85b400c1a6007fb88/src/testdrive.F90 > $@
 
 all test clean::
 	$(MAKE) -f Makefile.manual --directory=ascii $@


### PR DESCRIPTION
Sorry for the mess, my patch for test-drive (https://github.com/fortran-lang/test-drive/pull/8) accidentally broke the fpm deployment and the manual makefile build.

This is a hotfix to work around this issue until we decided on https://github.com/fortran-lang/stdlib/pull/565.