### PR TITLE
Readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,13 +134,13 @@ Important options are
 - `-DBUILD_SHARED_LIBS` set to `on` in case you want link your application dynamically against the standard library (default: `off`).
 - `-DBUILD_TESTING` set to `off` in case you want to disable the stdlib tests (default: `on`).
 - `-DCMAKE_VERBOSE_MAKEFILE` is by default set to `Off`, but if set to `On` will show commands used to compile the code.
-- `-DCMAKE_BUILD_TYPE` is set to `NoConfig` by default. Set to `Release` to compile with standard optimizations, or `RelWithDebInfo` for standard code development options. Beware these options may override compiler flags that are specified via `FFLAGS`. To avoid this, use an unknown value such as `-DCMAKE_BUILD_TYPE=UnknownBuildType`.
+- `-DCMAKE_BUILD_TYPE` is by default set to `RelWithDebInfo` which uses compiler flags suitable for code development (but with only `-O2` optimization). These options may override compiler flags that are specified via `FFLAGS`. To avoid this, use the value `-DCMAKE_BUILD_TYPE=NoConfig` in conjunction with `FFLAGS`.
 
-For example, to configure a build using the Ninja backend while specifying compiler flags via `FFLAGS`, generating procedures up to rank 7, installing to your home directory, using the `Release` compiler flags, and printing the compiler options, use
+For example, to configure a build using the Ninja backend while specifying compiler optimization via `FFLAGS`, generating procedures up to rank 7, installing to your home directory, using the `NoConfig` compiler flags, and printing the compiler commands, use
 
 ```sh
 export FFLAGS="-O3"
-cmake -B build -G Ninja -DCMAKE_MAXIMUM_RANK:String=7 -DCMAKE_INSTALL_PREFIX=$HOME/.local -DCMAKE_VERBOSE_MAKEFILE=On -DCMAKE_BUILD_TYPE=Release
+cmake -B build -G Ninja -DCMAKE_MAXIMUM_RANK:String=7 -DCMAKE_INSTALL_PREFIX=$HOME/.local -DCMAKE_VERBOSE_MAKEFILE=On -DCMAKE_BUILD_TYPE=NoConfig
 ```
 
 To build the standard library run

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Important options are
 - `-DBUILD_SHARED_LIBS` set to `on` in case you want link your application dynamically against the standard library (default: `off`).
 - `-DBUILD_TESTING` set to `off` in case you want to disable the stdlib tests (default: `on`).
 - `-DCMAKE_VERBOSE_MAKEFILE` is by default set to `Off`, but if set to `On` will show commands used to compile the code.
-- `-DCMAKE_BUILD_TYPE` is by default set to `RelWithDebInfo` which uses compiler flags suitable for code development (but with only `-O2` optimization). These options may override compiler flags that are specified via `FFLAGS`. To avoid this, use the value `-DCMAKE_BUILD_TYPE=NoConfig` in conjunction with `FFLAGS`.
+- `-DCMAKE_BUILD_TYPE` is by default set to `RelWithDebInfo`, which uses compiler flags suitable for code development (but with only `-O2` optimization). Beware the compiler flags set this way will override any compiler flags specified via `FFLAGS`. To prevent this, use `-DCMAKE_BUILD_TYPE=NoConfig` in conjunction with `FFLAGS`.
 
 For example, to configure a build using the Ninja backend while specifying compiler optimization via `FFLAGS`, generating procedures up to rank 7, installing to your home directory, using the `NoConfig` compiler flags, and printing the compiler commands, use
 

--- a/README.md
+++ b/README.md
@@ -133,14 +133,14 @@ Important options are
   Compiling with maximum rank 15 can be resource intensive and requires at least 16 GB of memory to allow parallel compilation or 4 GB memory for sequential compilation.
 - `-DBUILD_SHARED_LIBS` set to `on` in case you want link your application dynamically against the standard library (default: `off`).
 - `-DBUILD_TESTING` set to `off` in case you want to disable the stdlib tests (default: `on`).
-- `-DCMAKE_BUILD_TYPE` is set to `NoConfig` by default. Set to `Release` to compile with standard optimizations, or `RelWithDebInfo` for standard options for development. Other values can be passed to avoid having the associated compiler flags being set.
-- `-DCMAKE_VERBOSE_MAKEFILE` is by default set to `Off`, but if set to `On` will show the commands used to compile the code.
+- `-DCMAKE_VERBOSE_MAKEFILE` is by default set to `Off`, but if set to `On` will show commands used to compile the code.
+- `-DCMAKE_BUILD_TYPE` is set to `NoConfig` by default. Set to `Release` to compile with standard optimizations, or `RelWithDebInfo` for standard code development options. Beware these options may override compiler flags that are specified via `FFLAGS`. To avoid this, use an unknown value such as `-DCMAKE_BUILD_TYPE=UnknownBuildType`.
 
-For example, to configure a build using the Ninja backend while specifying compiler flags `FFLAGS`, generating procedures up to rank 7, and installing to your home directory, use
+For example, to configure a build using the Ninja backend while specifying compiler flags via `FFLAGS`, generating procedures up to rank 7, installing to your home directory, using the `Release` compiler flags, and printing the compiler options, use
 
 ```sh
 export FFLAGS="-O3"
-cmake -B build -G Ninja -DCMAKE_MAXIMUM_RANK:String=7 -DCMAKE_INSTALL_PREFIX=$HOME/.local
+cmake -B build -G Ninja -DCMAKE_MAXIMUM_RANK:String=7 -DCMAKE_INSTALL_PREFIX=$HOME/.local -DCMAKE_VERBOSE_MAKEFILE=On -DCMAKE_BUILD_TYPE=Release
 ```
 
 To build the standard library run

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ Important options are
   Compiling with maximum rank 15 can be resource intensive and requires at least 16 GB of memory to allow parallel compilation or 4 GB memory for sequential compilation.
 - `-DBUILD_SHARED_LIBS` set to `on` in case you want link your application dynamically against the standard library (default: `off`).
 - `-DBUILD_TESTING` set to `off` in case you want to disable the stdlib tests (default: `on`).
+- `-DCMAKE_BUILD_TYPE` is set to `NoConfig` by default. Set to `Release` to compile with standard optimizations, or `RelWithDebInfo` for standard options for development. Other values can be passed to avoid having the associated compiler flags being set.
+- `-DCMAKE_VERBOSE_MAKEFILE` is by default set to `Off`, but if set to `On` will show the commands used to compile the code.
 
 For example, to configure a build using the Ninja backend while specifying compiler flags `FFLAGS`, generating procedures up to rank 7, and installing to your home directory, use
 


### PR DESCRIPTION
This pull request explains some CMake options that affect stdlib builds. 
* It is designed to address [these issues](https://github.com/fortran-lang/stdlib/issues/614) in a simple way.

The first issue is that user-specified compiler optimizations in `FFLAGS` are overridden by the default the stdlib CMake setup. This means that, in the original README, the use of FFLAGS was not having any effect. 
* To fix this, the updated README discusses `-DCMAKE_BUILD_TYPE`. This can be setup to avoid default optimizations (while retaining flags that are essential to compile stdlib). This allows optimization flags in `FFLAGS` to be used.

The second issue is that by default, the user does not see what commands CMake is using to compile the code. This makes it difficult to notice problems like those above. 
* The solution is to set `-DCMAKE_VERBOSE_MAKEFILE=On`, which prints the compiler options.

I am a CMake novice, so it would be good to have this checked by an expert like @awvwgk . 