### PR TITLE
Fixes #706 - failure due unassigned value to a intent(out) variable.

### DIFF
--- a/src/stdlib_io_npy_load.fypp
+++ b/src/stdlib_io_npy_load.fypp
@@ -123,7 +123,7 @@ contains
         character :: buf(4)
         logical :: fortran_order
         
-        ! stat should be zero by default, if no error occured
+        ! stat should be zero if no error occurred
         stat = 0
         
         read(io, iostat=stat) header

--- a/src/stdlib_io_npy_load.fypp
+++ b/src/stdlib_io_npy_load.fypp
@@ -122,7 +122,10 @@ contains
         character(len=8) :: header
         character :: buf(4)
         logical :: fortran_order
-
+        
+        ! stat should be zero by default, if no error occured
+        stat = 0
+        
         read(io, iostat=stat) header
         if (stat /= 0) return
 


### PR DESCRIPTION
Fixes #709 as proposed by @degawa
I just moved the assignment to the start of the routine so its clear that if nothing changes that `stat` variable, it defaults to zero.