### PR TITLE
Update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Unreleased
 
+Features available from the latest git source
+
+- new module `stdlib_distribution_uniform`
+  [#272](https://github.com/fortran-lang/stdlib/pull/272)
+- new module `stdlib_selection`
+  [#500](https://github.com/fortran-lang/stdlib/pull/500)
+  - new procedures `select`, `arg_select`
+- new module `stdlib_version`
+  [#579](https://github.com/fortran-lang/stdlib/pull/579)
+  - new procedure `get_stdlib_version`
+- new module `stdlib_io_npy`
+  [#581](https://github.com/fortran-lang/stdlib/pull/581)
+  - new procedures `save_npy`, `load_npy`
+
+Changes to existing modules
+
+- change in module `stdlib_math`
+  - `linspace` and `logspace` made pure
+    [#549](https://github.com/fortran-lang/stdlib/pull/549)
+- change in module `stdlib_string_type`
+  - `move` procedure made *pure*/*elemental*
+    [#562](https://github.com/fortran-lang/stdlib/pull/562)
+- support for quadruple precision made optional
+  [#565](https://github.com/fortran-lang/stdlib/pull/565)
+
 
 # Version 0.1.0
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,8 @@ You are welcome to propose changes to the workflow by
 * Smaller PRs are better than large PRs, and will lead to a shorter review and
   merge cycle.
 * Add tests for your feature or bug fix to be sure that it stays functional and useful.
+* Include new features and changes in the
+  [CHANGELOG](https://github.com/fortran-lang/stdlib/blob/master/CHANGELOG.md)
 * Be open to constructive criticism and requests for improving your code.
 * Again, please follow the
   [Fortran stdlib style guide](https://github.com/fortran-lang/stdlib/blob/master/STYLE_GUIDE.md).


### PR DESCRIPTION
<!--
Thank you for contributing to stdlib.
To help us get your pull request merged more quickly, please consider reviewing any of the already open pull requests.
-->
Should we require every PR to add an entry to the changelog as well? This way we avoid a lot of work collecting those before a new release and also keep the changelog an up-to-date source of new features in stdlib.

Note: I just realized I should have added the npy format to the changelog after I hit the merge button