### PR TITLE
Fixes issue with `rvs_normal` where it lacks the elemental property

### DIFF
--- a/src/stdlib_stats_distribution_normal.fypp
+++ b/src/stdlib_stats_distribution_normal.fypp
@@ -160,6 +160,7 @@ contains
 
 
     #:for k1, t1 in REAL_KINDS_TYPES
+    impure elemental &
     function rvs_norm_${t1[0]}$${k1}$(loc, scale) result(res)
     !
     ! Normal random variate (loc, scale)
@@ -178,6 +179,7 @@ contains
 
 
     #:for k1, t1 in CMPLX_KINDS_TYPES
+    impure elemental &
     function rvs_norm_${t1[0]}$${k1}$(loc, scale) result(res)
     !
     ! Normally distributed complex. The real part and imaginary part are       &


### PR DESCRIPTION
As noted in [PR#662](https://github.com/fortran-lang/stdlib/pull/662#discussion_r907615242) there's an error in the demo program given for `rvs_normal` where it lacks the shown elemental property.

```
example/demo_normal_rvs.f90:29:12:

   29 |     print *, norm(a, b)         ! a rank 3 random variates array
      |            1
Error: There is no specific function for the generic ‘rvs_normal’ at (1)
<ERROR> Compilation failed for object " example_demo_normal_rvs.f90.o "
<ERROR>stopping due to failed compilation
```

<!--
Thank you for contributing to stdlib.
To help us get your pull request merged more quickly, please consider reviewing any of the already open pull requests.
-->
