### PR TITLE
Add warning for breaking change in fpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ stdlib = { git="https://github.com/fortran-lang/stdlib", branch="stdlib-fpm" }
 > To include the standard library metapackage, change the dependency to:
 > `stdlib = "*"`.
 > 
-> see also https://fpm.fortran-lang.org/en/spec/metapackages.html
+> [see also](https://fpm.fortran-lang.org/en/spec/metapackages.html)
 
 ## Using stdlib in your project
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,14 @@ To use `stdlib` within your `fpm` project, add the following lines to your `fpm.
 stdlib = { git="https://github.com/fortran-lang/stdlib", branch="stdlib-fpm" }
 ```
 
+> **Warning**
+> 
+> Fpm 0.8.2 and later implements stdlib as a *metapackage*.
+> To include the standard library metapackage, change the dependency to:
+> `stdlib = "*"`.
+> 
+> see also https://github.com/fortran-lang/fpm/pull/859
+
 ## Using stdlib in your project
 
 The stdlib project exports CMake package files and pkg-config files to make stdlib usable for other projects.

--- a/README.md
+++ b/README.md
@@ -201,11 +201,11 @@ stdlib = { git="https://github.com/fortran-lang/stdlib", branch="stdlib-fpm" }
 
 > **Warning**
 > 
-> Fpm 0.8.2 and later implements stdlib as a *metapackage*.
+> Fpm 0.9.0 and later implements stdlib as a *metapackage*.
 > To include the standard library metapackage, change the dependency to:
 > `stdlib = "*"`.
 > 
-> see also https://github.com/fortran-lang/fpm/pull/859
+> see also https://fpm.fortran-lang.org/en/spec/metapackages.html
 
 ## Using stdlib in your project
 


### PR DESCRIPTION
Fpm 0.8.2 introduced stdlib as a metapackage.
The previous way to include stdlib in a fpm project produces following error:
```
<ERROR> *cmd_run* Package error: Could not retrieve version string for metapackage key <stdlib>. Check syntax
```
<!--
Thank you for contributing to stdlib.
To help us get your pull request merged more quickly, please consider reviewing any of the already open pull requests.
-->
