### PR TITLE
fixed unassigned value to a intent(out) variable in `parse_header`

### DIFF
--- a/src/stdlib_io_npy_load.fypp
+++ b/src/stdlib_io_npy_load.fypp
@@ -185,6 +185,9 @@ contains
 
         integer :: minor
 
+        ! stat should be zero if no error occurred
+        stat = 0
+
         if (header(1:1) /= magic_number) then
             stat = 1
             msg = "Expected z'93' but got z'"//to_string(ichar(header(1:1)))//"' "//&


### PR DESCRIPTION
Thank you, @14NGiestas and @jvdp1, for fixing issue #706 I reported.

Although you solved the issue (any value is not assigned to an intent(out) argument) found in `get_descriptor`, I discovered that the same problem still exists in `parse_header` called in `get_descriptor`.
 
I am sending this pull request to fix the issue. I would be happy if you reviewed the pull request.
This pull request fixes the failure of `test_npy`.

```console
stdlib>fpm test test_npy --compiler nagfor --profile release --flag "-fpp"
Project is up to date
# Testing: npy
  Starting read-rdp-r2 ... (1/21)    
       ... read-rdp-r2 [FAILED]      
  Message: Reading of npy file failed
  Starting read-rdp-r3 ... (2/21)    
       ... read-rdp-r3 [FAILED]      
  Message: Reading of npy file failed
  Starting read-rsp-r1 ... (3/21)    
       ... read-rsp-r1 [FAILED]      
  Message: Reading of npy file failed
  Starting read-rsp-r2 ... (4/21)    
       ... read-rsp-r2 [FAILED]      
  Message: Reading of npy file failed
  Starting write-rdp-r2 ... (5/21)   
       ... write-rdp-r2 [FAILED]     
  Message: Reading of npy file failed
  Starting write-rsp-r2 ... (6/21)   
       ... write-rsp-r2 [FAILED]     
  Message: Reading of npy file failed
  Starting write-i2-r4 ... (7/21)    
       ... write-i2-r4 [FAILED]

7 test(s) failed!
ERROR STOP
<ERROR> Execution failed for object " test_npy.exe "
<ERROR>*cmd_run*:stopping due to failed executions
STOP 1

>fpm test test_npy --compiler nagfor --profile release --flag "-fpp"
Project is up to date
# Testing: npy
  Starting read-rdp-r2 ... (1/21)
       ... read-rdp-r2 [PASSED]
  Starting read-rdp-r3 ... (2/21)
       ... read-rdp-r3 [PASSED]
  Starting read-rsp-r1 ... (3/21)
       ... read-rsp-r1 [PASSED]
  Starting read-rsp-r2 ... (4/21)
       ... read-rsp-r2 [PASSED]
  Starting write-rdp-r2 ... (5/21)
       ... write-rdp-r2 [PASSED]
  Starting write-rsp-r2 ... (6/21)
       ... write-rsp-r2 [PASSED]
  Starting write-i2-r4 ... (7/21)
       ... write-i2-r4 [PASSED]
```

