### PR TITLE
fix doc stats-distribution-normal and stats-distribution-exponential

### DIFF
--- a/doc/specs/stdlib_stats_distribution_exponential.md
+++ b/doc/specs/stdlib_stats_distribution_exponential.md
@@ -14,11 +14,12 @@ Experimental
 
 ### Description
 
-An exponential distribution is the distribution of time between events in a Poisson point process. The inverse scale parameter `lambda` specifies the average time between events ($\lambda$), also called the rate of events.
+An exponential distribution is the distribution of time between events in a Poisson point process.
+The inverse scale parameter `lambda` specifies the average time between events (\(\lambda\)), also called the rate of events.
 
-Without argument, the function returns a random sample from the standard exponential distribution $E(\lambda=1)$.
+Without argument, the function returns a random sample from the standard exponential distribution \(E(\lambda=1)\).
 
-With a single argument, the function returns a random sample from the exponential distribution $E(\lambda=\text{lambda})$.
+With a single argument, the function returns a random sample from the exponential distribution \(E(\lambda=\text{lambda})\).
 For complex arguments, the real and imaginary parts are sampled independently of each other.
 
 With two arguments, the function returns a rank-1 array of exponentially distributed random variates.
@@ -64,7 +65,7 @@ The probability density function (pdf) of the single real variable exponential d
 
 $$f(x)=\begin{cases} \lambda e^{-\lambda x} &x\geqslant 0 \\\\ 0 &x< 0\end{cases}$$
 
-For a complex variable $z=(x + y i)$ with independent real $x$ and imaginary $y$ parts, the joint probability density function is the product of the corresponding real and imaginary marginal pdfs:[^2]
+For a complex variable \(z=(x + y i)\) with independent real \(x\) and imaginary \(y\) parts, the joint probability density function is the product of the corresponding real and imaginary marginal pdfs:[^2]
 
 $$f(x+\mathit{i}y)=f(x)f(y)=\begin{cases} \lambda_{x} \lambda_{y} e^{-(\lambda_{x} x + \lambda_{y} y)} &x\geqslant 0, y\geqslant 0 \\\\ 0 &\text{otherwise}\end{cases}$$
 
@@ -107,7 +108,7 @@ Cumulative distribution function (cdf) of the single real variable exponential d
 
 $$F(x)=\begin{cases}1 - e^{-\lambda x} &x\geqslant 0 \\\\ 0 &x< 0\end{cases}$$
 
-For a complex variable $z=(x + y i)$ with independent real $x$ and imaginary $y$ parts, the joint cumulative distribution function is the product of corresponding real and imaginary marginal cdfs:[^2]
+For a complex variable  \(z=(x + y i)\) with independent real \(x\) and imaginary \(y\) parts, the joint cumulative distribution function is the product of corresponding real and imaginary marginal cdfs:[^2]
 
 $$F(x+\mathit{i}y)=F(x)F(y)=\begin{cases} (1 - e^{-\lambda_{x} x})(1 - e^{-\lambda_{y} y}) &x\geqslant 0, \;\; y\geqslant 0 \\\\ 0 & \text{otherwise} \end{cases}$$
 
@@ -138,6 +139,6 @@ The result is a scalar or an array, with a shape conformable to the arguments, a
 {!example/stats_distribution_exponential/example_exponential_cdf.f90!}
 ```
 
-[^1] Marsaglia, George, and Wai Wan Tsang. "The ziggurat method for generating random variables." _Journal of statistical software_ 5 (2000): 1-7.
+[^1]: Marsaglia, George, and Wai Wan Tsang. "The ziggurat method for generating random variables." _Journal of statistical software_ 5 (2000): 1-7.
 
-[^2] Miller, Scott, and Donald Childers. _Probability and random processes: With applications to signal processing and communications_. Academic Press, 2012 (p. 197).
+[^2]: Miller, Scott, and Donald Childers. _Probability and random processes: With applications to signal processing and communications_. Academic Press, 2012 (p. 197).

--- a/doc/specs/stdlib_stats_distribution_normal.md
+++ b/doc/specs/stdlib_stats_distribution_normal.md
@@ -14,11 +14,12 @@ Experimental
 
 ### Description
 
-A normal continuous random variate distribution, also known as Gaussian, or Gauss or Laplace-Gauss distribution. The location `loc` specifies the mean or expectation ($\mu$). The `scale` specifies the standard deviation ($\sigma$).
+A normal continuous random variate distribution, also known as Gaussian, or Gauss or Laplace-Gauss distribution.
+The location `loc` specifies the mean or expectation (\(\mu\)). The `scale` specifies the standard deviation (\(\sigma\)).
 
-Without argument, the function returns a standard normal distributed random variate $N(0,1)$.
+Without argument, the function returns a standard normal distributed random variate \(N(0,1)\).
 
-With two arguments, the function returns a normal distributed random variate $N(\mu=\text{loc}, \sigma^2=\text{scale}^2)$. For complex arguments, the real and imaginary parts are independent of each other.
+With two arguments, the function returns a normal distributed random variate \(N(\mu=\text{loc}, \sigma^2=\text{scale}^2)\). For complex arguments, the real and imaginary parts are independent of each other.
 
 With three arguments, the function returns a rank-1 array of normal distributed random variates.
 
@@ -65,7 +66,7 @@ The probability density function (pdf) of the single real variable normal distri
 
 $$f(x) = \frac{1}{\sigma \sqrt{2}} \exp{\left[-\frac{1}{2}\left(\frac{x-\mu}{\sigma}\right)^{2}\right]}$$
 
-For a complex varible $z=(x + y i)$ with independent real $x$ and imaginary $y$ parts, the joint probability density function is the product of the the corresponding real and imaginary marginal pdfs:[^2]
+For a complex varible \( z=(x + y i) \) with independent real \( x \) and imaginary \( y \) parts, the joint probability density function is the product of the the corresponding real and imaginary marginal pdfs:[^2]
 
 $$f(x + y \mathit{i}) = f(x) f(y) = \frac{1}{2\sigma_{x}\sigma_{y}} \exp{\left[-\frac{1}{2}\left(\left(\frac{x-\mu_x}{\sigma_{x}}\right)^{2}+\left(\frac{y-\mu_y}{\sigma_{y}}\right)^{2}\right)\right]}$$
 
@@ -109,7 +110,7 @@ Cumulative distribution function of the single real variable normal distribution
 
 $$F(x) = \frac{1}{2}\left [ 1+\text{erf}\left(\frac{x-\mu}{\sigma \sqrt{2}}\right) \right ]$$
 
-For the complex variable $z=(x + y i)$ with independent real $x$ and imaginary $y$ parts, the joint cumulative distribution function is the product of the corresponding real and imaginary marginal cdfs:[^2]
+For the complex variable \( z=(x + y i) \) with independent real \( x \) and imaginary \( y \) parts, the joint cumulative distribution function is the product of the corresponding real and imaginary marginal cdfs:[^2]
 
 $$ F(x+y\mathit{i})=F(x)F(y)=\frac{1}{4} \
 \left[ 1+\text{erf}\left(\frac{x-\mu_x}{\sigma_x \sqrt{2}}\right) \right] \
@@ -140,9 +141,9 @@ The result is a scalar or an array, with a shape conformable to the arguments, a
 ### Example
 
 ```fortran
-{!example/stats_distribution_normal/example_norm_cdf.f90!}
+{!example/stats_distribution_normal/example_normal_cdf.f90!}
 ```
 
-[^1] Marsaglia, George, and Wai Wan Tsang. "The ziggurat method for generating random variables." _Journal of statistical software_ 5 (2000): 1-7.
+[^1]: Marsaglia, George, and Wai Wan Tsang. "The ziggurat method for generating random variables." _Journal of statistical software_ 5 (2000): 1-7.
 
-[^2] Miller, Scott, and Donald Childers. _Probability and random processes: With applications to signal processing and communications_. Academic Press, 2012 (p. 197).
+[^2]: Miller, Scott, and Donald Childers. _Probability and random processes: With applications to signal processing and communications_. Academic Press, 2012 (p. 197).


### PR DESCRIPTION
This PR aims to fix some residual/undetected issues with PR #717 and #718 , namely:
* inline math was not rendering due to use of incorrect symbol.
* footnotes were not rendering due to missing colon.
* outdated example filename.

I was not able to detect these issues earlier because, in my local windows env, FORD in unable to parse certain Fortran source files (encoding issue) and aborts. I still have this issue (and assume other may as well), but I am going around it by excluding the problematic files.