### PR TITLE
fixed a problem with `dat` and `npy` files in example dir not being deployed

### DIFF
--- a/ci/fpm-deployment.sh
+++ b/ci/fpm-deployment.sh
@@ -50,6 +50,8 @@ find src -maxdepth 1 -iname "*.f90" -exec cp {} "$destdir/src/" \;
 find test -name "test_*.f90" -exec cp {} "$destdir/test/" \;
 find test -name "*.dat" -exec cp {} "$destdir/" \;
 find example -name "example_*.f90" -exec cp {} "$destdir/example/" \;
+find example -name "*.dat" -exec cp {} "$destdir/" \;
+find example -name "*.npy" -exec cp {} "$destdir/" \;
 
 # Include additional files
 cp "${include[@]}" "$destdir/"


### PR DESCRIPTION
Regarding issue #705, I fixed `./ci/fpm-deployment.sh` by adding commands to copy `*.dat` and `*.npy` files.
A diff between the outputs of the scripts before and after the fix shows the `*.dat` and `*.npy` files are copied.

```console
~/stdlib$ git switch master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
~/stdlib$ bash ./ci/fpm-deployment.sh > current.log
~/stdlib$ rm -rf stdlib-fpm/

# fixed fpm-deployment.sh and re-run
~/stdlib$ bash ./ci/fpm-deployment.sh > fixed.log
~/stdlib$ diff current.log fixed.log 
5a6, 7
> example.dat
> example.npy
```

closes #705 