### PR TITLE
Add getline to read whole line from formatted unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Features available from the latest git source
 - new module `stdlib_version`
   [#579](https://github.com/fortran-lang/stdlib/pull/579)
   - new procedure `get_stdlib_version`
+- update module `stdlib_io`
+  [597](https://github.com/fortran-lang/stdlib/pull/597)
+  - new procedure `getline`
 - new module `stdlib_io_npy`
   [#581](https://github.com/fortran-lang/stdlib/pull/581)
   - new procedures `save_npy`, `load_npy`

--- a/doc/specs/stdlib_io.md
+++ b/doc/specs/stdlib_io.md
@@ -223,3 +223,51 @@ program demo_savenpy
     call save_npy('example.npy', x)
 end program demo_savenpy
 ```
+
+## `getline`
+
+### Status
+
+Experimental
+
+### Description
+
+Read a whole line from a formatted unit into a string variable
+
+### Syntax
+
+`call [[stdlib_io(module):getline(interface)]](unit, line[, iostat][, iomsg])`
+
+### Arguments
+
+`unit`: Formatted input unit.
+        This argument is `intent(in)`.
+
+`line`: Deferred length character or `string_type` variable.
+        This argument is `intent(out)`.
+
+`iostat`: Default integer, contains status of reading from unit, zero in case of success.
+          It is an optional argument, in case not present the program will halt for non-zero status.
+          This argument is `intent(out)`.
+
+`iomsg`: Deferred length character value, contains error message in case `iostat` is non-zero.
+         It is an optional argument, error message will be dropped if not present.
+         This argument is `intent(out)`.
+
+### Example
+
+```fortran
+program demo_getline
+    use, intrinsic :: iso_fortran_env, only : input_unit, output_unit
+    use stdlib_io, only: getline
+    implicit none
+    character(len=:), allocatable :: line
+    integer :: stat
+
+    call getline(input_unit, line, stat)
+    do while(stat == 0)
+      write(output_unit, '(a)') line
+      call getline(input_unit, line, stat)
+    end do
+end program demo_getline
+```

--- a/doc/specs/stdlib_io.md
+++ b/doc/specs/stdlib_io.md
@@ -236,12 +236,14 @@ Read a whole line from a formatted unit into a string variable
 
 ### Syntax
 
-`call [[stdlib_io(module):getline(interface)]](unit, line[, iostat][, iomsg])`
+`call [[stdlib_io(module):getline(interface)]] (unit, line[, iostat][, iomsg])`
+`call [[stdlib_io(module):getline(interface)]] (line[, iostat][, iomsg])`
 
 ### Arguments
 
 `unit`: Formatted input unit.
         This argument is `intent(in)`.
+        If `unit` is not specified standard input is used.
 
 `line`: Deferred length character or `string_type` variable.
         This argument is `intent(out)`.

--- a/src/Makefile.manual
+++ b/src/Makefile.manual
@@ -92,6 +92,7 @@ stdlib_io.o: \
     stdlib_error.o \
     stdlib_optval.o \
     stdlib_kinds.o \
+    stdlib_string_type.o \
     stdlib_ascii.o
 stdlib_io_npy.o: \
     stdlib_kinds.o

--- a/src/stdlib_io.fypp
+++ b/src/stdlib_io.fypp
@@ -357,7 +357,7 @@ contains
     character(len=bufsize) :: buffer, msg
     integer :: chunk, stat
 
-    allocate(character(len=0) :: line)
+    line = ""
     do
       read(unit, '(a)', advance='no', iostat=stat, iomsg=msg, size=chunk) buffer
       if (stat > 0) exit

--- a/src/stdlib_io.fypp
+++ b/src/stdlib_io.fypp
@@ -11,10 +11,11 @@ module stdlib_io
   use stdlib_error, only: error_stop
   use stdlib_optval, only: optval
   use stdlib_ascii, only: is_blank
+  use stdlib_string_type, only : string_type
   implicit none
   private
   ! Public API
-  public :: loadtxt, savetxt, open
+  public :: loadtxt, savetxt, open, getline
 
   ! Private API that is exposed so that we can test it in tests
   public :: parse_mode
@@ -30,6 +31,14 @@ module stdlib_io
     FMT_COMPLEX_DP = '(*(es24.16e3,1x,es24.16e3))', &
     FMT_COMPLEX_XDP = '(*(es26.18e3,1x,es26.18e3))', &
     FMT_COMPLEX_QP = '(*(es44.35e4,1x,es44.35e4))'
+
+  !> Version: experimental
+  !>
+  !> Read a whole line from a formatted unit into a string variable
+  interface getline
+    module procedure :: getline_char
+    module procedure :: getline_string
+  end interface getline
 
   interface loadtxt
     !! version: experimental
@@ -330,5 +339,60 @@ contains
     end do
 
   end function parse_mode
+
+  !> Version: experimental
+  !>
+  !> Read a whole line from a formatted unit into a deferred length character variable
+  subroutine getline_char(unit, line, iostat, iomsg)
+    !> Formatted IO unit
+    integer, intent(in) :: unit
+    !> Line to read
+    character(len=:), allocatable, intent(out) :: line
+    !> Status of operation
+    integer, intent(out), optional :: iostat
+    !> Error message
+    character(len=:), allocatable, optional :: iomsg
+
+    integer, parameter :: bufsize = 512
+    character(len=bufsize) :: buffer, msg
+    integer :: chunk, stat
+
+    allocate(character(len=0) :: line)
+    do
+      read(unit, '(a)', advance='no', iostat=stat, iomsg=msg, size=chunk) buffer
+      if (stat > 0) exit
+      line = line // buffer(:chunk)
+      if (stat < 0) then
+        if (is_iostat_eor(stat)) stat = 0
+        exit
+      end if
+    end do
+
+    if (stat /= 0 .and. present(iomsg)) iomsg = trim(msg)
+    if (present(iostat)) then
+      iostat = stat
+    else if (stat /= 0) then
+      call error_stop(trim(msg))
+    end if
+  end subroutine getline_char
+
+  !> Version: experimental
+  !>
+  !> Read a whole line from a formatted unit into a string variable
+  subroutine getline_string(unit, line, iostat, iomsg)
+    !> Formatted IO unit
+    integer, intent(in) :: unit
+    !> Line to read
+    type(string_type), intent(out) :: line
+    !> Status of operation
+    integer, intent(out), optional :: iostat
+    !> Error message
+    character(len=:), allocatable, optional :: iomsg
+
+    character(len=:), allocatable :: buffer
+
+    call getline(unit, buffer, iostat, iomsg)
+    line = string_type(buffer)
+  end subroutine getline_string
 
 end module stdlib_io

--- a/src/stdlib_io.fypp
+++ b/src/stdlib_io.fypp
@@ -6,6 +6,7 @@ module stdlib_io
   !! Provides a support for file handling
   !! ([Specification](../page/specs/stdlib_io.html))
 
+  use, intrinsic :: iso_fortran_env, only : input_unit
   use stdlib_kinds, only: sp, dp, xdp, qp, &
       int8, int16, int32, int64
   use stdlib_error, only: error_stop
@@ -38,6 +39,8 @@ module stdlib_io
   interface getline
     module procedure :: getline_char
     module procedure :: getline_string
+    module procedure :: getline_input_char
+    module procedure :: getline_input_string
   end interface getline
 
   interface loadtxt
@@ -356,17 +359,28 @@ contains
     integer, parameter :: bufsize = 512
     character(len=bufsize) :: buffer, msg
     integer :: chunk, stat
+    logical :: opened
+
+    if (unit /= -1) then
+      inquire(unit=unit, opened=opened)
+    else
+      opened = .false.
+    end if
+
+    if (opened) then
+      open(unit=unit, pad="yes", iostat=stat, iomsg=msg)
+    else
+      stat = 1
+      msg = "Unit is not connected"
+    end if
 
     line = ""
-    do
+    do while (stat == 0)
       read(unit, '(a)', advance='no', iostat=stat, iomsg=msg, size=chunk) buffer
       if (stat > 0) exit
       line = line // buffer(:chunk)
-      if (stat < 0) then
-        if (is_iostat_eor(stat)) stat = 0
-        exit
-      end if
     end do
+    if (is_iostat_eor(stat)) stat = 0
 
     if (stat /= 0 .and. present(iomsg)) iomsg = trim(msg)
     if (present(iostat)) then
@@ -394,5 +408,33 @@ contains
     call getline(unit, buffer, iostat, iomsg)
     line = string_type(buffer)
   end subroutine getline_string
+
+  !> Version: experimental
+  !>
+  !> Read a whole line from the standard input into a deferred length character variable
+  subroutine getline_input_char(line, iostat, iomsg)
+    !> Line to read
+    character(len=:), allocatable, intent(out) :: line
+    !> Status of operation
+    integer, intent(out), optional :: iostat
+    !> Error message
+    character(len=:), allocatable, optional :: iomsg
+
+    call getline(input_unit, line, iostat, iomsg)
+  end subroutine getline_input_char
+
+  !> Version: experimental
+  !>
+  !> Read a whole line from the standard input into a string variable
+  subroutine getline_input_string(line, iostat, iomsg)
+    !> Line to read
+    type(string_type), intent(out) :: line
+    !> Status of operation
+    integer, intent(out), optional :: iostat
+    !> Error message
+    character(len=:), allocatable, optional :: iomsg
+
+    call getline(input_unit, line, iostat, iomsg)
+  end subroutine getline_input_string
 
 end module stdlib_io

--- a/src/stdlib_io.fypp
+++ b/src/stdlib_io.fypp
@@ -356,7 +356,7 @@ contains
     !> Error message
     character(len=:), allocatable, optional :: iomsg
 
-    integer, parameter :: bufsize = 512
+    integer, parameter :: bufsize = 4096
     character(len=bufsize) :: buffer, msg
     integer :: chunk, stat
     logical :: opened

--- a/src/tests/io/CMakeLists.txt
+++ b/src/tests/io/CMakeLists.txt
@@ -13,6 +13,7 @@ ADDTEST(savetxt_qp)
 set_tests_properties(loadtxt_qp PROPERTIES LABELS quadruple_precision)
 set_tests_properties(savetxt_qp PROPERTIES LABELS quadruple_precision)
 
+ADDTEST(getline)
 ADDTEST(npy)
 ADDTEST(open)
 ADDTEST(parse_mode)

--- a/src/tests/io/Makefile.manual
+++ b/src/tests/io/Makefile.manual
@@ -6,6 +6,7 @@ SRCGEN = $(SRCFYPP:.fypp=.f90)
 
 PROGS_SRC = test_loadtxt.f90 \
             test_savetxt.f90 \
+            test_getline.f90 \
             test_npy.f90 \
             test_parse_mode.f90 \
             test_open.f90 \

--- a/src/tests/io/test_getline.f90
+++ b/src/tests/io/test_getline.f90
@@ -1,0 +1,88 @@
+module test_getline
+    use stdlib_io, only : getline
+    use stdlib_string_type, only : string_type, len
+    use testdrive, only : new_unittest, unittest_type, error_type, check
+    implicit none
+    private
+
+    public :: collect_getline
+
+contains
+
+    !> Collect all exported unit tests
+    subroutine collect_getline(testsuite)
+        !> Collection of tests
+        type(unittest_type), allocatable, intent(out) :: testsuite(:)
+
+        testsuite = [ &
+            new_unittest("read-char", test_read_char), &
+            new_unittest("read-string", test_read_string) &
+            ]
+    end subroutine collect_getline
+
+    subroutine test_read_char(error)
+        !> Error handling
+        type(error_type), allocatable, intent(out) :: error
+
+        integer :: io, i, stat
+        character(len=:), allocatable :: line
+
+        open(newunit=io, status="scratch")
+        write(io, "(a)") repeat("abc", 10), repeat("def", 100), repeat("ghi", 1000)
+        rewind(io)
+
+        do i = 1, 3
+          call getline(io, line, stat)
+          call check(error, stat)
+          call check(error, len(line), 3*10**i)
+        end do
+        close(io)
+    end subroutine test_read_char
+
+    subroutine test_read_string(error)
+        !> Error handling
+        type(error_type), allocatable, intent(out) :: error
+
+        integer :: io, i, stat
+        type(string_type) :: line
+
+        open(newunit=io, status="scratch")
+        write(io, "(a)") repeat("abc", 10), repeat("def", 100), repeat("ghi", 1000)
+        rewind(io)
+
+        do i = 1, 3
+          call getline(io, line, stat)
+          call check(error, stat)
+          call check(error, len(line), 3*10**i)
+        end do
+        close(io)
+    end subroutine test_read_string
+
+end module test_getline
+
+
+program tester
+    use, intrinsic :: iso_fortran_env, only : error_unit
+    use testdrive, only : run_testsuite, new_testsuite, testsuite_type
+    use test_getline, only : collect_getline
+    implicit none
+    integer :: stat, is
+    type(testsuite_type), allocatable :: testsuites(:)
+    character(len=*), parameter :: fmt = '("#", *(1x, a))'
+
+    stat = 0
+
+    testsuites = [ &
+        new_testsuite("getline", collect_getline) &
+        ]
+
+    do is = 1, size(testsuites)
+        write(error_unit, fmt) "Testing:", testsuites(is)%name
+        call run_testsuite(testsuites(is)%collect, error_unit, stat)
+    end do
+
+    if (stat > 0) then
+        write(error_unit, '(i0, 1x, a)') stat, "test(s) failed!"
+        error stop
+    end if
+end program


### PR DESCRIPTION
<details><summary>Alternative implementation by John @urbanjost in M_io</summary>

```f90
!!##NAME
!!    getline(3f) - [M_io] read a line from specified LUN into allocatable string up to line length limit
!!    (LICENSE:PD)
!!
!!##SYNTAX
!!   function getline(line,lun) result(ier)
!!
!!    character(len=:),allocatable,intent(out) :: line
!!    integer,intent(in),optional              :: lun
!!    integer,intent(out)                      :: ier
!!
!!##DESCRIPTION
!!    Read a line of any length up to programming environment maximum
!!    line length. Requires Fortran 2003+.
!!
!!    It is primarily expected to be used when reading input which will
!!    then be parsed.
!!
!!    The input file must have a PAD attribute of YES for the function
!!    to work properly, which is typically true.
!!
!!    The simple use of a loop that repeatedly re-allocates a character
!!    variable in addition to reading the input file one buffer at a
!!    time could (depending on the programming environment used) be
!!    inefficient, as it could reallocate and allocate memory used for
!!    the output string with each buffer read.
!!
!!##OPTIONS
!!    LINE   line read
!!    LUN    optional LUN (Fortran logical I/O unit) number. Defaults
!!           to stdin.
!!##RETURNS
!!    IER    zero unless an error occurred. If not zero, LINE returns the
!!           I/O error message.
!!
!!##EXAMPLE
!!
!!   Sample program:
!!
!!    program demo_getline
!!    use,intrinsic :: iso_fortran_env, only : stdin=>input_unit
!!    use M_io, only : getline
!!    implicit none
!!    character(len=:),allocatable :: line
!!       open(unit=stdin,pad='yes')
!!       INFINITE: do while (getline(line)==0)
!!          write(*,'(a)')'['//line//']'
!!       enddo INFINITE
!!    end program demo_getline
!!
!!##AUTHOR
!!    John S. Urban
!!
!!##LICENSE
!!    Public Domain
function getline(line,lun) result(ier)
implicit none

! ident_11="@(#)M_io::getline(3f): read a line from specified LUN into allocatable string up to line length limit"

character(len=:),allocatable,intent(out) :: line
integer,intent(in),optional              :: lun
integer                                  :: ier
character(len=4096)                      :: message

integer,parameter                        :: buflen=1024
character(len=:),allocatable             :: line_local
character(len=buflen)                    :: buffer
integer                                  :: isize
integer                                  :: lun_local

   line_local=''
   ier=0
   if(present(lun))then
      lun_local=lun
   else
      lun_local=stdin
   endif
   open(lun_local,pad='yes')

   INFINITE: do                                                      ! read characters from line and append to result
      read(lun_local,iostat=ier,fmt='(a)',advance='no',size=isize,iomsg=message) buffer ! read next buffer (might use stream I/O for files
                                                                     ! other than stdin so system line limit is not limiting
      if(isize.gt.0)line_local=line_local//buffer(:isize)            ! append what was read to result
      if(is_iostat_eor(ier))then                                     ! if hit EOR reading is complete unless backslash ends the line
         ier=0                                                       ! hitting end of record is not an error for this routine
         exit INFINITE                                               ! end of reading line
     elseif(ier.ne.0)then                                            ! end of file or error
        line=trim(message)
        exit INFINITE
     endif
   enddo INFINITE
   line=line_local                                                   ! trim line
end function getline
```
</details>
Closes #595 