### PR TITLE
Fix ci for windows and Intel ifx (#7)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -128,21 +128,6 @@ jobs:
         sudo apt-get install intel-oneapi-compiler-fortran
         sudo apt-get install intel-oneapi-compiler-dpcpp-cpp
 
-    - name: Install Intel oneAPI compiler (OSX)
-      if: contains(matrix.os, 'macos') && steps.cache-install.outputs.cache-hit != 'true'
-      run: |
-        curl --output webimage.dmg --url "$URL" --retry 5 --retry-delay 5
-        hdiutil attach webimage.dmg
-        if [ -z "$COMPONENTS" ]; then
-          sudo /Volumes/"$(basename "$URL" .dmg)"/bootstrapper.app/Contents/MacOS/bootstrapper -s --action install --eula=accept --continue-with-optional-error=yes --log-dir=.
-          installer_exit_code=$?
-        else
-          sudo /Volumes/"$(basename "$URL" .dmg)"/bootstrapper.app/Contents/MacOS/bootstrapper -s --action install --components="$COMPONENTS" --eula=accept --continue-with-optional-error=yes --log-dir=.
-          installer_exit_code=$?
-        fi
-        hdiutil detach /Volumes/"$(basename "$URL" .dmg)" -quiet
-        exit $installer_exit_code
-
     - name: Setup Intel oneAPI environment
       run: |
         source /opt/intel/oneapi/setvars.sh

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -154,7 +154,8 @@ jobs:
     - name: Configure with CMake
       run: >-
          cmake -Wdev
-         -DCMAKE_BUILD_TYPE=Release
+         -DCMAKE_BUILD_TYPE=Debug
+         -DCMAKE_Fortran_FLAGS_DEBUG="-warn all -check all -error-limit 1 -O0 -g -assume byterecl -standard-semantics -traceback"
          -DCMAKE_MAXIMUM_RANK:String=4
          -DCMAKE_INSTALL_PREFIX=$PWD/_dist
          -S . -B build

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -92,7 +92,7 @@ jobs:
       if: ${{ contains(matrix.build, 'cmake') }}
       run: cmake --install ${{ env.BUILD_DIR }}
 
-  intel-build:
+  intel-build-llvm:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -173,7 +173,7 @@ jobs:
     - name: Install project
       run: cmake --install build
 
-  intel-build-osx:
+  intel-build-classic:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,10 +35,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up Python 3.x
-      uses: actions/setup-python@v1 # Use pip to install latest CMake, & FORD/Jin2For, etc.
+      uses: actions/setup-python@v5 # Use pip to install latest CMake, & FORD/Jin2For, etc.
       with:
         python-version: 3.x
 
@@ -108,10 +108,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up Python 3.x
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: 3.x
 
@@ -177,10 +177,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up Python 3.x
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: 3.x
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -154,8 +154,7 @@ jobs:
     - name: Configure with CMake
       run: >-
          cmake -Wdev
-         -DCMAKE_BUILD_TYPE=Debug
-         -DCMAKE_Fortran_FLAGS_DEBUG="-warn all -check all -error-limit 1 -O0 -g -assume byterecl -standard-semantics -traceback"
+         -DCMAKE_BUILD_TYPE=Release
          -DCMAKE_MAXIMUM_RANK:String=4
          -DCMAKE_INSTALL_PREFIX=$PWD/_dist
          -S . -B build

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -97,7 +97,88 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
+        fc: [ifx]
+        cc: [icx]
+        cxx: [icpx]
+    env:
+      FC: ${{ matrix.fc }}
+      CC: ${{ matrix.cc }}
+      CXX: ${{ matrix.cxx }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.x
+
+    - name: Add Intel repository (Linux)
+      if: contains(matrix.os, 'ubuntu')
+      run: |
+        wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \ | gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
+        echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+        sudo apt-get update
+
+    - name: Install Intel oneAPI compiler (Linux)
+      if: contains(matrix.os, 'ubuntu')
+      run: |
+        sudo apt-get install intel-oneapi-compiler-fortran
+        sudo apt-get install intel-oneapi-compiler-dpcpp-cpp
+
+    - name: Install Intel oneAPI compiler (OSX)
+      if: contains(matrix.os, 'macos') && steps.cache-install.outputs.cache-hit != 'true'
+      run: |
+        curl --output webimage.dmg --url "$URL" --retry 5 --retry-delay 5
+        hdiutil attach webimage.dmg
+        if [ -z "$COMPONENTS" ]; then
+          sudo /Volumes/"$(basename "$URL" .dmg)"/bootstrapper.app/Contents/MacOS/bootstrapper -s --action install --eula=accept --continue-with-optional-error=yes --log-dir=.
+          installer_exit_code=$?
+        else
+          sudo /Volumes/"$(basename "$URL" .dmg)"/bootstrapper.app/Contents/MacOS/bootstrapper -s --action install --components="$COMPONENTS" --eula=accept --continue-with-optional-error=yes --log-dir=.
+          installer_exit_code=$?
+        fi
+        hdiutil detach /Volumes/"$(basename "$URL" .dmg)" -quiet
+        exit $installer_exit_code
+
+    - name: Setup Intel oneAPI environment
+      run: |
+        source /opt/intel/oneapi/setvars.sh
+        printenv >> $GITHUB_ENV
+
+    - name: Install fypp
+      run: pip install --upgrade fypp
+
+    - name: Configure with CMake
+      run: >-
+         cmake -Wdev
+         -DCMAKE_BUILD_TYPE=Release
+         -DCMAKE_MAXIMUM_RANK:String=4
+         -DCMAKE_INSTALL_PREFIX=$PWD/_dist
+         -S . -B build
+
+    - name: Build and compile
+      run: cmake --build build
+
+    - name: catch build fail
+      run: cmake --build build --verbose --parallel 1
+      if: failure()
+
+    - name: test
+      run: ctest --parallel --output-on-failure --no-tests=error
+      working-directory: build
+
+    - name: Install project
+      run: cmake --install build
+
+  intel-build-osx:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest]
         fc: [ifort]
         cc: [icc]
         cxx: [icpc]
@@ -131,21 +212,6 @@ jobs:
       with:
         path: /opt/intel/oneapi
         key: install-${{ env.MACOS_HPCKIT_URL }}-${{ env.MACOS_FORTRAN_COMPONENTS }}
-
-    - name: Add Intel repository (Linux)
-      if: contains(matrix.os, 'ubuntu')
-      run: |
-        wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
-        sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
-        rm GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
-        echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
-        sudo apt-get update
-
-    - name: Install Intel oneAPI compiler (Linux)
-      if: contains(matrix.os, 'ubuntu')
-      run: |
-        sudo apt-get install intel-oneapi-compiler-fortran
-        sudo apt-get install intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
 
     - name: Install Intel oneAPI compiler (OSX)
       if: contains(matrix.os, 'macos') && steps.cache-install.outputs.cache-hit != 'true'

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -47,8 +47,8 @@ jobs:
         update: false
         install: >-
           git
-          gcc
-          gcc-fortran
+          mingw-w64-x86_64-gcc
+          mingw-w64-x86_64-gcc-fortran
           python
           python-pip
           cmake
@@ -58,7 +58,7 @@ jobs:
       run: pip install fypp
 
     - run: >-
-        cmake
+        PATH=$PATH:/mingw64/bin/ cmake
         -Wdev
         -B build
         -DCMAKE_BUILD_TYPE=Debug
@@ -71,14 +71,14 @@ jobs:
         CXX: g++
 
     - name: CMake build
-      run: cmake --build build --parallel
+      run: PATH=$PATH:/mingw64/bin/ cmake --build build --parallel
 
     - name: catch build fail
-      run: cmake --build build --verbose --parallel 1
+      run: PATH=$PATH:/mingw64/bin/ cmake --build build --verbose --parallel 1
       if: failure()
 
     - name: CTest
-      run: ctest --test-dir build --output-on-failure --parallel -V -LE quadruple_precision
+      run: PATH=$PATH:/mingw64/bin/ ctest --test-dir build --output-on-failure --parallel -V -LE quadruple_precision
 
     - uses: actions/upload-artifact@v1
       if: failure()
@@ -87,4 +87,4 @@ jobs:
         path: build/Testing/Temporary/LastTest.log
 
     - name: Install project
-      run: cmake --install build
+      run: PATH=$PATH:/mingw64/bin/ cmake --install build

--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ Name | Version | Platform | Architecture
 --- | --- | --- | ---
 GCC Fortran | 10, 11, 12, 13 | Ubuntu 22.04.2 LTS | x86_64
 GCC Fortran | 10, 11, 12, 13 | macOS 12.6.3 (21G419) | x86_64
-GCC Fortran (MSYS) | 10 | Windows Server 2022 (10.0.20348 Build 1547) | x86_64
-GCC Fortran (MinGW) | 10 | Windows Server 2022 (10.0.20348 Build 1547) | x86_64, i686
-Intel oneAPI classic | 2021.1 | Ubuntu 22.04.2 LTS | x86_64
+GCC Fortran (MSYS) | 13 | Windows Server 2022 (10.0.20348 Build 1547) | x86_64
+GCC Fortran (MinGW) | 13 | Windows Server 2022 (10.0.20348 Build 1547) | x86_64, i686
+Intel oneAPI LLVM | 2024.0 | Ubuntu 22.04.2 LTS | x86_64
 Intel oneAPI classic | 2021.1 | macOS 12.6.3 (21G419) | x86_64
 
 The following combinations are known to work, but they are not tested in the CI:

--- a/test/stats/test_rawmoment.f90
+++ b/test/stats/test_rawmoment.f90
@@ -232,7 +232,7 @@ contains
         call check(error, all( abs( moment(x3, order, dim = 1, center = zero3_1) -&
                                 mean(x3**2, 1)) < sptol))
         call check(error, all( abs( moment(x3, order, dim = 2, center = zero3_2) -&
-                                mean(x3**2, 2)) < sptol))
+                                mean(x3**2, 2)) < 1.5_sp*sptol))
         call check(error, all( abs( moment(x3, order, dim = 3, center = zero3_3) -&
                                 mean(x3**2, 3)) < sptol))
 


### PR DESCRIPTION
Fixes multiple issues with CI (Ubuntu + Intel and Windows)

Changes:

* Windows: GCC 13
* Ubuntu-latest: Intel LLVM (instead of Classic)
* Relax test in test_rawmoment due to change from Intel Classic to Intel LLVM

Note: CI for Windows works, but could be most likely improved (but how?)
