### PR TITLE
Add brief explanation on how to include stdlib in a Makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ stdlib = { git="https://github.com/fortran-lang/stdlib", branch="stdlib-fpm" }
 
 ## Using stdlib in your project
 
+### Using stdlib with CMake
+
 The stdlib project exports CMake package files and pkg-config files to make stdlib usable for other projects.
 The package files are located in the library directory in the installation prefix.
 
@@ -234,6 +236,18 @@ target_link_libraries(
 
 To make the installed stdlib project discoverable add the stdlib directory to the ``CMAKE_PREFIX_PATH``.
 The usual install location of the package files is ``$PREFIX/lib/cmake/fortran_stdlib``.
+
+### Using stdlib with a regular Makefile
+
+The library can be included in a regular Makefile, for example with
+```make
+STDLIB_PATH := path/to/build
+LIBDIRS := $(STDLIB_PATH)/src
+INCDIRS := $(STDLIB_PATH)/src/mod_files
+...
+```
+Here it is assumed that the compiler will look for libraries in `LIBDIRS` and for module files in `INCDIRS`.
+A flag `-lfortran_stdlib` should be included to link against `libfortran_stdlib.a` or `libfortran_stdlib.so`.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -242,18 +242,47 @@ stdlib = { git="https://github.com/fortran-lang/stdlib", branch="stdlib-fpm" }
 ### Using stdlib with a regular Makefile
 
 After the library has been built, it can be included in a regular Makefile.
+The recommended way to do this is using the [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/) tool, for which an example is shown below.
+```make
+# Necessary if the installation directory is not in PKG_CONFIG_PATH
+install_dir := path/to/install_dir
+export PKG_CONFIG_PATH := $(install_dir)/lib/pkgconfig:$(PKG_CONFIG_PATH)
+
+STDLIB_CFLAGS := `pkg-config --cflags fortran_stdlib`
+STDLIB_LIBS := `pkg-config --libs fortran_stdlib`
+
+# Example definition of Fortran compiler and flags
+FC := gfortran
+FFLAGS := -O2 -Wall -g
+
+# Definition of targets etc.
+...
+
+# Example rule to compile object files from .f90 files
+%.o: %.f90
+    $(FC) -c -o $@ $< $(FFLAGS) $(STDLIB_CFLAGS)
+
+# Example rule to link an executable from object files
+%: %.o
+    $(FC) -o $@ $^ $(FFLAGS) $(STDLIB_LIBS)
+
+```
+
+The same can also be achieved without pkg-config.
 If the library has been installed in a directory inside the compiler's search path,
-only a flag `-lfortran_stdlib` is required to link against `libfortran_stdlib.a` or `libfortran_stdlib.so`.
+only a flag `-lfortran_stdlib` is required.
 If the installation directory is not in the compiler's search path, one can add for example
 ```make
-libdir=${install_dir}/lib
-moduledir=${install_dir}/include/fortran_stdlib/<compiler name and version>
+install_dir := path/to/install_dir
+libdir := $(install_dir)/lib
+moduledir := $(install_dir)/include/fortran_stdlib/<compiler name and version>
 ```
-Here it is assumed that the compiler will look for libraries in `libdir` and for module files in `moduledir`.
-The library can also be included from a build directory without installation:
+The linker should then look for libraries in `libdir` (using e.g.`-L$(libdir)`) and the compiler should look for module files in `moduledir` (using e.g. `-I$(moduledir)`).
+Alternatively, the library can also be included from a build directory without installation with
 ```make
-libdir=$(build_dir)/src
-moduledir=$(build_dir)/src/mod_files
+...
+libdir := $(build_dir)/src
+moduledir := $(build_dir)/src/mod_files
 ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ target_link_libraries(
 To make the installed stdlib project discoverable add the stdlib directory to the ``CMAKE_PREFIX_PATH``.
 The usual install location of the package files is ``$PREFIX/lib/cmake/fortran_stdlib``.
 
-### Using stdlib with with fpm
+### Using stdlib with fpm
 
 To use `stdlib` within your `fpm` project, add the following lines to your `fpm.toml` file:
 ```toml

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ moduledir := $(install_dir)/include/fortran_stdlib/<compiler name and version>
 The linker should then look for libraries in `libdir` (using e.g.`-L$(libdir)`) and the compiler should look for module files in `moduledir` (using e.g. `-I$(moduledir)`).
 Alternatively, the library can also be included from a build directory without installation with
 ```make
-...
+build_dir := path/to/build_dir
 libdir := $(build_dir)/src
 moduledir := $(build_dir)/src/mod_files
 ```

--- a/README.md
+++ b/README.md
@@ -201,20 +201,6 @@ fpm run --example prog
 with `prog` being the name of the example program (e.g., `example_sort`).
 
 
-To use `stdlib` within your `fpm` project, add the following lines to your `fpm.toml` file:
-```toml
-[dependencies]
-stdlib = { git="https://github.com/fortran-lang/stdlib", branch="stdlib-fpm" }
-```
-
-> **Warning**
-> 
-> Fpm 0.9.0 and later implements stdlib as a *metapackage*.
-> To include the standard library metapackage, change the dependency to:
-> `stdlib = "*"`.
-> 
-> [see also](https://fpm.fortran-lang.org/spec/metapackages.html)
-
 ## Using stdlib in your project
 
 ### Using stdlib with CMake
@@ -237,17 +223,38 @@ target_link_libraries(
 To make the installed stdlib project discoverable add the stdlib directory to the ``CMAKE_PREFIX_PATH``.
 The usual install location of the package files is ``$PREFIX/lib/cmake/fortran_stdlib``.
 
+### Using stdlib with with fpm
+
+To use `stdlib` within your `fpm` project, add the following lines to your `fpm.toml` file:
+```toml
+[dependencies]
+stdlib = { git="https://github.com/fortran-lang/stdlib", branch="stdlib-fpm" }
+```
+
+> **Warning**
+> 
+> Fpm 0.9.0 and later implements stdlib as a *metapackage*.
+> To include the standard library metapackage, change the dependency to:
+> `stdlib = "*"`.
+> 
+> [see also](https://fpm.fortran-lang.org/spec/metapackages.html)
+
 ### Using stdlib with a regular Makefile
 
-The library can be included in a regular Makefile, for example with
+After the library has been built, it can be included in a regular Makefile.
+If the library has been installed in a directory inside the compiler's search path,
+only a flag `-lfortran_stdlib` is required to link against `libfortran_stdlib.a` or `libfortran_stdlib.so`.
+If the installation directory is not in the compiler's search path, one can add for example
 ```make
-STDLIB_PATH := path/to/build
-LIBDIRS := $(STDLIB_PATH)/src
-INCDIRS := $(STDLIB_PATH)/src/mod_files
-...
+libdir=${install_dir}/lib
+moduledir=${install_dir}/include/fortran_stdlib/<compiler name and version>
 ```
-Here it is assumed that the compiler will look for libraries in `LIBDIRS` and for module files in `INCDIRS`.
-A flag `-lfortran_stdlib` should be included to link against `libfortran_stdlib.a` or `libfortran_stdlib.so`.
+Here it is assumed that the compiler will look for libraries in `libdir` and for module files in `moduledir`.
+The library can also be included from a build directory without installation:
+```make
+libdir=$(build_dir)/src
+moduledir=$(build_dir)/src/mod_files
+```
 
 ## Documentation
 


### PR DESCRIPTION
The current documentation on how to use stdlib in a project focuses on Cmake, see https://github.com/fortran-lang/stdlib?tab=readme-ov-file#using-stdlib-in-your-project

It can seem as is you actually need CMAKE to include stdlib (I got this impression). I think it would also be helpful to describe how to include stdlib in a regular makefile. This small change includes such documentation. I was not 100% sure about the paths: is it correct that the library is always in <build_folder>/src?