### PR TITLE
least squares: relax test tolerance

### DIFF
--- a/test/linalg/test_linalg_lstsq.fypp
+++ b/test/linalg/test_linalg_lstsq.fypp
@@ -56,7 +56,7 @@ module test_linalg_least_squares
         call check(error,state%ok(),state%print())
         if (allocated(error)) return
         
-        call check(error, all(abs(p-ab)<1.0e-6_${rk}$), 'data converged')
+        call check(error, all(abs(p-ab)<1.0e-4_${rk}$), 'data converged')
         if (allocated(error)) return
         
         call check(error, rank==2, 'matrix rank == 2')
@@ -85,7 +85,7 @@ module test_linalg_least_squares
         call check(error,state%ok(),state%print())
         if (allocated(error)) return
         
-        call check(error, all(abs(x-xsol)<1.0e-6_${rk}$), 'data converged')
+        call check(error, all(abs(x-xsol)<1.0e-4_${rk}$), 'data converged')
         if (allocated(error)) return
         
     end subroutine test_lstsq_random_${ri}$    


### PR DESCRIPTION
Problem: 
`1.0e-6` is too tight a tolerance for least squares on some systems (`1.0e-6 << sqrt(epsilon(0.0))`)

Example: failed CI job
https://github.com/fortran-lang/stdlib/actions/runs/9015259889/job/24769521465

Solution:
relax tolerance to `1.0e-4`

cc: @jvdp1 @jalvesz 