### PR TITLE
Feature: loadtxt skiprows and max_rows

### DIFF
--- a/doc/specs/stdlib_io.md
+++ b/doc/specs/stdlib_io.md
@@ -17,13 +17,17 @@ Loads a rank-2 `array` from a text file.
 
 ### Syntax
 
-`call [[stdlib_io(module):loadtxt(interface)]](filename, array)`
+`call [[stdlib_io(module):loadtxt(interface)]](filename, array [, skiprows] [, max_rows])`
 
 ### Arguments
 
 `filename`: Shall be  a character expression containing the file name from which to load the rank-2 `array`.
 
 `array`: Shall be an allocatable rank-2 array of type `real`, `complex` or `integer`.
+
+`skiprows` (optional): Skip the first `skiprows` lines. If skipping more rows than present, a 0-sized array will be returned. The default is 0.
+
+`max_rows` (optional): Read `max_rows` lines of content after `skiprows` lines. The default is -1, to read all the lines.
 
 ### Return value
 

--- a/doc/specs/stdlib_io.md
+++ b/doc/specs/stdlib_io.md
@@ -27,7 +27,7 @@ Loads a rank-2 `array` from a text file.
 
 `skiprows` (optional): Skip the first `skiprows` lines. If skipping more rows than present, a 0-sized array will be returned. The default is 0.
 
-`max_rows` (optional): Read `max_rows` lines of content after `skiprows` lines. The default is -1, to read all the lines.
+`max_rows` (optional): Read `max_rows` lines of content after `skiprows` lines. A negative value results in reading all lines. A value of zero results in no lines to be read. The default value is -1.
 
 ### Return value
 

--- a/src/stdlib_io.fypp
+++ b/src/stdlib_io.fypp
@@ -81,7 +81,7 @@ module stdlib_io
 contains
 
   #:for k1, t1 in KINDS_TYPES
-    subroutine  loadtxt_${t1[0]}$${k1}$(filename, d, skiprows)
+    subroutine  loadtxt_${t1[0]}$${k1}$(filename, d, skiprows, max_rows)
       !! version: experimental
       !!
       !! Loads a 2D array from a text file.
@@ -95,6 +95,8 @@ contains
       ${t1}$, allocatable, intent(out) :: d(:,:)
       !! Skip the first `skiprows` lines, default: 0.
       integer, intent(in), optional :: skiprows
+      !! Read max_rows lines of content after skiprows lines. The default is -1, to read all the lines.
+      integer, intent(in), optional :: max_rows
       !!
       !! Example
       !! -------
@@ -113,10 +115,12 @@ contains
       !!     ...
       !!
       integer :: s
-      integer :: nrow, ncol, i, skiprows_
+      integer :: nrow, ncol, i, skiprows_, max_rows_
 
       skiprows_ = optval(skiprows, 0)
       if ( skiprows_ < 0 ) call error_stop("loadtxt: skiprows needs to be non-negative.")
+
+      max_rows_ = optval(max_rows, -1)
 
       s = open(filename)
 
@@ -128,14 +132,16 @@ contains
 
       ! determine number or rows
       nrow = number_of_rows(s) - skiprows_
-
       if ( nrow < 0 ) call error_stop("loadtxt: skipping more rows than present.")
+      if ( max_rows_ < 0 .or. max_rows_ > nrow) max_rows_ = nrow
+
+      allocate(d(max_rows_, ncol))
+
       do i = 1, skiprows_
         read(s, *)
       end do
 
-      allocate(d(nrow, ncol))
-      do i = 1, nrow
+      do i = 1, max_rows_
         #:if 'real' in t1
           read(s, "(*"//FMT_REAL_${k1}$(1:len(FMT_REAL_${k1}$)-1)//",1x))") d(i, :)
         #:elif 'complex' in t1

--- a/src/stdlib_io.fypp
+++ b/src/stdlib_io.fypp
@@ -81,7 +81,7 @@ module stdlib_io
 contains
 
   #:for k1, t1 in KINDS_TYPES
-    subroutine  loadtxt_${t1[0]}$${k1}$(filename, d)
+    subroutine  loadtxt_${t1[0]}$${k1}$(filename, d, skiprows)
       !! version: experimental
       !!
       !! Loads a 2D array from a text file.
@@ -93,6 +93,8 @@ contains
       character(len=*), intent(in) :: filename
       !! The array 'd' will be automatically allocated with the correct dimensions
       ${t1}$, allocatable, intent(out) :: d(:,:)
+      !! Skip the first `skiprows` lines, default: 0.
+      integer, intent(in), optional :: skiprows
       !!
       !! Example
       !! -------
@@ -111,7 +113,9 @@ contains
       !!     ...
       !!
       integer :: s
-      integer :: nrow, ncol, i
+      integer :: nrow, ncol, i, skiprows_
+
+      skiprows_ = optval(skiprows, 0)
 
       s = open(filename)
 
@@ -122,7 +126,12 @@ contains
       #:endif
 
       ! determine number or rows
-      nrow = number_of_rows(s)
+      nrow = number_of_rows(s) - skiprows_
+
+      if ( nrow < 0 ) call error_stop("loadtxt: skipping more rows than present.")
+      do i = 1, skiprows_
+        read(s, *)
+      end do
 
       allocate(d(nrow, ncol))
       do i = 1, nrow

--- a/src/stdlib_io.fypp
+++ b/src/stdlib_io.fypp
@@ -118,7 +118,7 @@ contains
       integer :: nrow, ncol, i, skiprows_, max_rows_
 
       skiprows_ = optval(skiprows, 0)
-      if ( skiprows_ < 0 ) call error_stop("loadtxt: skiprows needs to be non-negative.")
+      if ( skiprows_ < 0 ) call error_stop("loadtxt: skiprows must be non-negative.")
 
       max_rows_ = optval(max_rows, -1)
 

--- a/src/stdlib_io.fypp
+++ b/src/stdlib_io.fypp
@@ -125,16 +125,17 @@ contains
 
       s = open(filename)
 
-      ! determine number of columns
-      ncol = number_of_columns(s)
-      #:if 'complex' in t1
-      ncol = ncol / 2
-      #:endif
-
       ! determine number or rows
       nrow = number_of_rows(s)
       skiprows_ = min(skiprows_, nrow)
-      if ( max_rows_ < 0 .or. max_rows_ > (nrow - skiprows_)) max_rows_ = nrow - skiprows_
+      if ( max_rows_ < 0 .or. max_rows_ > (nrow - skiprows_) ) max_rows_ = nrow - skiprows_
+
+      ! determine number of columns
+      ncol = 0
+      if ( skiprows_ < nrow ) ncol = number_of_columns(s, skiprows=skiprows_)
+      #:if 'complex' in t1
+      ncol = ncol / 2
+      #:endif
 
       allocate(d(max_rows_, ncol))
 
@@ -196,17 +197,25 @@ contains
   #:endfor
 
 
-  integer function number_of_columns(s)
+  integer function number_of_columns(s, skiprows)
     !! version: experimental
     !!
     !! determine number of columns
     integer,intent(in) :: s
+    integer, intent(in), optional :: skiprows
 
-    integer :: ios
+    integer :: ios, skiprows_
     character :: c
     logical :: lastblank
 
+    skiprows_ = optval(skiprows, 0)
+
     rewind(s)
+
+    do i = 1, skiprows_
+      read(s, *)
+    end do
+
     number_of_columns = 0
     lastblank = .true.
     do

--- a/src/stdlib_io.fypp
+++ b/src/stdlib_io.fypp
@@ -117,9 +117,7 @@ contains
       integer :: s
       integer :: nrow, ncol, i, skiprows_, max_rows_
 
-      skiprows_ = optval(skiprows, 0)
-      if ( skiprows_ < 0 ) call error_stop("loadtxt: skiprows must be non-negative.")
-
+      skiprows_ = max(optval(skiprows, 0), 0)
       max_rows_ = optval(max_rows, -1)
 
       s = open(filename)

--- a/src/stdlib_io.fypp
+++ b/src/stdlib_io.fypp
@@ -204,7 +204,7 @@ contains
     integer,intent(in) :: s
     integer, intent(in), optional :: skiprows
 
-    integer :: ios, skiprows_
+    integer :: ios, skiprows_, i
     character :: c
     logical :: lastblank
 

--- a/src/stdlib_io.fypp
+++ b/src/stdlib_io.fypp
@@ -116,6 +116,7 @@ contains
       integer :: nrow, ncol, i, skiprows_
 
       skiprows_ = optval(skiprows, 0)
+      if ( skiprows_ < 0 ) call error_stop("loadtxt: skiprows needs to be non-negative.")
 
       s = open(filename)
 

--- a/src/stdlib_io.fypp
+++ b/src/stdlib_io.fypp
@@ -93,7 +93,7 @@ contains
       character(len=*), intent(in) :: filename
       !! The array 'd' will be automatically allocated with the correct dimensions
       ${t1}$, allocatable, intent(out) :: d(:,:)
-      !! Skip the first `skiprows` lines, default: 0.
+      !! Skip the first `skiprows` lines. If skipping more rows than present, a 0-sized array will be returned. The default is 0.
       integer, intent(in), optional :: skiprows
       !! Read max_rows lines of content after skiprows lines. The default is -1, to read all the lines.
       integer, intent(in), optional :: max_rows

--- a/src/stdlib_io.fypp
+++ b/src/stdlib_io.fypp
@@ -95,7 +95,10 @@ contains
       ${t1}$, allocatable, intent(out) :: d(:,:)
       !! Skip the first `skiprows` lines. If skipping more rows than present, a 0-sized array will be returned. The default is 0.
       integer, intent(in), optional :: skiprows
-      !! Read max_rows lines of content after skiprows lines. The default is -1, to read all the lines.
+      !! Read `max_rows` lines of content after `skiprows` lines.
+      !! A negative value results in reading all lines.
+      !! A value of zero results in no lines to be read.
+      !! The default value is -1.
       integer, intent(in), optional :: max_rows
       !!
       !! Example

--- a/src/stdlib_io.fypp
+++ b/src/stdlib_io.fypp
@@ -129,9 +129,9 @@ contains
       #:endif
 
       ! determine number or rows
-      nrow = number_of_rows(s) - skiprows_
-      if ( nrow < 0 ) call error_stop("loadtxt: skipping more rows than present.")
-      if ( max_rows_ < 0 .or. max_rows_ > nrow) max_rows_ = nrow
+      nrow = number_of_rows(s)
+      skiprows_ = min(skiprows_, nrow)
+      if ( max_rows_ < 0 .or. max_rows_ > (nrow - skiprows_)) max_rows_ = nrow - skiprows_
 
       allocate(d(max_rows_, ncol))
 

--- a/src/tests/io/test_loadtxt.f90
+++ b/src/tests/io/test_loadtxt.f90
@@ -19,6 +19,7 @@ contains
             new_unittest("loadtxt_sp_huge", test_loadtxt_sp_huge), &
             new_unittest("loadtxt_sp_tiny", test_loadtxt_sp_tiny), &
             new_unittest("loadtxt_dp", test_loadtxt_dp), &
+            new_unittest("loadtxt_dp_skip", test_loadtxt_dp_skip), &
             new_unittest("loadtxt_dp_huge", test_loadtxt_dp_huge), &
             new_unittest("loadtxt_dp_tiny", test_loadtxt_dp_tiny), &
             new_unittest("loadtxt_complex", test_loadtxt_complex) &
@@ -132,6 +133,27 @@ contains
         end do
 
     end subroutine test_loadtxt_dp
+
+
+    subroutine test_loadtxt_dp_skip(error)
+        !> Error handling
+        type(error_type), allocatable, intent(out) :: error
+        real(dp), allocatable :: input(:,:), expected(:,:)
+        integer :: n
+
+        allocate(input(10,10))
+
+        do n = 1, 5
+            call random_number(input)
+            input = input - 0.5
+            call savetxt('test_dp_skip.txt', input)
+            call loadtxt('test_dp_skip.txt', expected, skiprows=n)
+            call check(error, all(input(n+1:,:) == expected))
+            deallocate(expected)
+            if (allocated(error)) return
+        end do
+
+    end subroutine test_loadtxt_dp_skip
 
 
     subroutine test_loadtxt_dp_huge(error)

--- a/src/tests/io/test_loadtxt.f90
+++ b/src/tests/io/test_loadtxt.f90
@@ -19,7 +19,7 @@ contains
             new_unittest("loadtxt_sp_huge", test_loadtxt_sp_huge), &
             new_unittest("loadtxt_sp_tiny", test_loadtxt_sp_tiny), &
             new_unittest("loadtxt_dp", test_loadtxt_dp), &
-            new_unittest("test_loadtxt_dp_max_skip", test_loadtxt_dp_max_skip), &
+            new_unittest("loadtxt_dp_max_skip", test_loadtxt_dp_max_skip), &
             new_unittest("loadtxt_dp_huge", test_loadtxt_dp_huge), &
             new_unittest("loadtxt_dp_tiny", test_loadtxt_dp_tiny), &
             new_unittest("loadtxt_complex", test_loadtxt_complex) &

--- a/src/tests/io/test_loadtxt.f90
+++ b/src/tests/io/test_loadtxt.f90
@@ -19,7 +19,7 @@ contains
             new_unittest("loadtxt_sp_huge", test_loadtxt_sp_huge), &
             new_unittest("loadtxt_sp_tiny", test_loadtxt_sp_tiny), &
             new_unittest("loadtxt_dp", test_loadtxt_dp), &
-            new_unittest("loadtxt_dp_skip", test_loadtxt_dp_skip), &
+            new_unittest("test_loadtxt_dp_max_skip", test_loadtxt_dp_max_skip), &
             new_unittest("loadtxt_dp_huge", test_loadtxt_dp_huge), &
             new_unittest("loadtxt_dp_tiny", test_loadtxt_dp_tiny), &
             new_unittest("loadtxt_complex", test_loadtxt_complex) &
@@ -135,25 +135,27 @@ contains
     end subroutine test_loadtxt_dp
 
 
-    subroutine test_loadtxt_dp_skip(error)
+    subroutine test_loadtxt_dp_max_skip(error)
         !> Error handling
         type(error_type), allocatable, intent(out) :: error
         real(dp), allocatable :: input(:,:), expected(:,:)
-        integer :: n
+        integer :: n, m
 
         allocate(input(10,10))
 
-        do n = 1, 5
-            call random_number(input)
-            input = input - 0.5
-            call savetxt('test_dp_skip.txt', input)
-            call loadtxt('test_dp_skip.txt', expected, skiprows=n)
-            call check(error, all(input(n+1:,:) == expected))
-            deallocate(expected)
-            if (allocated(error)) return
+        do m = 0, 5
+            do n = 1, 11
+                call random_number(input)
+                input = input - 0.5
+                call savetxt('test_dp_max_skip.txt', input)
+                call loadtxt('test_dp_max_skip.txt', expected, skiprows=m, max_rows=n)
+                call check(error, all(input(m+1:min(n+m,10),:) == expected))
+                deallocate(expected)
+                if (allocated(error)) return
+            end do
         end do
 
-    end subroutine test_loadtxt_dp_skip
+    end subroutine test_loadtxt_dp_max_skip
 
 
     subroutine test_loadtxt_dp_huge(error)


### PR DESCRIPTION
Hey there,

I needed to skip rows with loadtxt, so I added this feature similar to the numpy routine. In addition, I also added `max_rows`.

Added optional arguments:
- `skiprows`: skipping rows at the beginning of the file (default 0)
- `max_rows`: maximum for read lines (default -1 for all lines)

Argument names are taken from `numpy.loadtxt`. All negative values for `max_rows` are interpreted as "all lines".