### PR TITLE
Fix `bits()` in `bitset_type` before initialization

### DIFF
--- a/src/stdlib_bitsets.fypp
+++ b/src/stdlib_bitsets.fypp
@@ -100,7 +100,7 @@ module stdlib_bitsets
 !! Parent type for bitset_64 and bitset_large ([Specification](../page/specs/stdlib_bitsets.html#the-stdlib_bitsets-derived-types))
 
         private
-        integer(bits_kind) :: num_bits
+        integer(bits_kind) :: num_bits = 0_bits_kind
 
     contains
 

--- a/src/stdlib_bitsets_large.fypp
+++ b/src/stdlib_bitsets_large.fypp
@@ -1051,7 +1051,7 @@ contains
     pure module subroutine set_range_large(self, start_pos, stop_pos)
 !
 !     Sets all valid bits to 1 from the START_POS to the STOP_POS positions
-!     in SELF. If STOP_POA < START_POS no bits are changed. Positions outside
+!     in SELF. If STOP_POS < START_POS no bits are changed. Positions outside
 !     the range 0 to BITS(SELF)-1 are ignored.
 !
         class(bitset_large), intent(inout) :: self

--- a/test/bitsets/test_stdlib_bitset_64.f90
+++ b/test/bitsets/test_stdlib_bitset_64.f90
@@ -231,6 +231,15 @@ contains
 
         type(bitset_64) :: set4, set5
 
+        !The following block triggers an issue in gfortran 11 and 12
+        block
+        type(bitset_64) :: set6
+        call check(error, set6 % bits(), 0, &
+            'set6 % bits() returned non-zero value '//&
+            'even though set6 was not initialized.')
+        if (allocated(error)) return
+        end block
+
         set5 = log1
         call check(error, set5%bits(), 64, &
             'initialization with logical(int8) failed to set the right size.')

--- a/test/bitsets/test_stdlib_bitset_large.f90
+++ b/test/bitsets/test_stdlib_bitset_large.f90
@@ -345,6 +345,15 @@ contains
         logical(int64), allocatable :: log8(:)
         type(bitset_large) :: set4, set5
 
+        !The following triggers an issue in gfortran 11 and 12
+        block
+        type(bitset_large) :: set6
+        call check(error, set6 % bits(), 0, &
+            'set6 % bits() returned non-zero value '//&
+            'even though set6 was not initialized.')
+        if (allocated(error)) return
+        end block
+
         set5 = log1
         call check(error, set5 % bits(), 64, &
             ' initialization with logical(int8) failed to set' // &


### PR DESCRIPTION
Fixes #746 

+ Addition of tests that trigger the bug with GFortran 11 and 12

Issue #746 reported by @degawa 



