### PR TITLE
Fixed access violation in a type-bound procedure of `open_hashmap_type`

### DIFF
--- a/src/stdlib_hashmap_open.f90
+++ b/src/stdlib_hashmap_open.f90
@@ -283,7 +283,7 @@ contains
                     invalid_inmap
             end if
         else if ( associated( map % inverse(inmap) % target ) ) then
-            exists = .true.
+            if ( present(exists) ) exists = .true.
             call copy_other( map % inverse(inmap) % target % other, other )
         else
             if ( present(exists) ) then


### PR DESCRIPTION
Based on issue #704, I added a presence check for the optional argument `exists` in `get_other_open_data` to fix the access violation due to assignment to an optional variable that was not presented.

The tasks done are summarized as follows:
- Fixed stdlib_hashmap_open.f90.
- Built using gfortran 11.2 bundled with quickstart Fortran on Windows 10 with cmake 3.20.3.
- Executed `cmake --build build --target test` to run the tests and confirmed all tests passed.
- Executed examples below that were using the `open_hashmap_type` and confirmed those finished successfully.
    - example_hashmaps_entries.f90
    - example_hashmaps_loading.f90
    - example_hashmaps_rehash.f90
    - example_hashmaps_remove.f90
    - example_hashmaps_set_other_data.f90

closes #704 