### PR TITLE
Update error in case fypp preprocessor is not found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ endif()
 # --- find preprocessor
 find_program(FYPP fypp)
 if(NOT FYPP)
-  message(FATAL_ERROR "Preprocessor fypp not found!")
+  message(FATAL_ERROR "Preprocessor fypp not found! Please install fypp following the instructions in https://fypp.readthedocs.io/en/stable/fypp.html#installing")
 endif()
 
 add_subdirectory(src)


### PR DESCRIPTION
<!--
Thank you for contributing to stdlib.
To help us get your pull request merged more quickly, please consider reviewing any of the already open pull requests.
-->
Provide a better error message in case the fypp preprocessor cannot be found by CMake. Point the user to the installation instructions at https://fypp.readthedocs.io/en/stable/fypp.html#installing