### PR TITLE
Update GCC versions in OS matrix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        gcc_v: [9, 10, 11] # Version of GFortran we want to use.
+        gcc_v: [10, 11, 12] # Version of GFortran we want to use.
         build: [cmake]
         include:
           - os: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -88,12 +88,12 @@ The following combinations are tested on the default branch of stdlib:
 
 Name | Version | Platform | Architecture
 --- | --- | --- | ---
-GCC Fortran | 9, 10, 11 | Ubuntu 20.04 | x86_64
-GCC Fortran | 9, 10, 11 | MacOS Catalina 10.15 | x86_64
-GCC Fortran (MSYS) | 10 | Windows Server 2019 | x86_64
-GCC Fortran (MinGW) | 10 | Windows Server 2019 | x86_64, i686
-Intel oneAPI classic | 2021.1 | Ubuntu 20.04 | x86_64
-Intel oneAPI classic | 2021.1 | MacOS Catalina 10.15 | x86_64
+GCC Fortran | 10, 11, 12 | Ubuntu 22.04.2 LTS | x86_64
+GCC Fortran | 10, 11, 12 | macOS 12.6.3 (21G419) | x86_64
+GCC Fortran (MSYS) | 10 | Windows Server 2022 (10.0.20348 Build 1547) | x86_64
+GCC Fortran (MinGW) | 10 | Windows Server 2022 (10.0.20348 Build 1547) | x86_64, i686
+Intel oneAPI classic | 2021.1 | Ubuntu 22.04.2 LTS | x86_64
+Intel oneAPI classic | 2021.1 | macOS 12.6.3 (21G419) | x86_64
 
 The following combinations are known to work, but they are not tested in the CI:
 


### PR DESCRIPTION
This PR updates the GCC versions in the OS matrix from [9, 10, 11] to [10, 11, 12]. I did this for both macOS and Ubuntu to keep gcc version parity between 2 OSs, and to not introduce complexity to the CI.yml, the syntax of which I'm still becoming familiar and am not 100% comfortable. Let's hope this works. The brew install step for gcc-11 and gcc-12 on macOS is not necessary because they're provided by the system, but I assume it doesn't hurt and keeps the CI.yml simpler. I hope this works.

Closes #696.