### PR TITLE
add implicit none to example programs that do not have it

### DIFF
--- a/example/bitsets/example_bitsets_all.f90
+++ b/example/bitsets/example_bitsets_all.f90
@@ -1,5 +1,6 @@
 program example_all
   use stdlib_bitsets
+  implicit none
   character(*), parameter :: &
     bits_all = '111111111111111111111111111111111'
   type(bitset_64) :: set0

--- a/example/bitsets/example_bitsets_and.f90
+++ b/example/bitsets/example_bitsets_and.f90
@@ -1,5 +1,6 @@
 program example_and
   use stdlib_bitsets
+  implicit none
   type(bitset_large) :: set0, set1
   call set0%init(166)
   call set1%init(166)

--- a/example/bitsets/example_bitsets_and_not.f90
+++ b/example/bitsets/example_bitsets_and_not.f90
@@ -1,5 +1,6 @@
 program example_and_not
   use stdlib_bitsets
+  implicit none
   type(bitset_large) :: set0, set1
   call set0%init(166)
   call set1%init(166)

--- a/example/bitsets/example_bitsets_any.f90
+++ b/example/bitsets/example_bitsets_any.f90
@@ -1,5 +1,6 @@
 program example_any
   use stdlib_bitsets
+  implicit none
   character(*), parameter :: &
     bits_0 = '0000000000000000000'
   type(bitset_64) :: set0

--- a/example/bitsets/example_bitsets_bit_count.f90
+++ b/example/bitsets/example_bitsets_bit_count.f90
@@ -1,5 +1,6 @@
 program example_bit_count
   use stdlib_bitsets
+  implicit none
   character(*), parameter :: &
     bits_0 = '0000000000000000000'
   type(bitset_64) :: set0

--- a/example/bitsets/example_bitsets_bits.f90
+++ b/example/bitsets/example_bitsets_bits.f90
@@ -1,5 +1,6 @@
 program example_bits
   use stdlib_bitsets
+  implicit none
   character(*), parameter :: &
     bits_0 = '0000000000000000000'
   type(bitset_64) :: set0

--- a/example/bitsets/example_bitsets_clear.f90
+++ b/example/bitsets/example_bitsets_clear.f90
@@ -1,5 +1,6 @@
 program example_clear
   use stdlib_bitsets
+  implicit none
   type(bitset_large) :: set0
   call set0%init(166)
   call set0%not()

--- a/example/bitsets/example_bitsets_equality.f90
+++ b/example/bitsets/example_bitsets_equality.f90
@@ -1,5 +1,6 @@
 program example_equality
   use stdlib_bitsets
+  implicit none
   type(bitset_64) :: set0, set1, set2
   call set0%init(33)
   call set1%init(33)

--- a/example/bitsets/example_bitsets_extract.f90
+++ b/example/bitsets/example_bitsets_extract.f90
@@ -1,5 +1,6 @@
 program example_extract
   use stdlib_bitsets
+  implicit none
   type(bitset_large) :: set0, set1
   call set0%init(166)
   call set0%set(100, 150)

--- a/example/bitsets/example_bitsets_flip.f90
+++ b/example/bitsets/example_bitsets_flip.f90
@@ -1,5 +1,6 @@
 program example_flip
   use stdlib_bitsets
+  implicit none
   type(bitset_large) :: set0
   call set0%init(166)
   if (set0%none()) write (*, *) 'SET0 is properly initialized.'

--- a/example/bitsets/example_bitsets_from_string.f90
+++ b/example/bitsets/example_bitsets_from_string.f90
@@ -1,5 +1,6 @@
 program example_from_string
   use stdlib_bitsets
+  implicit none
   character(*), parameter :: &
     bits_all = '111111111111111111111111111111111'
   type(bitset_64) :: set0

--- a/example/bitsets/example_bitsets_ge.f90
+++ b/example/bitsets/example_bitsets_ge.f90
@@ -1,5 +1,6 @@
 program example_ge
   use stdlib_bitsets
+  implicit none
   type(bitset_64) :: set0, set1, set2
   call set0%init(33)
   call set1%init(33)

--- a/example/bitsets/example_bitsets_gt.f90
+++ b/example/bitsets/example_bitsets_gt.f90
@@ -1,5 +1,6 @@
 program example_gt
   use stdlib_bitsets
+  implicit none
   type(bitset_64) :: set0, set1, set2
   call set0%init(33)
   call set1%init(33)

--- a/example/bitsets/example_bitsets_inequality.f90
+++ b/example/bitsets/example_bitsets_inequality.f90
@@ -1,5 +1,6 @@
 program example_inequality
   use stdlib_bitsets
+  implicit none
   type(bitset_64) :: set0, set1, set2
   call set0%init(33)
   call set1%init(33)

--- a/example/bitsets/example_bitsets_init.f90
+++ b/example/bitsets/example_bitsets_init.f90
@@ -1,5 +1,6 @@
 program example_init
   use stdlib_bitsets
+  implicit none
   type(bitset_large) :: set0
   call set0%init(166)
   if (set0%bits() == 166) &

--- a/example/bitsets/example_bitsets_le.f90
+++ b/example/bitsets/example_bitsets_le.f90
@@ -1,5 +1,6 @@
 program example_le
   use stdlib_bitsets
+  implicit none
   type(bitset_64) :: set0, set1, set2
   call set0%init(33)
   call set1%init(33)

--- a/example/bitsets/example_bitsets_lt.f90
+++ b/example/bitsets/example_bitsets_lt.f90
@@ -1,5 +1,6 @@
 program example_lt
   use stdlib_bitsets
+  implicit none
   type(bitset_64) :: set0, set1, set2
   call set0%init(33)
   call set1%init(33)

--- a/example/bitsets/example_bitsets_none.f90
+++ b/example/bitsets/example_bitsets_none.f90
@@ -1,5 +1,6 @@
 program example_none
   use stdlib_bitsets
+  implicit none
   character(*), parameter :: &
     bits_0 = '0000000000000000000'
   type(bitset_large) :: set0

--- a/example/bitsets/example_bitsets_not.f90
+++ b/example/bitsets/example_bitsets_not.f90
@@ -1,5 +1,6 @@
 program example_not
   use stdlib_bitsets
+  implicit none
   type(bitset_large) :: set0
   call set0%init(155)
   if (set0%none()) then

--- a/example/bitsets/example_bitsets_or.f90
+++ b/example/bitsets/example_bitsets_or.f90
@@ -1,5 +1,6 @@
 program example_or
   use stdlib_bitsets
+  implicit none
   type(bitset_large) :: set0, set1
   call set0%init(166)
   call set1%init(166)

--- a/example/bitsets/example_bitsets_set.f90
+++ b/example/bitsets/example_bitsets_set.f90
@@ -1,5 +1,6 @@
 program example_set
   use stdlib_bitsets
+  implicit none
   type(bitset_large) :: set0
   call set0%init(166)
   if (set0%none()) write (*, *) 'SET0 is properly initialized.'

--- a/example/bitsets/example_bitsets_test.f90
+++ b/example/bitsets/example_bitsets_test.f90
@@ -1,5 +1,6 @@
 program example_test
   use stdlib_bitsets
+  implicit none
   type(bitset_large) :: set0
   call set0%init(166)
   call set0%not()

--- a/example/bitsets/example_bitsets_to_string.f90
+++ b/example/bitsets/example_bitsets_to_string.f90
@@ -1,5 +1,6 @@
 program example_to_string
   use stdlib_bitsets
+  implicit none
   character(*), parameter :: &
     bits_all = '111111111111111111111111111111111'
   type(bitset_64) :: set0

--- a/example/bitsets/example_bitsets_value.f90
+++ b/example/bitsets/example_bitsets_value.f90
@@ -1,5 +1,6 @@
 program example_value
   use stdlib_bitsets
+  implicit none
   type(bitset_large) :: set0
   call set0%init(166)
   call set0%not()

--- a/example/bitsets/example_bitsets_xor.f90
+++ b/example/bitsets/example_bitsets_xor.f90
@@ -1,5 +1,6 @@
 program example_xor
   use stdlib_bitsets
+  implicit none
   type(bitset_large) :: set0, set1
   call set0%init(166)
   call set1%init(166)

--- a/example/hashmaps/example_hashmaps_get_other_data.f90
+++ b/example/hashmaps/example_hashmaps_get_other_data.f90
@@ -2,6 +2,7 @@ program example_get_other_data
   use stdlib_kinds, only: int8
   use stdlib_hashmaps, only: chaining_hashmap_type, int_index
   use stdlib_hashmap_wrappers, only: fnv_1_hasher, key_type, other_type, set, get
+  implicit none
   logical                     :: conflict
   type(key_type)              :: key
   type(other_type)            :: other

--- a/example/hashmaps/example_hashmaps_map_entry.f90
+++ b/example/hashmaps/example_hashmaps_map_entry.f90
@@ -2,6 +2,7 @@ program example_map_entry
   use, intrinsic:: iso_fortran_env, only: int8
   use stdlib_hashmaps, only: chaining_hashmap_type
   use stdlib_hashmap_wrappers, only: fnv_1_hasher, key_type, other_type, set
+  implicit none
   type(chaining_hashmap_type) :: map
   type(key_type)      :: key
   logical             :: conflict

--- a/example/hashmaps/example_hashmaps_remove.f90
+++ b/example/hashmaps/example_hashmaps_remove.f90
@@ -3,6 +3,7 @@ program example_remove
   use stdlib_hashmaps, only: open_hashmap_type, int_index
   use stdlib_hashmap_wrappers, only: fnv_1_hasher, &
                                      fnv_1a_hasher, key_type, other_type, set
+  implicit none
   type(open_hashmap_type) :: map
   type(key_type)      :: key
   type(other_type)    :: other

--- a/example/logger/example_add_log_unit.f90
+++ b/example/logger/example_add_log_unit.f90
@@ -1,5 +1,6 @@
 program example_add_log_unit
   use stdlib_logger, only: global_logger, read_only_error
+  implicit none
 
   character(256) :: iomsg
   integer :: iostat, unit, stat

--- a/example/logger/example_configure.f90
+++ b/example/logger/example_configure.f90
@@ -1,5 +1,6 @@
 program example_configure
   use stdlib_logger, only: global => global_logger
+  implicit none
 
   call global%configure(indent=.false., max_width=72)
 

--- a/example/logger/example_global_logger.f90
+++ b/example/logger/example_global_logger.f90
@@ -1,5 +1,6 @@
 program example_global_logger
   use stdlib_logger, global => global_logger
+  implicit none
 
   integer :: unit, stat
 

--- a/example/logger/example_log_io_error.f90
+++ b/example/logger/example_log_io_error.f90
@@ -1,5 +1,6 @@
 program example_log_io_error
   use stdlib_logger, global => global_logger
+  implicit none
 
   character(*), parameter :: filename = 'nodummy.txt'
   integer                 :: iostat, lun

--- a/example/logger/example_log_text_error.f90
+++ b/example/logger/example_log_text_error.f90
@@ -1,5 +1,6 @@
 program example_log_text_error
   use stdlib_logger
+  implicit none
 
   character(*), parameter :: filename = 'dummy.txt'
   integer                 :: col_no, line_no, lun, status

--- a/example/math/example_math_all_close.f90
+++ b/example/math/example_math_all_close.f90
@@ -1,6 +1,7 @@
 program example_math_all_close
 
   use stdlib_math, only: all_close
+  implicit none
   real    :: y, NAN
   complex :: z(4, 4)
 

--- a/example/math/example_math_arange.f90
+++ b/example/math/example_math_arange.f90
@@ -1,5 +1,6 @@
 program example_math_arange
   use stdlib_math, only: arange
+  implicit none
 
   print *, arange(3)                 ! [1,2,3]
   print *, arange(-1)                ! [1,0,-1]

--- a/example/math/example_math_arg.f90
+++ b/example/math/example_math_arg.f90
@@ -1,5 +1,6 @@
 program example_math_arg
   use stdlib_math, only: arg
+  implicit none
   print *, arg((0.0, 0.0))                  ! 0.0
   print *, arg((3.0, 4.0))                  ! 0.927
   print *, arg(2.0*exp((0.0, 0.5)))         ! 0.5

--- a/example/math/example_math_argd.f90
+++ b/example/math/example_math_argd.f90
@@ -1,5 +1,6 @@
 program example_math_argd
   use stdlib_math, only: argd
+  implicit none
   print *, argd((0.0, 0.0))                  ! 0.0°
   print *, argd((3.0, 4.0))                  ! 53.1°
   print *, argd(2.0*exp((0.0, 0.5)))         ! 28.64°

--- a/example/math/example_math_argpi.f90
+++ b/example/math/example_math_argpi.f90
@@ -1,5 +1,6 @@
 program example_math_argpi
   use stdlib_math, only: argpi
+  implicit none
   print *, argpi((0.0, 0.0))                  ! 0.0
   print *, argpi((3.0, 4.0))                  ! 0.295
   print *, argpi(2.0*exp((0.0, 0.5)))         ! 0.159

--- a/example/math/example_math_is_close.f90
+++ b/example/math/example_math_is_close.f90
@@ -1,6 +1,7 @@
 program example_math_is_close
 
   use stdlib_math, only: is_close
+  implicit none
   real :: x(2) = [1, 2], y, NAN
 
   y = -3

--- a/example/strings/example_stream_of_strings_to_numbers.f90
+++ b/example/strings/example_stream_of_strings_to_numbers.f90
@@ -1,6 +1,7 @@
 program example_stream_of_strings_to_numbers
     use stdlib_kinds, only: dp
     use stdlib_str2num, only: to_num_from_stream
+    implicit none
     character(:), allocatable, target :: chain
     character(len=:), pointer :: cptr
     real(dp), allocatable :: r(:), p(:)

--- a/example/strings/example_to_string.f90
+++ b/example/strings/example_to_string.f90
@@ -1,5 +1,6 @@
 program example_to_string
   use stdlib_strings, only: to_string
+  implicit none
 
 !> Example for `complex` type
   print *, to_string((1, 1))              !! "(1.00000000,1.00000000)"


### PR DESCRIPTION
This adds `implicit none` to a number of programs in the `example` folder that otherwise don't have it. 

While not essential, the programs are used in library documentation, and IMO it's better to demonstrate good practice.

I have run the tests using `cmake --build build --target test` and they all appear to pass.