### PR TITLE
Update linalg.md and example_blas_gemv.f90

### DIFF
--- a/doc/specs/stdlib_linalg.md
+++ b/doc/specs/stdlib_linalg.md
@@ -41,7 +41,7 @@ These can be enabled during the build process. For example, with CMake, one can 
 The same is possible from the `fpm` branch, where the `cpp` preprocessor is enabled by default. For example, the macros can be added to the project's manifest:
 
 ```toml
-# Link to blas and lapack libraries; or `link = "openblas"` for openblas
+# Link against appropriate external BLAS and LAPACK libraries, if necessary
 [build]
 link = ["blas", "lapack"]  
 

--- a/doc/specs/stdlib_linalg.md
+++ b/doc/specs/stdlib_linalg.md
@@ -41,6 +41,10 @@ These can be enabled during the build process. For example, with CMake, one can 
 The same is possible from the `fpm` branch, where the `cpp` preprocessor is enabled by default. For example, the macros can be added to the project's manifest:
 
 ```toml
+# Link to blas and lapack libraries; or `link = "openblas"` for openblas
+[build]
+link = ["blas", "lapack"]  
+
 [dependencies]
 stdlib="*"
 

--- a/example/linalg/example_blas_gemv.f90
+++ b/example/linalg/example_blas_gemv.f90
@@ -2,13 +2,13 @@ program example_gemv
   use stdlib_linalg, only: eye
   use stdlib_linalg_blas, only: sp,gemv
   implicit none(type,external)
-  real(sp) :: A(2, 2), B(2)
+  real(sp) :: A(2, 2), B(2), C(2)
   B = [1.0,2.0]
   A = eye(2)
   
   ! Use legacy BLAS interface 
-  call gemv('No transpose',m=size(A,1),n=size(A,2),alpha=1.0,a=A,lda=size(A,1),x=B,incx=1,beta=0.0,y=B,incy=1)
+  call gemv('No transpose',m=size(A,1),n=size(A,2),alpha=1.0,a=A,lda=size(A,1),x=B,incx=1,beta=0.0,y=C,incy=1)
 
-  print *, B ! returns 1.0 2.0
+  print *, C ! returns 1.0 2.0
 
 end program example_gemv


### PR DESCRIPTION
<!--
Thank you for contributing to stdlib.
To help us get your pull request merged more quickly, please consider reviewing any of the already open pull requests.
-->

## Description

1. Linking relying on `fpm.toml` requires adding the `link` keyword within the `[build]` section.
2. An error in the `example_blas_gemv` has been corrected.
![image](https://github.com/fortran-lang/stdlib/assets/32035096/a615b23f-620d-4ae7-ba25-c8ac6d1f9344)
