### PR TITLE
Fix undefined use of <cstdint> types

### DIFF
--- a/test/hash_functions/SpookyV2Test.cpp
+++ b/test/hash_functions/SpookyV2Test.cpp
@@ -5,36 +5,36 @@ extern "C" {
 #endif
 
 void SpookyHash32_with_state_test(const void *key, size_t len, const void *state, void *out) {
-  uint64_t *state64= (uint64_t *)state;
-  uint64_t s0 = state64[0];
-  uint64_t s1 = state64[1];
+  uint64 *state64= (uint64 *)state;
+  uint64 s0 = state64[0];
+  uint64 s1 = state64[1];
   SpookyHash::Hash128(key, len, &s0, &s1);
-  ((uint32_t *)out)[0]= (uint32_t)s0;
+  ((uint32 *)out)[0]= (uint32)s0;
 }
 
 void SpookyHash64_with_state_test(const void *key, size_t len, const void *state, void *out) {
-  uint64_t *state64= (uint64_t *)state;
-  uint64_t *out64= (uint64_t *)out;
+  uint64 *state64= (uint64 *)state;
+  uint64 *out64= (uint64 *)out;
   out64[0] = state64[0];
-  uint64_t s1 = state64[1];
+  uint64 s1 = state64[1];
   SpookyHash::Hash128(key, len, out64, &s1);
 }
 
 void SpookyHash128_with_state_test(const void *key, size_t len, const void *state, void *out) {
-  uint64_t *state64= (uint64_t *)state;
-  uint64_t *out64= (uint64_t *)out;
+  uint64 *state64= (uint64 *)state;
+  uint64 *out64= (uint64 *)out;
   out64[0] = state64[0];
   out64[1] = state64[1];
   SpookyHash::Hash128(key, len, out64, out64+1);
 }
 
 void SpookyHash_seed_state_test(int in_bits, const void *seed, void *state) {
-    uint64_t *state64= (uint64_t *)state;
+    uint64 *state64= (uint64 *)state;
     if (in_bits == 32) {
-        state64[0]= state64[1]= ((uint32_t*)seed)[0];
+        state64[0]= state64[1]= ((uint32*)seed)[0];
     }
     else {
-        uint64_t *seed64= (uint64_t *)seed;
+        uint64 *seed64= (uint64 *)seed;
         if (in_bits == 64) {
             state64[0]= state64[1]= seed64[0];
         }


### PR DESCRIPTION
I could not compile tests on windows, since SpookyV2Test.cpp uses types from the cstdint header (e.g., uint64_t) without including the header. The type aliases are already defined in SpookyV2.h, so I have used those type aliases instead.