### PR TITLE
Minor update to makefile installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ make -f Makefile.manual ADD_FYPPFLAGS=-DMAXRANK=4
 
 You can also specify the compiler and compiler-flags by setting the ``FC`` and ``FFLAGS`` environmental variables. Among other things, this facilitates use of compiler optimizations that are not specified in the Makefile.manual defaults.
 ```sh
-make -f Makefile.manual ADD_FYPPFLAGS=-DMAXRANK=4 FC=gfortran FFLAGS="-O3"
+make -f Makefile.manual ADD_FYPPFLAGS=-DMAXRANK=4 FC=gfortran FFLAGS="-O3 "
 ```
 
 ### Build with [fortran-lang/fpm](https://github.com/fortran-lang/fpm)

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ make -f Makefile.manual ADD_FYPPFLAGS=-DMAXRANK=4
 
 You can also specify the compiler and compiler-flags by setting the ``FC`` and ``FFLAGS`` environmental variables. Among other things, this facilitates use of compiler optimizations that are not specified in the Makefile.manual defaults.
 ```sh
-make -f Makefile.manual ADD_FYPPFLAGS=-DMAXRANK=4 FC=gfortran FFLAGS="-O3 -flto"
+make -f Makefile.manual ADD_FYPPFLAGS=-DMAXRANK=4 FC=gfortran FFLAGS="-O3"
 ```
 
 ### Build with [fortran-lang/fpm](https://github.com/fortran-lang/fpm)

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ make -f Makefile.manual ADD_FYPPFLAGS=-DMAXRANK=4
 
 You can also specify the compiler and compiler-flags by setting the ``FC`` and ``FFLAGS`` environmental variables. Among other things, this facilitates use of compiler optimizations that are not specified in the Makefile.manual defaults.
 ```sh
-make -f Makefile.manual ADD_FYPPFLAGS=-DMAXRANK=4 FC=gfortran FFLAGS="-O3 "
+make -f Makefile.manual ADD_FYPPFLAGS=-DMAXRANK=4 FC=gfortran FFLAGS="-O3"
 ```
 
 ### Build with [fortran-lang/fpm](https://github.com/fortran-lang/fpm)


### PR DESCRIPTION
This removes the use of the option `-flto` in the instructions to compile with a Makefile.

The reason for doing that is that currently, `-flto` can cause some tests to break - see [discussion here](https://github.com/fortran-lang/stdlib/issues/592#issuecomment-991863294).

Note -- this pull request initially had a failing github test. But that issue must be unrelated to this commit, because the changes here only affect README.md