### PR TITLE
Proposal to fix the procedure `move` for string_type

### DIFF
--- a/doc/specs/stdlib_string_type.md
+++ b/doc/specs/stdlib_string_type.md
@@ -1537,7 +1537,8 @@ Pure subroutine (Elemental subroutine, only when both `from` and `to` are `type(
 - `from`: Character scalar or [[stdlib_string_type(module):string_type(type)]].
   This argument is `intent(inout)`.
 - `to`: Character scalar or [[stdlib_string_type(module):string_type(type)]].
-  This argument is `intent(out)`.
+  This argument is `intent(inout)` when both `from` and `to` are `type(string_type)`,
+  otherwise `intent(out)`.
 
 #### Example
 

--- a/doc/specs/stdlib_string_type.md
+++ b/doc/specs/stdlib_string_type.md
@@ -1523,6 +1523,7 @@ Experimental
 Moves the allocation from `from` to `to`, consequently deallocating `from` in this process.
 If `from` is not allocated before execution, `to` gets deallocated by the process.
 An unallocated `string_type` instance is equivalent to an empty string.
+If `from` and `to` are the same variable, then `from` remains unchanged.
 
 #### Syntax
 

--- a/src/stdlib_string_type.fypp
+++ b/src/stdlib_string_type.fypp
@@ -681,11 +681,10 @@ contains
     elemental subroutine move_string_string(from, to)
         type(string_type), intent(inout) :: from
         type(string_type), intent(inout) :: to
+        character(:), allocatable :: tmp
 
-        if(.not.allocated(from%raw))then
-         if(allocated(to%raw))deallocate(to%raw)
-         return
-        endif
+        call move_alloc(from%raw, tmp)
+        call move_alloc(tmp, to%raw)
 
         if(from%raw .eq. to%raw)then
          deallocate(from%raw)

--- a/src/stdlib_string_type.fypp
+++ b/src/stdlib_string_type.fypp
@@ -686,12 +686,6 @@ contains
         call move_alloc(from%raw, tmp)
         call move_alloc(tmp, to%raw)
 
-        if(from%raw .eq. to%raw)then
-         deallocate(from%raw)
-        else
-         call move_alloc(from%raw, to%raw)
-        endif
-
     end subroutine move_string_string
 
     !> Moves the allocated character scalar from 'from' to 'to'

--- a/src/stdlib_string_type.fypp
+++ b/src/stdlib_string_type.fypp
@@ -680,9 +680,18 @@ contains
     !> No output
     elemental subroutine move_string_string(from, to)
         type(string_type), intent(inout) :: from
-        type(string_type), intent(out) :: to
+        type(string_type), intent(inout) :: to
 
-        call move_alloc(from%raw, to%raw)
+        if(.not.allocated(from%raw))then
+         if(allocated(to%raw))deallocate(to%raw)
+         return
+        endif
+
+        if(from%raw .eq. to%raw)then
+         deallocate(from%raw)
+        else
+         call move_alloc(from%raw, to%raw)
+        endif
 
     end subroutine move_string_string
 

--- a/test/string/test_string_intrinsic.f90
+++ b/test/string/test_string_intrinsic.f90
@@ -667,6 +667,7 @@ contains
         !> Error handling
         type(error_type), allocatable, intent(out) :: error
         type(string_type) :: from_string, to_string
+        type(string_type) :: from_string_not
         type(string_type) :: from_strings(2), to_strings(2)
         character(len=:), allocatable :: from_char, to_char
 
@@ -706,7 +707,7 @@ contains
         call check(error, .not. allocated(from_char) .and. from_string == "new char", "move: test_case 6")
         if (allocated(error)) return
 
-        ! character (unallocated) --> string_type (allocated)
+        ! character (not allocated) --> string_type (allocated)
         call move(from_char, from_string)
         call check(error, from_string == "", "move: test_case 7")
         if (allocated(error)) return
@@ -720,6 +721,18 @@ contains
         ! elemental: string_type (allocated) --> string_type (not allocated)
         call move(from_strings, to_strings)
         call check(error, all(from_strings(:) == "") .and. all(to_strings(:) == "Move This String"), "move: test_case 9")
+
+        ! string_type (not allocated) --> string_type (not allocated)
+        call move(from_string_not, to_string)
+        call check(error, from_string_not == "" .and. to_string == "", "move: test_case 10")
+        if (allocated(error)) return
+
+        ! string_type (not allocated) --> string_type (not allocated)
+        to_string = "to be deallocated"
+        call move(from_string_not, to_string)
+        call check(error, from_string_not == "" .and. to_string == "", "move: test_case 11")
+        if (allocated(error)) return
+
     end subroutine test_move
 
 end module test_string_intrinsic

--- a/test/string/test_string_intrinsic.f90
+++ b/test/string/test_string_intrinsic.f90
@@ -715,7 +715,7 @@ contains
         from_string = "moving to self"
         ! string_type (allocated) --> string_type (allocated)
         call move(from_string, from_string)
-        call check(error, from_string == "", "move: test_case 8")
+        call check(error, from_string == "moving to self", "move: test_case 8")
         if (allocated(error)) return
         
         ! elemental: string_type (allocated) --> string_type (not allocated)


### PR DESCRIPTION

Issue (see #731 and #735 for more detail): seg fault occurs when the input and output `string_type` variable is the same in `move`:
```fortran
call move( from, from)
```

@band-a-prend @nkevy @awvwgk  Would this proposition work for you? Could you test it with GCC 13, please?

Fixes #731 and #735


