### PR TITLE
Add `.dat` and `.stream` file extensions to `.gitignore` on `master` branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ API-doc/
 *log*.txt
 *test*.txt
 scratch.txt
+*.dat
+*.stream


### PR DESCRIPTION
When running `fpm test` on the `stdlib-fpm` branch, some `.dat` and `.stream` files are being generated. After switching to the `master` branch, the files appear in the `git diff` because the extensions are currently missing in `.gitignore`. They are added herein.