### PR TITLE
Rename references to default branch

### DIFF
--- a/API-doc-FORD-file.md
+++ b/API-doc-FORD-file.md
@@ -28,7 +28,7 @@ extra_mods: iso_fortran_env:https://gcc.gnu.org/onlinedocs/gfortran/ISO_005fFORT
 print_creation_date: true
 creation_date: %Y-%m-%d %H:%M %z
 project_github: https://github.com/fortran-lang/stdlib
-project_download: https://github.com/fortran-lang/stdlib/archive/master.zip
+project_download: https://github.com/fortran-lang/stdlib/archive/HEAD.zip
 project_website: https://stdlib.fortran-lang.org
 favicon: doc/media/favicon.ico
 license: by-sa
@@ -57,7 +57,7 @@ The documentation for comment markup in source code, running [FORD] and the [FOR
 
 [FORD]: https://github.com/Fortran-FOSS-Programmers/ford#readme
 [FORD wiki]: https://github.com/Fortran-FOSS-Programmers/ford/wiki
-[FORD project file]: https://github.com/fortran-lang/stdlib/blob/master/API-doc-FORD-file.md
+[FORD project file]: https://github.com/fortran-lang/stdlib/blob/HEAD/API-doc-FORD-file.md
 
 Goals and Motivation
 ====================

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ requests.
 
 By contributing to *stdlib*, you certify that you own or are allowed to share the
 content of your contribution under the
-[stdlib license](https://github.com/fortran-lang/stdlib/blob/master/LICENSE).
+[stdlib license](https://github.com/fortran-lang/stdlib/blob/HEAD/LICENSE).
 
 * [Style](#style)
 * [Reporting a bug](#reporting-a-bug)
@@ -22,7 +22,7 @@ content of your contribution under the
 ## Style
 
 Please follow the
-[Fortran stdlib style guide](https://github.com/fortran-lang/stdlib/blob/master/STYLE_GUIDE.md)
+[Fortran stdlib style guide](https://github.com/fortran-lang/stdlib/blob/HEAD/STYLE_GUIDE.md)
 for any Fortran code that you contribute.
 This allows the community to focus on substance rather than style.
 
@@ -42,7 +42,7 @@ Before opening a bug report:
 1. Check if the issue has already been reported
    ([issues](https://github.com/fortran-lang/stdlib/issues)).
 2. Check if it is still an issue or it has been fixed?
-   Try to reproduce it with the latest version from the master branch.
+   Try to reproduce it with the latest version from the default branch.
 3. Isolate the problem and create a minimal test case.
 
 A good bug report should include all information needed to reproduce the bug.
@@ -74,7 +74,7 @@ It is quite possible we have not considered such solutions yet.
 ## Workflow
 
 The general workflow is documented in
-[this document](https://github.com/fortran-lang/stdlib/blob/master/WORKFLOW.md)
+[this document](https://github.com/fortran-lang/stdlib/blob/HEAD/WORKFLOW.md)
 
 The workflow guide is a living document.
 You are welcome to propose changes to the workflow by
@@ -91,7 +91,7 @@ You are welcome to propose changes to the workflow by
 * Add tests for your feature or bug fix to be sure that it stays functional and useful.
 * Be open to constructive criticism and requests for improving your code.
 * Again, please follow the
-  [Fortran stdlib style guide](https://github.com/fortran-lang/stdlib/blob/master/STYLE_GUIDE.md).
+  [Fortran stdlib style guide](https://github.com/fortran-lang/stdlib/blob/HEAD/STYLE_GUIDE.md).
 
 
 ## For new contributors

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -81,7 +81,7 @@ The following two sections are most relevant for contributing new code:
 
 To write the "spec" (specification) for a new proposal, please place it in the
 [FORD "pages"](https://github.com/Fortran-FOSS-Programmers/ford/wiki/Writing-Pages) directory at
-[`doc/specs/`](https://github.com/fortran-lang/stdlib/tree/master/doc/specs).
+[`doc/specs/`](https://github.com/fortran-lang/stdlib/tree/HEAD/doc/specs).
 To get help please see the ["Writing Pages"](https://github.com/Fortran-FOSS-Programmers/ford/wiki/Writing-Pages)
 and ["Writing Documentation"](https://github.com/Fortran-FOSS-Programmers/ford/wiki/Writing-Documentation) pages
 on the [FORD wiki](https://github.com/Fortran-FOSS-Programmers/ford/wiki).

--- a/src/stdlib_selection.fypp
+++ b/src/stdlib_selection.fypp
@@ -6,7 +6,7 @@
 module stdlib_selection
 !
 ! This code was modified from the "Coretran" implementation "quickSelect" by
-! Leon Foks, https://github.com/leonfoks/coretran/tree/master/src/sorting
+! Leon Foks, https://github.com/leonfoks/coretran/tree/HEAD/src/sorting
 !
 ! Leon Foks gave permission to release this code under stdlib's MIT license.
 ! (https://github.com/fortran-lang/stdlib/pull/500#commitcomment-57418593)


### PR DESCRIPTION
- use HEAD to reference latest commit, which is independent of branch name
