### PR TITLE
macos-latest -> macos-12

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-12]
         gcc_v: [10, 11, 12, 13] # Version of GFortran we want to use.
         build: [cmake]
         include:
@@ -163,7 +163,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest]
+        os: [macos-12]
         fc: [ifort]
         cc: [icc]
         cxx: [icpc]


### PR DESCRIPTION
It looks like macOS-latest runners have arm architecture where gcc is not supported (at least yet).
For now, I suggest to select the macos version to 12.
