### PR TITLE
Fix aliased `string` `move` interface

### DIFF
--- a/src/stdlib_string_type.fypp
+++ b/src/stdlib_string_type.fypp
@@ -17,6 +17,7 @@ module stdlib_string_type
        & to_title_ => to_title, to_sentence_ => to_sentence, reverse_ => reverse
     use stdlib_kinds, only : int8, int16, int32, int64, lk, c_bool
     use stdlib_optval, only: optval
+    use iso_c_binding, only: c_loc,c_associated
     implicit none
     private
 
@@ -679,10 +680,12 @@ contains
     !> Moves the allocated character scalar from 'from' to 'to'
     !> No output
     elemental subroutine move_string_string(from, to)
-        type(string_type), intent(inout) :: from
-        type(string_type), intent(inout) :: to
-        character(:), allocatable :: tmp
+        type(string_type), intent(inout), target :: from
+        type(string_type), intent(inout), target :: to
+        character(:), allocatable :: tmp 
 
+        if (c_associated(c_loc(from),c_loc(to))) return
+       
         call move_alloc(from%raw, tmp)
         call move_alloc(tmp, to%raw)
 


### PR DESCRIPTION
Fixes #744 (previous fix: 

The following line is causing a segfault on macOS, gfortran 13.2.0, hence failed test: 

https://github.com/fortran-lang/stdlib/blob/b8fbb3ce1aaf2fd1729897739fcdae8f6b3c4ef4/test/string/test_string_intrinsic.f90#L717

This line is _invalid Fortran_ because it violates the no-alising rule (that is one of the few reasons Fortran can optimize better than C): two dummy arguments passed by reference cannot point to the same address. So probably, gfortran optimizes out the temporary variable which then causes trouble. 

My proposed solution is to check the address first, and avoid the dangerous operation if the variable is the same. 






