### PR TITLE
Consistent spec titles

### DIFF
--- a/doc/specs/index.md
+++ b/doc/specs/index.md
@@ -15,9 +15,9 @@ This is and index/directory of the specifications (specs) for each new module/fe
  - [ascii](./stdlib_ascii.html) - Procedures for handling ASCII characters
  - [bitsets](./stdlib_bitsets.html) - Bitset data types and procedures
  - [error](./stdlib_error.html) - Catching and handling errors
- - [hash\_procedures](./stdlib_hash_procedures.html) - Hashing integer
+ - [hash](./stdlib_hash_procedures.html) - Hashing integer
    vectors or character strings
- - [IO](./stdlib_io.html) - Input/output helper & convenience
+ - [io](./stdlib_io.html) - Input/output helper & convenience
  - [kinds](./stdlib_kinds.html) - Kind parameters
  - [linalg](./stdlib_linalg.html) - Linear Algebra
  - [logger](./stdlib_logger.html) - Runtime logging system
@@ -30,8 +30,8 @@ This is and index/directory of the specifications (specs) for each new module/fe
  - [stats_distributions_uniform](./stdlib_stats_distribution_uniform.html) - Uniform Probability Distribution
  - [stats_distributions_normal](./stdlib_stats_distribution_normal.html) - Normal Probability Distribution
  - [string\_type](./stdlib_string_type.html) - Basic string support
- - [strings](./stdlib_strings.html) - String handling and manipulation routines
  - [stringlist_type](./stdlib_stringlist_type.html) - 1-Dimensional list of strings
+ - [strings](./stdlib_strings.html) - String handling and manipulation routines
  - [version](./stdlib_version.html) - Version information
 
 ## Released/Stable Features & Modules

--- a/doc/specs/stdlib_ascii.md
+++ b/doc/specs/stdlib_ascii.md
@@ -1,5 +1,5 @@
 ---
-title: ASCII
+title: ascii
 ---
 
 # The `stdlib_ascii` module

--- a/doc/specs/stdlib_bitsets.md
+++ b/doc/specs/stdlib_bitsets.md
@@ -1,5 +1,5 @@
 ---
-title: Bitsets
+title: bitsets
 ---
 
 # The `stdlib_bitsets` module

--- a/doc/specs/stdlib_hash_procedures.md
+++ b/doc/specs/stdlib_hash_procedures.md
@@ -1,5 +1,5 @@
 ---
-title: Hash procedures
+title: hash
 ---
 
 # The `stdlib_hash_32bit` and `stdlib_hash_64bit` modules

--- a/doc/specs/stdlib_io.md
+++ b/doc/specs/stdlib_io.md
@@ -1,5 +1,5 @@
 ---
-title: IO
+title: io
 ---
 
 # IO

--- a/doc/specs/stdlib_random.md
+++ b/doc/specs/stdlib_random.md
@@ -1,5 +1,5 @@
 ---
-title: stats_random
+title: random
 ---
 
 # Statistical Distributions -- Pseudorandom Number Generator Module

--- a/doc/specs/stdlib_selection.md
+++ b/doc/specs/stdlib_selection.md
@@ -1,5 +1,5 @@
 ---
-title: Selection Procedures
+title: selection
 ---
 
 # The `stdlib_selection` module

--- a/doc/specs/stdlib_sorting.md
+++ b/doc/specs/stdlib_sorting.md
@@ -1,5 +1,5 @@
 ---
-title: Sorting Procedures
+title: sorting
 ---
 
 # The `stdlib_sorting` module

--- a/doc/specs/stdlib_string_type.md
+++ b/doc/specs/stdlib_string_type.md
@@ -1,5 +1,5 @@
 ---
-title: string type
+title: string_type
 ---
 
 # The `stdlib_string_type` module

--- a/doc/specs/stdlib_stringlist_type.md
+++ b/doc/specs/stdlib_stringlist_type.md
@@ -1,5 +1,5 @@
 ---
-title: stringlist type
+title: stringlist_type
 ---
 
 # `stdlib_stringlist_type` module (1-D list of strings)

--- a/doc/specs/stdlib_strings.md
+++ b/doc/specs/stdlib_strings.md
@@ -1,5 +1,5 @@
 ---
-title: string handling
+title: strings
 ---
 
 # The `stdlib_strings` module

--- a/doc/specs/stdlib_version.md
+++ b/doc/specs/stdlib_version.md
@@ -1,5 +1,5 @@
 ---
-title: Version information
+title: version
 ---
 
 # The `stdlib_version` module


### PR DESCRIPTION
This PR:

* Renames several spec title attributes to make them consistent with others (module names)
* A few similar edits to the index.md of the Spec top-level page, for consistency.

Closes #608.