### PR TITLE
Move `reverse` from `stdlib_ascii` to `stdlib_strings`

### DIFF
--- a/example/ascii/example_ascii_reverse.f90
+++ b/example/ascii/example_ascii_reverse.f90
@@ -1,5 +1,5 @@
 program example_reverse
-  use stdlib_ascii, only: reverse
+  use stdlib_strings, only: reverse
   implicit none
   print'(a)', reverse("Hello, World!") ! returns "!dlroW ,olleH"
 end program example_reverse

--- a/example/string_type/example_reverse.f90
+++ b/example/string_type/example_reverse.f90
@@ -1,5 +1,5 @@
 program example_reverse
-  use stdlib_string_type
+  use stdlib_strings
   implicit none
   type(string_type) :: string, reverse_string
 

--- a/src/stdlib_ascii.fypp
+++ b/src/stdlib_ascii.fypp
@@ -19,7 +19,7 @@ module stdlib_ascii
     public :: is_lower, is_upper
 
     ! Character conversion functions
-    public :: to_lower, to_upper, to_title, to_sentence, reverse
+    public :: to_lower, to_upper, to_title, to_sentence
 
     ! All control characters in the ASCII table (see www.asciitable.com).
     character(len=1), public, parameter :: NUL = achar(int(z'00')) !! Null
@@ -95,14 +95,6 @@ module stdlib_ascii
     interface to_sentence
         module procedure :: to_sentence
     end interface to_sentence
-
-    !> Returns a new character sequence which is reverse of
-    !> the input charater sequence
-    !> This method is pure and returns a character sequence
-    interface reverse
-        module procedure :: reverse
-    end interface reverse
-    
 
 contains
 
@@ -328,21 +320,5 @@ contains
         end do
 
     end function to_sentence
-
-    !> Reverse the character order in the input character variable
-    !> ([Specification](../page/specs/stdlib_ascii.html#reverse))
-    !>
-    !> Version: experimental
-    pure function reverse(string) result(reverse_string)
-        character(len=*), intent(in) :: string
-        character(len=len(string)) :: reverse_string
-        integer :: i, n
-
-        n = len(string)
-        do i = 1, n
-            reverse_string(n-i+1:n-i+1) = string(i:i)
-        end do
-
-    end function reverse
 
 end module stdlib_ascii

--- a/src/stdlib_string_type.fypp
+++ b/src/stdlib_string_type.fypp
@@ -14,7 +14,7 @@
 !> The specification of this module is available [here](../page/specs/stdlib_string_type.html).
 module stdlib_string_type
     use stdlib_ascii, only: to_lower_ => to_lower, to_upper_ => to_upper, &
-       & to_title_ => to_title, to_sentence_ => to_sentence, reverse_ => reverse
+       & to_title_ => to_title, to_sentence_ => to_sentence
     use stdlib_kinds, only : int8, int16, int32, int64, lk, c_bool
     use stdlib_optval, only: optval
     implicit none
@@ -23,7 +23,7 @@ module stdlib_string_type
     public :: string_type
     public :: len, len_trim, trim, index, scan, verify, repeat, adjustr, adjustl
     public :: lgt, lge, llt, lle, char, ichar, iachar
-    public :: to_lower, to_upper, to_title, to_sentence, reverse, move
+    public :: to_lower, to_upper, to_title, to_sentence, move
     public :: assignment(=)
     public :: operator(>), operator(>=), operator(<), operator(<=)
     public :: operator(==), operator(/=), operator(//)
@@ -140,14 +140,6 @@ module stdlib_string_type
     interface to_sentence
         module procedure :: to_sentence_string
     end interface to_sentence
-
-    !> Reverses the character sequence hold by the input string
-    !> 
-    !> This method is elemental and returns a new string_type instance which holds this
-    !> reverse character sequence
-    interface reverse
-        module procedure :: reverse_string
-    end interface reverse
 
     !> Return the character sequence represented by the string.
     !>
@@ -550,16 +542,6 @@ contains
         sentence_string%raw = to_sentence_(maybe(string))
 
     end function to_sentence_string
-
-
-    !> Reverse the character sequence hold by the input string
-    elemental function reverse_string(string) result(reversed_string)
-        type(string_type), intent(in) :: string
-        type(string_type) :: reversed_string
-
-        reversed_string%raw = reverse_(maybe(string))
-
-    end function reverse_string
 
 
     !> Position of a sequence of character within a character sequence.

--- a/src/stdlib_strings.fypp
+++ b/src/stdlib_strings.fypp
@@ -15,6 +15,7 @@ module stdlib_strings
     public :: strip, chomp
     public :: starts_with, ends_with
     public :: slice, find, replace_all, padl, padr, count, zfill
+    public :: reverse
 
     !> Version: experimental
     !>
@@ -163,6 +164,13 @@ module stdlib_strings
         module procedure :: zfill_string
         module procedure :: zfill_char
     end interface zfill
+
+    !> Returns a new character sequence which is reverse of
+    !> the input charater sequence
+    !> This method is pure and returns a character sequence
+    interface reverse
+        module procedure :: reverse
+    end interface reverse
 
 contains
 
@@ -942,6 +950,22 @@ contains
         res = padl(string, output_length, "0")
 
     end function zfill_char
+
+    !> Reverse the character order in the input character variable
+    !> ([Specification](../page/specs/stdlib_strings.html#reverse))
+    !>
+    !> Version: experimental
+    pure function reverse(string) result(reverse_string)
+        character(len=*), intent(in) :: string
+        character(len=len(string)) :: reverse_string
+        integer :: i, n
+
+        n = len(string)
+        do i = 1, n
+            reverse_string(n-i+1:n-i+1) = string(i:i)
+        end do
+
+    end function reverse
     
 
 end module stdlib_strings

--- a/test/ascii/test_ascii.f90
+++ b/test/ascii/test_ascii.f90
@@ -5,7 +5,7 @@ module test_ascii
         whitespace, letters, is_alphanum, is_alpha, is_lower, is_upper, &
         is_digit, is_octal_digit, is_hex_digit, is_white, is_blank, &
         is_control, is_punctuation, is_graphical, is_printable, is_ascii, &
-        to_lower, to_upper, to_title, to_sentence, reverse, LF, TAB, NUL, DEL
+        to_lower, to_upper, to_title, to_sentence, LF, TAB, NUL, DEL
     use stdlib_kinds, only : int8, int16, int32, int64, lk
     implicit none
     private
@@ -55,8 +55,8 @@ contains
             new_unittest("to_upper_string", test_to_upper_string), &
             new_unittest("to_lower_string", test_to_lower_string), &
             new_unittest("to_title_string", test_to_title_string), &
-            new_unittest("to_sentence_string", test_to_sentence_string), &
-            new_unittest("reverse_string", test_reverse_string) &
+            new_unittest("to_sentence_string", test_to_sentence_string) &
+            ! new_unittest("reverse_string", test_reverse_string) &
             ]
     end subroutine collect_ascii
 
@@ -901,30 +901,30 @@ contains
         if (allocated(error)) return
     end subroutine test_to_sentence_string
 
-    subroutine test_reverse_string(error)
-        !> Error handling
-        type(error_type), allocatable, intent(out) :: error
+    ! subroutine test_reverse_string(error)
+    !     !> Error handling
+    !     type(error_type), allocatable, intent(out) :: error
 
-        character(len=:), allocatable :: dlc
-        character(len=32), parameter :: input = "reversed"
+    !     character(len=:), allocatable :: dlc
+    !     character(len=32), parameter :: input = "reversed"
 
-        dlc = reverse("reversed")
-        call check(error, dlc, "desrever")
-        if (allocated(error)) return
+    !     dlc = reverse("reversed")
+    !     call check(error, dlc, "desrever")
+    !     if (allocated(error)) return
 
-        dlc = reverse(input)
-        call check(error, len(dlc), 32)
-        if (allocated(error)) return
+    !     dlc = reverse(input)
+    !     call check(error, len(dlc), 32)
+    !     if (allocated(error)) return
 
-        call check(error, len_trim(dlc), 32)
-        if (allocated(error)) return
+    !     call check(error, len_trim(dlc), 32)
+    !     if (allocated(error)) return
 
-        call check(error, trim(dlc), "                        desrever")
-        if (allocated(error)) return
+    !     call check(error, trim(dlc), "                        desrever")
+    !     if (allocated(error)) return
 
-        call check(error, trim(adjustl(dlc)), "desrever")
-        if (allocated(error)) return
-    end subroutine test_reverse_string
+    !     call check(error, trim(adjustl(dlc)), "desrever")
+    !     if (allocated(error)) return
+    ! end subroutine test_reverse_string
 
 
 end module test_ascii

--- a/test/io/test_parse_mode.f90
+++ b/test/io/test_parse_mode.f90
@@ -1,5 +1,6 @@
 module test_parse_mode
-    use stdlib_ascii, only: reverse
+    ! use stdlib_ascii, only: reverse
+    use stdlib_strings, only: reverse
     use stdlib_io, only: parse_mode
     use testdrive, only: new_unittest, unittest_type, error_type, check
     implicit none

--- a/test/string/test_string_functions.f90
+++ b/test/string/test_string_functions.f90
@@ -3,10 +3,10 @@ module test_string_functions
     use, intrinsic :: iso_fortran_env, only : error_unit
     use testdrive, only : new_unittest, unittest_type, error_type, check
     use stdlib_string_type, only : string_type, assignment(=), operator(==), &
-                                    to_lower, to_upper, to_title, to_sentence, reverse
+                                    to_lower, to_upper, to_title, to_sentence
     use stdlib_strings, only: slice, find, replace_all, padl, padr, count, zfill
     use stdlib_optval, only: optval
-    use stdlib_strings, only : to_string
+    use stdlib_strings, only : to_string, reverse
     implicit none
 
 contains

--- a/test/string/test_string_match.f90
+++ b/test/string/test_string_match.f90
@@ -1,8 +1,8 @@
 ! SPDX-Identifier: MIT
 module test_string_match
     use testdrive, only : new_unittest, unittest_type, error_type, check
-    use stdlib_ascii, only : reverse
-    use stdlib_strings, only : starts_with, ends_with
+    ! use stdlib_ascii, only : reverse
+    use stdlib_strings, only : starts_with, ends_with, reverse
     use stdlib_string_type, only : string_type
     implicit none
 


### PR DESCRIPTION
When I build, it throws me following error, I am not sure why it happens:

```console
% cmake --build build                             
[ 19%] Built target fortran_stdlib
[ 19%] Built target test-drive-lib
[ 19%] Built target test_always_skip
[ 20%] Built target test_always_fail
[ 21%] Built target test-drive-tester
[ 22%] Built target test_logicalloc
[ 22%] Built target test_ascii
[ 22%] Built target test_stdlib_bitset_64
[ 23%] Built target test_stdlib_bitset_large
[ 24%] Built target test_hash_functions
[ 24%] Built target test_32_bit_hash_performance
[ 24%] Built target test_64_bit_hash_performance
[ 25%] Built target test_chaining_maps
[ 25%] Built target test_open_maps
[ 25%] Built target test_maps
[ 25%] Built target test_loadtxt
[ 25%] Built target test_savetxt
[ 25%] Built target test_loadtxt_qp
[ 25%] Built target test_savetxt_qp
[ 25%] Built target test_getline
[ 26%] Built target test_npy
[ 26%] Built target test_open
[ 26%] Built target test_parse_mode
[ 26%] Built target test_linalg
[ 26%] Built target test_linalg_matrix_property_checks
[ 26%] Built target test_stdlib_logger
[ 27%] Built target test_optval
[ 28%] Built target test_selection
[ 29%] Built target test_sorting
[ 29%] Built target test_specialfunctions_gamma
[ 29%] Built target test_corr
[ 29%] Built target test_cov
[ 30%] Built target test_mean
[ 30%] Built target test_median
[ 30%] Built target test_moment
[ 31%] Built target test_rawmoment
[ 31%] Built target test_var
[ 32%] Built target test_varn
[ 32%] Built target test_random
[ 33%] Built target test_distribution_uniform
[ 33%] Built target test_distribution_normal
[ 34%] Built target test_distribution_exponential
[ 35%] Built target test_string_assignment
[ 35%] Built target test_string_operator
[ 35%] Built target test_string_intrinsic
[ 36%] Built target test_string_match
[ 36%] Built target test_string_derivedtype_io
[ 36%] Building Fortran object test/string/CMakeFiles/test_string_functions.dir/test_string_functions.f90.o
/Users/pranavchiku/repos/stdlib-fortran-lang/test/string/test_string_functions.f90:93:26:

   93 |         call check(error, reverse(test_string) == compare_string)
      |                          1
Error: There is no specific function for the generic 'reverse' at (1)
/Users/pranavchiku/repos/stdlib-fortran-lang/test/string/test_string_functions.f90:717:9:

  717 |     use test_string_functions, only : collect_string_functions
      |         1
Fatal Error: Cannot open module file 'test_string_functions.mod' for reading at (1): No such file or directory
compilation terminated.
make[2]: *** [test/string/CMakeFiles/test_string_functions.dir/test_string_functions.f90.o] Error 1
make[1]: *** [test/string/CMakeFiles/test_string_functions.dir/all] Error 2
make: *** [all] Error 2
```
