### PR TITLE
`fpm` deployment: workaround for case-insensitive fs

### DIFF
--- a/ci/fpm-deployment.sh
+++ b/ci/fpm-deployment.sh
@@ -89,8 +89,10 @@ rm "${prune[@]}"
 
 # Capitalize .f90 -> .F90 for preprocessed files
 for pp_source in "${preprocessed[@]}"
-do 
-   mv "$pp_source.f90" "$pp_source.F90" 
+do
+   # workaround for case-insensitive fs    	
+   mv "$pp_source.f90" "$pp_source.rename" 
+   mv "$pp_source.rename" "$pp_source.F90" 
 done
 
 # List stdlib-fpm package contents


### PR DESCRIPTION
cf. https://github.com/fortran-lang/stdlib/pull/787#issuecomment-2044239468

I understand the CI script is not supposed to be OS-agnostic, it should only live within the repo. 
However, it seems like people use the `stdlib-fpm` branch more than just as an fpm dependency, so, this fix is probably useful.

cc: @jalvesz @jvdp1 