### PR TITLE
fix gauss quadrature

### DIFF
--- a/src/stdlib_quadrature_gauss.f90
+++ b/src/stdlib_quadrature_gauss.f90
@@ -39,7 +39,7 @@ contains
                     x(n-i+1) = -x(i+1)
 
                     dleg = dlegendre(n+1,x(i+1))
-                    w(i+1)   = 2._dp/((1-x(i+1)**2)*dleg**2) 
+                    w(i+1)   = 2._dp/((1-x(i+1)**2)*dleg**2)
                     w(n-i+1) = w(i+1)
                 end do
 
@@ -47,7 +47,7 @@ contains
                     x(n/2+1) = 0
 
                     dleg = dlegendre(n+1, 0.0_dp)
-                    w(n/2+1) = 2._dp/(dleg**2) 
+                    w(n/2+1) = 2._dp/(dleg**2)
                 end if
                 end block
         end select
@@ -56,8 +56,8 @@ contains
         if (present(interval)) then
             associate ( a => interval(1) , b => interval(2) )
             x = 0.5_dp*(b-a)*x+0.5_dp*(b+a)
-            x(1)       = interval(1)
-            x(size(x)) = interval(2)
+            ! x(1)       = interval(1)
+            ! x(size(x)) = interval(2)
             w = 0.5_dp*(b-a)*w
             end associate
         end if
@@ -96,7 +96,7 @@ contains
                     x(n-i+1) = -x(i+1)
 
                     leg = legendre(n, x(i+1))
-                    w(i+1)   = 2._dp/(n*(n+1._dp)*leg**2) 
+                    w(i+1)   = 2._dp/(n*(n+1._dp)*leg**2)
                     w(n-i+1) = w(i+1)
                 end do
 
@@ -104,19 +104,19 @@ contains
                     x(n/2+1) = 0
 
                     leg = legendre(n, 0.0_dp)
-                    w(n/2+1)   = 2._dp/(n*(n+1._dp)*leg**2) 
+                    w(n/2+1)   = 2._dp/(n*(n+1._dp)*leg**2)
                 end if
                 end block
         end select
         end associate
-        
+
         if (present(interval)) then
             associate ( a => interval(1) , b => interval(2) )
             x = 0.5_dp*(b-a)*x+0.5_dp*(b+a)
-            x(1)       = interval(1)
-            x(size(x)) = interval(2)
+            ! x(1)       = interval(1)
+            ! x(size(x)) = interval(2)
             w = 0.5_dp*(b-a)*w
             end associate
         end if
     end subroutine
-end submodule    
+end submodule


### PR DESCRIPTION
when providing intervals [-1, 1] to guass quad function I was getting a different result. I was able to fix by commenting the two lines in each of the quad functions as shown. Sorry, my editor strips trailing spaces, hence the other diffs.

```
real(dp), dimension(2), parameter :: interval = [-1_dp,1_dp]
call gauss_legendre(x,w,interval)
```