### PR TITLE
option to disable testing by setting BUILD_TESTING to OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ list(GET VERSION_LIST 1 PROJECT_VERSION_MINOR)
 list(GET VERSION_LIST 2 PROJECT_VERSION_PATCH)
 unset(VERSION_LIST)
 
-enable_testing()
+option(BUILD_TESTING "Define if tests should be enabled" ON)
 
 # Follow GNU conventions for installation directories
 include(GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ list(GET VERSION_LIST 1 PROJECT_VERSION_MINOR)
 list(GET VERSION_LIST 2 PROJECT_VERSION_PATCH)
 unset(VERSION_LIST)
 
-option(BUILD_TESTING "Define if tests should be enabled" ON)
+include(CTest)
 
 # Follow GNU conventions for installation directories
 include(GNUInstallDirs)

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Important options are
   The minimum required rank to compile this project is 4.
   Compiling with maximum rank 15 can be resource intensive and requires at least 16 GB of memory to allow parallel compilation or 4 GB memory for sequential compilation.
 - `-DBUILD_SHARED_LIBS` set to `on` in case you want link your application dynamically against the standard library (default: `off`).
+- `-DBUILD_TESTING` set to `off` in case you want to disable the stdlib tests (default: `on`).
 
 For example, to configure a build using the Ninja backend while specifying compiler flags `FFLAGS`, generating procedures up to rank 7, and installing to your home directory, use
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -115,6 +115,7 @@ else()
 endif()
 
 if(BUILD_TESTING)
+  enable_testing()
   add_subdirectory(tests)
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -114,7 +114,9 @@ else()
   target_sources(${PROJECT_NAME} PRIVATE f08estop.f90)
 endif()
 
-add_subdirectory(tests)
+if(BUILD_TESTING)
+  add_subdirectory(tests)
+endif()
 
 install(TARGETS ${PROJECT_NAME}
         EXPORT ${PROJECT_NAME}-targets


### PR DESCRIPTION
Removed enable_testing(), since this seems to be enabled when the subdirectory "tests" is added.
Used the intrinsic CTests name BUILD_TESTING, ref: https://cmake.org/cmake/help/latest/module/CTest.html.

From my understanding, maybe the ideal way of tackling this issue would be to handle BUILD_TESTING as an intrinsic setting in test-drive? Then we might not need the
`option(BUILD_TESTING "Define if tests should be enabled" ON)`
in CMakeLists.txt

<!--
Thank you for contributing to stdlib.
To help us get your pull request merged more quickly, please consider reviewing any of the already open pull requests.
-->
