### PR TITLE
Fixes #673: update docs CI

### DIFF
--- a/.github/workflows/doc-deployment.yml
+++ b/.github/workflows/doc-deployment.yml
@@ -5,12 +5,6 @@ on: [push, pull_request]
 env:
   LANG: "en_US.UTF-8"
   LC_ALL: "en_US.UTF-8"
-  HOMEBREW_DISPLAY_INSTALL_TIMES: "ON"
-  HOMEBREW_NO_ANALYTICS: "ON"
-  HOMEBREW_NO_AUTO_UPDATE: "ON"
-  HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK: "ON"
-  HOMEBREW_NO_GITHUB_API: "ON"
-  HOMEBREW_NO_INSTALL_CLEANUP: "ON"
   PIP_DISABLE_PIP_VERSION_CHECK: "ON"
   PIP_NO_CLEAN: "ON"
   PIP_PREFER_BINARY: "ON"
@@ -19,45 +13,45 @@ env:
 
 jobs:
   Build-API-Docs:
-    runs-on: macos-latest
-    env:
-      GCC_V: 10
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
         with:
-          fetch-depth: 0 # Full history to get tag and commit info
-      - name: Install GFortran macOS
+          python-version: '3.x'
+
+      - name: Install dependencies
         run: |
-          brew install gcc@${GCC_V} || brew upgrade gcc@${GCC_V} || true
-          brew link gcc@${GCC_V}
-          gfortran-${GCC_V} --version
-      - name: Install Dependencies
-        run: |
-          pip3 install --prefer-binary --no-clean --disable-pip-version-check --progress-bar off lxml fypp
-          brew install -f --force-bottle --keep-tmp ford
-          type -a ford
+          pip install -v ford==6.1.10
+          pip install fypp
+          python --version
           ford --version
-          gfortran-${GCC_V} --version
+          fypp --version
+
       - name: Skip graph and search unless deploying
         if: github.ref != 'refs/heads/master' && ! startsWith( github.ref, 'refs/tags/' )
         run: |
-            sed -i .bak 's/^[[:blank:]]*graph:  *[Tt]rue/graph: false/' "${FORD_FILE}"
+            sed -i 's/^[[:blank:]]*graph:  *[Tt]rue/graph: false/' "${FORD_FILE}"
             echo "MAYBE_SKIP_SEARCH=--no-search" >> $GITHUB_ENV
+
       - name: Build Docs
         run: |
           git fetch --all --tags
           ford -r $(git describe --always) --debug ${MAYBE_SKIP_SEARCH} "${FORD_FILE}"
+
       - name: Upload Documentation
         uses: actions/upload-artifact@v2
         with:
           name: FORD-API-docs
           path: ./API-doc/
+
       - name: Broken Link Check
         uses: technote-space/broken-link-checker-action@v1
         with:
           TARGET: file://${{ github.workspace }}/API-doc/index.html
           RECURSIVE: true
           ASSIGNEES: ${{ github.actor }}
+
       - name: Deploy API Docs
         uses: peaceiris/actions-gh-pages@v3
         if: github.event_name == 'push' && github.repository == 'fortran-lang/stdlib' && ( startsWith( github.ref, 'refs/tags/' ) || github.ref == 'refs/heads/master' )


### PR DESCRIPTION
<!--
Thank you for contributing to stdlib.
To help us get your pull request merged more quickly, please consider reviewing any of the already open pull requests.
-->
## Description

This PR focuses on fixing `ford`'s version (now it is `ford-6.1.10`) for CI stability and using `ubuntu` to install `ford`.

Close #673.

(PS. Once we know that [ford/issue/446](https://github.com/Fortran-FOSS-Programmers/ford/issues/446) is fixed, we can update the `ford` version later if necessary.)

## Tasks

- [x] Remove `macOS`, `homebrew` and `gfortran` related configuration;
- [x] Add installation of `ford`, `fypp` on `ubuntu`;
- [x] Remove the `.bak` string from the `sed` command, it will report an error under `Ubuntu` and `Windows`.