### PR TITLE
fixed 32-bit integer overflow in stdlib_io_npy

### DIFF
--- a/src/stdlib_io_npy_load.fypp
+++ b/src/stdlib_io_npy_load.fypp
@@ -134,12 +134,12 @@ contains
 
         if (major > 1) then
             header_len = ichar(buf(1)) &
-                &      + ichar(buf(2)) * 2**8 &
-                &      + ichar(buf(3)) * 2**16 &
-                &      + ichar(buf(4)) * 2**24
+                &      + ichar(buf(2)) * 256**1 &
+                &      + ichar(buf(3)) * 256**2 &
+                &      + ichar(buf(4)) * 256**3
         else
-            header_len = ichar(buf(1)) &
-                &      + ichar(buf(2)) * 2**8
+            header_len = ichar(buf(1))  &
+                &      + ichar(buf(2)) * 256**1
         end if
         allocate(character(header_len) :: dict, stat=stat)
         if (stat /= 0) return

--- a/src/stdlib_io_npy_load.fypp
+++ b/src/stdlib_io_npy_load.fypp
@@ -138,7 +138,7 @@ contains
                 &      + ichar(buf(3)) * 256**2 &
                 &      + ichar(buf(4)) * 256**3
         else
-            header_len = ichar(buf(1))  &
+            header_len = ichar(buf(1)) &
                 &      + ichar(buf(2)) * 256**1
         end if
         allocate(character(header_len) :: dict, stat=stat)

--- a/src/stdlib_io_npy_load.fypp
+++ b/src/stdlib_io_npy_load.fypp
@@ -136,7 +136,7 @@ contains
             header_len = ichar(buf(1)) &
                 &      + ichar(buf(2)) * 2**8 &
                 &      + ichar(buf(3)) * 2**16 &
-                &      + ichar(buf(4)) * 2**32
+                &      + ichar(buf(4)) * 2**24
         else
             header_len = ichar(buf(1)) &
                 &      + ichar(buf(2)) * 2**8

--- a/src/stdlib_io_npy_save.fypp
+++ b/src/stdlib_io_npy_save.fypp
@@ -60,10 +60,10 @@ contains
         !> String of bytes
         character(len=4) :: str
 
-        str = achar(mod(val, 2**8)) // &
-            & achar(mod(val, 2**16) / 2**8) // &
-            & achar(mod(val, 2**24) / 2**16) // &
-            & achar(val / 2**24)
+        str = achar(mod(val, 256**1)) // &
+            & achar(mod(val, 256**2) / 256**1) // &
+            & achar(mod(val, 256**3) / 256**2) // &
+            & achar(val / 256**3)
     end function to_bytes_i4
 
 

--- a/src/stdlib_io_npy_save.fypp
+++ b/src/stdlib_io_npy_save.fypp
@@ -62,8 +62,8 @@ contains
 
         str = achar(mod(val, 2**8)) // &
             & achar(mod(val, 2**16) / 2**8) // &
-            & achar(mod(val, 2**32) / 2**16) // &
-            & achar(val / 2**32)
+            & achar(mod(val, 2**24) / 2**16) // &
+            & achar(val / 2**24)
     end function to_bytes_i4
 
 


### PR DESCRIPTION
32-bit integer overflows in `stdlib_io_npy_save.fypp` and `stdlib_io_npy_load.fypp` are fixed from `2**32` to `2**24`, to become the power of base-number (256) at the 4th digit a base-256 number.
To improve readability and understandability, the powers of base-number are refactored from `2**8`, `2**16`, `2**24` to `256**1`, `256**2`, `256**3`, respectively.

The tasks done are summarized as follows:
- fixed and refactored `stdlib_io_npy_save.fypp`
- fixed and refactored `stdlib_io_npy_load.fypp`
- built with gfortran 10.3, ifort 2021.1, and nagfor 7.1 on Windows 10 with cmake 3.20.3
- executed `cmake --build build --target test` to run the test npy and confirmed it passed

closes #647 

Note that `config/DefaultFlags.cmake` is locally changed to specify compiler flags for nagfor as follows:
```cmake
elseif(CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
  set(
    CMAKE_Fortran_FLAGS_INIT
    "-fpp"
    "-f2018"
    "-ieee=full"
  )
  set(
    CMAKE_Fortran_FLAGS_RELEASE_INIT
  )
  set(
    CMAKE_Fortran_FLAGS_DEBUG_INIT
    "-g"
    "-nan"
  )
```