### PR TITLE
Error on no tests in CTest

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,10 +43,6 @@ jobs:
       with:
         python-version: 3.x
 
-    - name: Install CMake Linux
-      if: contains(matrix.os, 'ubuntu')
-      run: ci/install_cmake.sh
-
     - name: Install fypp
       run: pip install --upgrade fypp
 
@@ -85,7 +81,12 @@ jobs:
 
     - name: test
       if: ${{ contains(matrix.build, 'cmake') }}
-      run: ctest --test-dir ${{ env.BUILD_DIR }} --parallel --output-on-failure
+      run: >-
+        ctest
+        --test-dir ${{ env.BUILD_DIR }}
+        --parallel
+        --output-on-failure
+        --no-tests=error
 
     - name: Install project
       if: ${{ contains(matrix.build, 'cmake') }}
@@ -122,10 +123,6 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.x
-
-    - name: Install CMake Linux
-      if: contains(matrix.os, 'ubuntu')
-      run: ci/install_cmake.sh
 
     - name: Prepare for cache restore (OSX)
       if: contains(matrix.os, 'macos')
@@ -197,7 +194,7 @@ jobs:
       if: failure()
 
     - name: test
-      run: ctest --parallel --output-on-failure
+      run: ctest --parallel --output-on-failure --no-tests=error
       working-directory: build
 
     - name: Install project

--- a/ci/install_cmake.sh
+++ b/ci/install_cmake.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -ex
-
-wget -qO- https://github.com/Kitware/CMake/releases/download/v3.16.3/cmake-3.16.3-Linux-x86_64.tar.gz | sudo tar xz --strip=1 -C /usr/local/
-which cmake
-cmake --version


### PR DESCRIPTION
<!--
Thank you for contributing to stdlib.
To help us get your pull request merged more quickly, please consider reviewing any of the already open pull requests.
-->
We are currently pinning CMake to version 3.16 in our CI, which doesn't allow to raise an error in case CTest doesn't find any tests. Unless there is a particular reason to test with CMake 3.16, we can use this PR to use the preinstalled CMake 3.22 version.

Closes #587 