### PR TITLE
Fix iomsg allocation in save_npy

### DIFF
--- a/src/stdlib_io_npy_save.fypp
+++ b/src/stdlib_io_npy_save.fypp
@@ -128,7 +128,9 @@ contains
         end if
 
         if (present(iomsg)) then
-            iomsg = "Failed to write array to file '"//filename//"'"
+            if (stat /= 0) then
+                iomsg = "Failed to write array to file '"//filename//"'"
+            end if
         end if
     end subroutine save_npy_${t1[0]}$${k1}$_${rank}$
   #:endfor

--- a/src/tests/io/test_npy.f90
+++ b/src/tests/io/test_npy.f90
@@ -34,7 +34,8 @@ contains
             new_unittest("duplicate-descr", test_duplicate_descr, should_fail=.true.), &
             new_unittest("missing-descr", test_missing_descr, should_fail=.true.), &
             new_unittest("missing-fortran_order", test_missing_fortran_order, should_fail=.true.), &
-            new_unittest("missing-shape", test_missing_shape, should_fail=.true.) &
+            new_unittest("missing-shape", test_missing_shape, should_fail=.true.), &
+            new_unittest("iomsg-deallocated", test_iomsg_deallocated) &
             ]
     end subroutine collect_npy
 
@@ -618,6 +619,27 @@ contains
 
         call check(error, stat, msg)
     end subroutine test_missing_shape
+
+    subroutine test_iomsg_deallocated(error)
+        !> Error handling
+        type(error_type), allocatable, intent(out) :: error
+
+        integer :: stat
+        character(len=:), allocatable :: msg
+
+        character(len=*), parameter :: filename = ".test-iomsg-deallocated.npy"
+        real(sp), allocatable :: input(:, :), output(:, :)
+
+        msg = "This message should be deallocated."
+
+        allocate(input(12, 5))
+        call random_number(input)
+        call save_npy(filename, input, stat, msg)
+        call delete_file(filename)
+
+        call check(error,.not. allocated(msg), "Message wrongly allocated.")
+
+    end subroutine
 
     subroutine delete_file(filename)
         character(len=*), intent(in) :: filename


### PR DESCRIPTION
<!--
Thank you for contributing to stdlib.
To help us get your pull request merged more quickly, please consider reviewing any of the already open pull requests.
-->

This is currently just a draft for a minor issue remaining in #581.

I've added a test to check that iomsg is deallocated if present, although this should technically be guaranteed by a standard-conforming compiler when the `intent(out)` attribute is present. 

To make sure the message gets allocated I need a way to trigger `stat /= 0`. Is their any known way of doing this for a new file?

On more thought, I'm afraid that both `stat` and `iomsg` only communicate the result of the command `close()`, and not if opening or writing were unsuccessful. I'm not sure whether the standard stipulates these commands be connected (in other words whether the same I/O error will trigger the same iostat flag in any of the three commands).

