### PR TITLE
Upgrade Intel-classic compiler in macOS CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -169,7 +169,7 @@ jobs:
         cxx: [icpc]
     env:
       MACOS_HPCKIT_URL: >-
-        https://registrationcenter-download.intel.com/akdlm/irc_nas/18242/m_HPCKit_p_2021.4.0.3389_offline.dmg
+        https:/registrationcenter-download.intel.com/akdlm/IRC_NAS/a99cb1c5-5af6-4824-9811-ae172d24e594/m_HPCKit_p_2023.1.0.44543.dmg
       MACOS_FORTRAN_COMPONENTS: all
       FC: ${{ matrix.fc }}
       CC: ${{ matrix.cc }}

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ GCC Fortran | 10, 11, 12, 13 | macOS 12.6.3 (21G419) | x86_64
 GCC Fortran (MSYS) | 13 | Windows Server 2022 (10.0.20348 Build 1547) | x86_64
 GCC Fortran (MinGW) | 13 | Windows Server 2022 (10.0.20348 Build 1547) | x86_64, i686
 Intel oneAPI LLVM | 2024.0 | Ubuntu 22.04.2 LTS | x86_64
-Intel oneAPI classic | 2021.1 | macOS 12.6.3 (21G419) | x86_64
+Intel oneAPI classic | 2023.1 | macOS 12.6.3 (21G419) | x86_64
 
 The following combinations are known to work, but they are not tested in the CI:
 


### PR DESCRIPTION
Address #776: 2021.4 -> 2023.1