### PR TITLE
Fixed incorrect intent of the variable "conflict" on hashmaps in document

### DIFF
--- a/doc/specs/stdlib_hashmaps.md
+++ b/doc/specs/stdlib_hashmaps.md
@@ -1478,7 +1478,7 @@ entry.
   associated with the `key`.
 
 `conflict` (optional): shall be a scalar variable of type
-`logical`. It is an `intent(in)` argument. If present, a `.true.`
+`logical`. It is an `intent(out)` argument. If present, a `.true.`
 value indicates that an entry with the value of `key` already exists
 and the entry was not entered into the map, a `.false.` value indicates
 that `key` was not present in the map and the entry was added to the


### PR DESCRIPTION
<!--
Thank you for contributing to stdlib.
To help us get your pull request merged more quickly, please consider reviewing any of the already open pull requests.
-->

In the source code, the intent of the variable "conflict" in the procedure "map_entry" is "out", whereas in the documentation it is "in".
I corrected it from "in" to "out" on the documentation.

https://github.com/fortran-lang/stdlib/blob/82f35a57063f5db39ac8c469867d560327ff7cd0/src/stdlib_hashmaps.f90#L417-L431