### PR TITLE
fpm-deployment: update `VERSION` field in fpm.toml with actual version

### DIFF
--- a/ci/fpm-deployment.sh
+++ b/ci/fpm-deployment.sh
@@ -20,7 +20,6 @@ fi
 
 # Additional files to include
 include=(
-  "ci/fpm.toml"
   "LICENSE"
   "VERSION"
 )
@@ -53,6 +52,9 @@ find example -name "example_*.f90" -exec cp {} "$destdir/example/" \;
 
 # Include additional files
 cp "${include[@]}" "$destdir/"
+
+# Update version in the manifest (not all systems support sed -i)
+sed -E "s,version = \"VERSION\",version = \"$major.$minor.$patch\",g" ci/fpm.toml > "$destdir/fpm.toml"
 
 # Source file workarounds for fpm; ignore missing files
 rm "${prune[@]}"


### PR DESCRIPTION
See #701, this update in the fpm deployment script updates the `VERSION` placeholder in fpm.toml so an actual version is printed. 

I don't know how to test the deployment on my fork. 