### PR TITLE
`lk` -> `llk` in `*sytrd_sy2sb`

### DIFF
--- a/src/stdlib_linalg_lapack_c.fypp
+++ b/src/stdlib_linalg_lapack_c.fypp
@@ -36507,7 +36507,7 @@ module stdlib_linalg_lapack_c
            
            ! Local Scalars 
            logical(lk) :: lquery, upper
-           integer(ilp) :: i, j, iinfo, lwmin, pn, pk, lk, ldt, ldw, lds2, lds1, ls2, ls1, lw, lt,&
+           integer(ilp) :: i, j, iinfo, lwmin, pn, pk, llk, ldt, ldw, lds2, lds1, ls2, ls1, lw, lt,&
                       tpos, wpos, s2pos, s1pos
            ! Intrinsic Functions 
            intrinsic :: min,max
@@ -36543,13 +36543,13 @@ module stdlib_linalg_lapack_c
            if( n<=kd+1 ) then
                if( upper ) then
                    do i = 1, n
-                       lk = min( kd+1, i )
-                       call stdlib_ccopy( lk, a( i-lk+1, i ), 1,ab( kd+1-lk+1, i ), 1 )
+                       llk = min( kd+1, i )
+                       call stdlib_ccopy( llk, a( i-llk+1, i ), 1,ab( kd+1-llk+1, i ), 1 )
                    end do
                else
                    do i = 1, n
-                       lk = min( kd+1, n-i+1 )
-                       call stdlib_ccopy( lk, a( i, i ), 1, ab( 1, i ), 1 )
+                       llk = min( kd+1, n-i+1 )
+                       call stdlib_ccopy( llk, a( i, i ), 1, ab( 1, i ), 1 )
                    end do
                endif
                work( 1 ) = 1
@@ -36586,8 +36586,8 @@ module stdlib_linalg_lapack_c
                             iinfo )
                   ! copy the upper portion of a into ab
                   do j = i, i+pk-1
-                     lk = min( kd, n-j ) + 1
-                     call stdlib_ccopy( lk, a( j, j ), lda, ab( kd+1, j ), ldab-1 )
+                     llk = min( kd, n-j ) + 1
+                     call stdlib_ccopy( llk, a( j, j ), lda, ab( kd+1, j ), ldab-1 )
                   end do
                   call stdlib_claset( 'LOWER', pk, pk, czero, cone,a( i, i+kd ), lda )
                   ! form the matrix t
@@ -36609,8 +36609,8 @@ module stdlib_linalg_lapack_c
                end do
               ! copy the upper band to ab which is the band storage matrix
               do j = n-kd+1, n
-                 lk = min(kd, n-j) + 1
-                 call stdlib_ccopy( lk, a( j, j ), lda, ab( kd+1, j ), ldab-1 )
+                 llk = min(kd, n-j) + 1
+                 call stdlib_ccopy( llk, a( j, j ), lda, ab( kd+1, j ), ldab-1 )
               end do
            else
                ! reduce the lower triangle of a to lower band matrix
@@ -36622,8 +36622,8 @@ module stdlib_linalg_lapack_c
                             iinfo )
                   ! copy the upper portion of a into ab
                   do j = i, i+pk-1
-                     lk = min( kd, n-j ) + 1
-                     call stdlib_ccopy( lk, a( j, j ), 1, ab( 1, j ), 1 )
+                     llk = min( kd, n-j ) + 1
+                     call stdlib_ccopy( llk, a( j, j ), 1, ab( 1, j ), 1 )
                   end do
                   call stdlib_claset( 'UPPER', pk, pk, czero, cone,a( i+kd, i ), lda )
                   ! form the matrix t
@@ -36645,15 +36645,15 @@ module stdlib_linalg_lapack_c
                   ! ==================================================================
                   ! restore a for comparison and checking to be removed
                    ! do 45 j = i, i+pk-1
-                      ! lk = min( kd, n-j ) + 1
-                      ! call stdlib_ccopy( lk, ab( 1, j ), 1, a( j, j ), 1 )
+                      ! llk = min( kd, n-j ) + 1
+                      ! call stdlib_ccopy( llk, ab( 1, j ), 1, a( j, j ), 1 )
                       45 continue
                   ! ==================================================================
                end do loop_40
               ! copy the lower band to ab which is the band storage matrix
               do j = n-kd+1, n
-                 lk = min(kd, n-j) + 1
-                 call stdlib_ccopy( lk, a( j, j ), 1, ab( 1, j ), 1 )
+                 llk = min(kd, n-j) + 1
+                 call stdlib_ccopy( llk, a( j, j ), 1, ab( 1, j ), 1 )
               end do
            end if
            work( 1 ) = lwmin

--- a/src/stdlib_linalg_lapack_d.fypp
+++ b/src/stdlib_linalg_lapack_d.fypp
@@ -57092,7 +57092,7 @@ module stdlib_linalg_lapack_d
            
            ! Local Scalars 
            logical(lk) :: lquery, upper
-           integer(ilp) :: i, j, iinfo, lwmin, pn, pk, lk, ldt, ldw, lds2, lds1, ls2, ls1, lw, lt,&
+           integer(ilp) :: i, j, iinfo, lwmin, pn, pk, llk, ldt, ldw, lds2, lds1, ls2, ls1, lw, lt,&
                       tpos, wpos, s2pos, s1pos
            ! Intrinsic Functions 
            intrinsic :: min,max
@@ -57128,13 +57128,13 @@ module stdlib_linalg_lapack_d
            if( n<=kd+1 ) then
                if( upper ) then
                    do i = 1, n
-                       lk = min( kd+1, i )
-                       call stdlib_dcopy( lk, a( i-lk+1, i ), 1,ab( kd+1-lk+1, i ), 1 )
+                       llk = min( kd+1, i )
+                       call stdlib_dcopy( llk, a( i-llk+1, i ), 1,ab( kd+1-llk+1, i ), 1 )
                    end do
                else
                    do i = 1, n
-                       lk = min( kd+1, n-i+1 )
-                       call stdlib_dcopy( lk, a( i, i ), 1, ab( 1, i ), 1 )
+                       llk = min( kd+1, n-i+1 )
+                       call stdlib_dcopy( llk, a( i, i ), 1, ab( 1, i ), 1 )
                    end do
                endif
                work( 1 ) = 1
@@ -57171,8 +57171,8 @@ module stdlib_linalg_lapack_d
                             iinfo )
                   ! copy the upper portion of a into ab
                   do j = i, i+pk-1
-                     lk = min( kd, n-j ) + 1
-                     call stdlib_dcopy( lk, a( j, j ), lda, ab( kd+1, j ), ldab-1 )
+                     llk = min( kd, n-j ) + 1
+                     call stdlib_dcopy( llk, a( j, j ), lda, ab( kd+1, j ), ldab-1 )
                   end do
                   call stdlib_dlaset( 'LOWER', pk, pk, zero, one,a( i, i+kd ), lda )
                   ! form the matrix t
@@ -57194,8 +57194,8 @@ module stdlib_linalg_lapack_d
                end do
               ! copy the upper band to ab which is the band storage matrix
               do j = n-kd+1, n
-                 lk = min(kd, n-j) + 1
-                 call stdlib_dcopy( lk, a( j, j ), lda, ab( kd+1, j ), ldab-1 )
+                 llk = min(kd, n-j) + 1
+                 call stdlib_dcopy( llk, a( j, j ), lda, ab( kd+1, j ), ldab-1 )
               end do
            else
                ! reduce the lower triangle of a to lower band matrix
@@ -57207,8 +57207,8 @@ module stdlib_linalg_lapack_d
                             iinfo )
                   ! copy the upper portion of a into ab
                   do j = i, i+pk-1
-                     lk = min( kd, n-j ) + 1
-                     call stdlib_dcopy( lk, a( j, j ), 1, ab( 1, j ), 1 )
+                     llk = min( kd, n-j ) + 1
+                     call stdlib_dcopy( llk, a( j, j ), 1, ab( 1, j ), 1 )
                   end do
                   call stdlib_dlaset( 'UPPER', pk, pk, zero, one,a( i+kd, i ), lda )
                   ! form the matrix t
@@ -57230,15 +57230,15 @@ module stdlib_linalg_lapack_d
                   ! ==================================================================
                   ! restore a for comparison and checking to be removed
                    ! do 45 j = i, i+pk-1
-                      ! lk = min( kd, n-j ) + 1
-                      ! call stdlib_dcopy( lk, ab( 1, j ), 1, a( j, j ), 1 )
+                      ! llk = min( kd, n-j ) + 1
+                      ! call stdlib_dcopy( llk, ab( 1, j ), 1, a( j, j ), 1 )
                       45 continue
                   ! ==================================================================
                end do loop_40
               ! copy the lower band to ab which is the band storage matrix
               do j = n-kd+1, n
-                 lk = min(kd, n-j) + 1
-                 call stdlib_dcopy( lk, a( j, j ), 1, ab( 1, j ), 1 )
+                 llk = min(kd, n-j) + 1
+                 call stdlib_dcopy( llk, a( j, j ), 1, ab( 1, j ), 1 )
               end do
            end if
            work( 1 ) = lwmin

--- a/src/stdlib_linalg_lapack_q.fypp
+++ b/src/stdlib_linalg_lapack_q.fypp
@@ -72917,7 +72917,7 @@ module stdlib_linalg_lapack_q
            
            ! Local Scalars 
            logical(lk) :: lquery, upper
-           integer(ilp) :: i, j, iinfo, lwmin, pn, pk, lk, ldt, ldw, lds2, lds1, ls2, ls1, lw, lt,&
+           integer(ilp) :: i, j, iinfo, lwmin, pn, pk, llk, ldt, ldw, lds2, lds1, ls2, ls1, lw, lt,&
                       tpos, wpos, s2pos, s1pos
            ! Intrinsic Functions 
            intrinsic :: min,max
@@ -72953,13 +72953,13 @@ module stdlib_linalg_lapack_q
            if( n<=kd+1 ) then
                if( upper ) then
                    do i = 1, n
-                       lk = min( kd+1, i )
-                       call stdlib_qcopy( lk, a( i-lk+1, i ), 1,ab( kd+1-lk+1, i ), 1 )
+                       llk = min( kd+1, i )
+                       call stdlib_qcopy( llk, a( i-llk+1, i ), 1,ab( kd+1-llk+1, i ), 1 )
                    end do
                else
                    do i = 1, n
-                       lk = min( kd+1, n-i+1 )
-                       call stdlib_qcopy( lk, a( i, i ), 1, ab( 1, i ), 1 )
+                       llk = min( kd+1, n-i+1 )
+                       call stdlib_qcopy( llk, a( i, i ), 1, ab( 1, i ), 1 )
                    end do
                endif
                work( 1 ) = 1
@@ -72996,8 +72996,8 @@ module stdlib_linalg_lapack_q
                             iinfo )
                   ! copy the upper portion of a into ab
                   do j = i, i+pk-1
-                     lk = min( kd, n-j ) + 1
-                     call stdlib_qcopy( lk, a( j, j ), lda, ab( kd+1, j ), ldab-1 )
+                     llk = min( kd, n-j ) + 1
+                     call stdlib_qcopy( llk, a( j, j ), lda, ab( kd+1, j ), ldab-1 )
                   end do
                   call stdlib_qlaset( 'LOWER', pk, pk, zero, one,a( i, i+kd ), lda )
                   ! form the matrix t
@@ -73019,8 +73019,8 @@ module stdlib_linalg_lapack_q
                end do
               ! copy the upper band to ab which is the band storage matrix
               do j = n-kd+1, n
-                 lk = min(kd, n-j) + 1
-                 call stdlib_qcopy( lk, a( j, j ), lda, ab( kd+1, j ), ldab-1 )
+                 llk = min(kd, n-j) + 1
+                 call stdlib_qcopy( llk, a( j, j ), lda, ab( kd+1, j ), ldab-1 )
               end do
            else
                ! reduce the lower triangle of a to lower band matrix
@@ -73032,8 +73032,8 @@ module stdlib_linalg_lapack_q
                             iinfo )
                   ! copy the upper portion of a into ab
                   do j = i, i+pk-1
-                     lk = min( kd, n-j ) + 1
-                     call stdlib_qcopy( lk, a( j, j ), 1, ab( 1, j ), 1 )
+                     llk = min( kd, n-j ) + 1
+                     call stdlib_qcopy( llk, a( j, j ), 1, ab( 1, j ), 1 )
                   end do
                   call stdlib_qlaset( 'UPPER', pk, pk, zero, one,a( i+kd, i ), lda )
                   ! form the matrix t
@@ -73055,15 +73055,15 @@ module stdlib_linalg_lapack_q
                   ! ==================================================================
                   ! restore a for comparison and checking to be removed
                    ! do 45 j = i, i+pk-1
-                      ! lk = min( kd, n-j ) + 1
-                      ! call stdlib_qcopy( lk, ab( 1, j ), 1, a( j, j ), 1 )
+                      ! llk = min( kd, n-j ) + 1
+                      ! call stdlib_qcopy( llk, ab( 1, j ), 1, a( j, j ), 1 )
                       45 continue
                   ! ==================================================================
                end do loop_40
               ! copy the lower band to ab which is the band storage matrix
               do j = n-kd+1, n
-                 lk = min(kd, n-j) + 1
-                 call stdlib_qcopy( lk, a( j, j ), 1, ab( 1, j ), 1 )
+                 llk = min(kd, n-j) + 1
+                 call stdlib_qcopy( llk, a( j, j ), 1, ab( 1, j ), 1 )
               end do
            end if
            work( 1 ) = lwmin

--- a/src/stdlib_linalg_lapack_s.fypp
+++ b/src/stdlib_linalg_lapack_s.fypp
@@ -55567,7 +55567,7 @@ module stdlib_linalg_lapack_s
            
            ! Local Scalars 
            logical(lk) :: lquery, upper
-           integer(ilp) :: i, j, iinfo, lwmin, pn, pk, lk, ldt, ldw, lds2, lds1, ls2, ls1, lw, lt,&
+           integer(ilp) :: i, j, iinfo, lwmin, pn, pk, llk, ldt, ldw, lds2, lds1, ls2, ls1, lw, lt,&
                       tpos, wpos, s2pos, s1pos
            ! Intrinsic Functions 
            intrinsic :: min,max
@@ -55603,13 +55603,13 @@ module stdlib_linalg_lapack_s
            if( n<=kd+1 ) then
                if( upper ) then
                    do i = 1, n
-                       lk = min( kd+1, i )
-                       call stdlib_scopy( lk, a( i-lk+1, i ), 1,ab( kd+1-lk+1, i ), 1 )
+                       llk = min( kd+1, i )
+                       call stdlib_scopy( llk, a( i-llk+1, i ), 1,ab( kd+1-llk+1, i ), 1 )
                    end do
                else
                    do i = 1, n
-                       lk = min( kd+1, n-i+1 )
-                       call stdlib_scopy( lk, a( i, i ), 1, ab( 1, i ), 1 )
+                       llk = min( kd+1, n-i+1 )
+                       call stdlib_scopy( llk, a( i, i ), 1, ab( 1, i ), 1 )
                    end do
                endif
                work( 1 ) = 1
@@ -55646,8 +55646,8 @@ module stdlib_linalg_lapack_s
                             iinfo )
                   ! copy the upper portion of a into ab
                   do j = i, i+pk-1
-                     lk = min( kd, n-j ) + 1
-                     call stdlib_scopy( lk, a( j, j ), lda, ab( kd+1, j ), ldab-1 )
+                     llk = min( kd, n-j ) + 1
+                     call stdlib_scopy( llk, a( j, j ), lda, ab( kd+1, j ), ldab-1 )
                   end do
                   call stdlib_slaset( 'LOWER', pk, pk, zero, one,a( i, i+kd ), lda )
                   ! form the matrix t
@@ -55669,8 +55669,8 @@ module stdlib_linalg_lapack_s
                end do
               ! copy the upper band to ab which is the band storage matrix
               do j = n-kd+1, n
-                 lk = min(kd, n-j) + 1
-                 call stdlib_scopy( lk, a( j, j ), lda, ab( kd+1, j ), ldab-1 )
+                 llk = min(kd, n-j) + 1
+                 call stdlib_scopy( llk, a( j, j ), lda, ab( kd+1, j ), ldab-1 )
               end do
            else
                ! reduce the lower triangle of a to lower band matrix
@@ -55682,8 +55682,8 @@ module stdlib_linalg_lapack_s
                             iinfo )
                   ! copy the upper portion of a into ab
                   do j = i, i+pk-1
-                     lk = min( kd, n-j ) + 1
-                     call stdlib_scopy( lk, a( j, j ), 1, ab( 1, j ), 1 )
+                     llk = min( kd, n-j ) + 1
+                     call stdlib_scopy( llk, a( j, j ), 1, ab( 1, j ), 1 )
                   end do
                   call stdlib_slaset( 'UPPER', pk, pk, zero, one,a( i+kd, i ), lda )
                   ! form the matrix t
@@ -55705,15 +55705,15 @@ module stdlib_linalg_lapack_s
                   ! ==================================================================
                   ! restore a for comparison and checking to be removed
                    ! do 45 j = i, i+pk-1
-                      ! lk = min( kd, n-j ) + 1
-                      ! call stdlib_scopy( lk, ab( 1, j ), 1, a( j, j ), 1 )
+                      ! llk = min( kd, n-j ) + 1
+                      ! call stdlib_scopy( llk, ab( 1, j ), 1, a( j, j ), 1 )
                       45 continue
                   ! ==================================================================
                end do loop_40
               ! copy the lower band to ab which is the band storage matrix
               do j = n-kd+1, n
-                 lk = min(kd, n-j) + 1
-                 call stdlib_scopy( lk, a( j, j ), 1, ab( 1, j ), 1 )
+                 llk = min(kd, n-j) + 1
+                 call stdlib_scopy( llk, a( j, j ), 1, ab( 1, j ), 1 )
               end do
            end if
            work( 1 ) = lwmin

--- a/src/stdlib_linalg_lapack_w.fypp
+++ b/src/stdlib_linalg_lapack_w.fypp
@@ -28868,7 +28868,7 @@ module stdlib_linalg_lapack_w
            
            ! Local Scalars 
            logical(lk) :: lquery, upper
-           integer(ilp) :: i, j, iinfo, lwmin, pn, pk, lk, ldt, ldw, lds2, lds1, ls2, ls1, lw, lt,&
+           integer(ilp) :: i, j, iinfo, lwmin, pn, pk, llk, ldt, ldw, lds2, lds1, ls2, ls1, lw, lt,&
                       tpos, wpos, s2pos, s1pos
            ! Intrinsic Functions 
            intrinsic :: min,max
@@ -28904,13 +28904,13 @@ module stdlib_linalg_lapack_w
            if( n<=kd+1 ) then
                if( upper ) then
                    do i = 1, n
-                       lk = min( kd+1, i )
-                       call stdlib_wcopy( lk, a( i-lk+1, i ), 1,ab( kd+1-lk+1, i ), 1 )
+                       llk = min( kd+1, i )
+                       call stdlib_wcopy( llk, a( i-llk+1, i ), 1,ab( kd+1-llk+1, i ), 1 )
                    end do
                else
                    do i = 1, n
-                       lk = min( kd+1, n-i+1 )
-                       call stdlib_wcopy( lk, a( i, i ), 1, ab( 1, i ), 1 )
+                       llk = min( kd+1, n-i+1 )
+                       call stdlib_wcopy( llk, a( i, i ), 1, ab( 1, i ), 1 )
                    end do
                endif
                work( 1 ) = 1
@@ -28947,8 +28947,8 @@ module stdlib_linalg_lapack_w
                             iinfo )
                   ! copy the upper portion of a into ab
                   do j = i, i+pk-1
-                     lk = min( kd, n-j ) + 1
-                     call stdlib_wcopy( lk, a( j, j ), lda, ab( kd+1, j ), ldab-1 )
+                     llk = min( kd, n-j ) + 1
+                     call stdlib_wcopy( llk, a( j, j ), lda, ab( kd+1, j ), ldab-1 )
                   end do
                   call stdlib_wlaset( 'LOWER', pk, pk, czero, cone,a( i, i+kd ), lda )
                   ! form the matrix t
@@ -28970,8 +28970,8 @@ module stdlib_linalg_lapack_w
                end do
               ! copy the upper band to ab which is the band storage matrix
               do j = n-kd+1, n
-                 lk = min(kd, n-j) + 1
-                 call stdlib_wcopy( lk, a( j, j ), lda, ab( kd+1, j ), ldab-1 )
+                 llk = min(kd, n-j) + 1
+                 call stdlib_wcopy( llk, a( j, j ), lda, ab( kd+1, j ), ldab-1 )
               end do
            else
                ! reduce the lower triangle of a to lower band matrix
@@ -28983,8 +28983,8 @@ module stdlib_linalg_lapack_w
                             iinfo )
                   ! copy the upper portion of a into ab
                   do j = i, i+pk-1
-                     lk = min( kd, n-j ) + 1
-                     call stdlib_wcopy( lk, a( j, j ), 1, ab( 1, j ), 1 )
+                     llk = min( kd, n-j ) + 1
+                     call stdlib_wcopy( llk, a( j, j ), 1, ab( 1, j ), 1 )
                   end do
                   call stdlib_wlaset( 'UPPER', pk, pk, czero, cone,a( i+kd, i ), lda )
                   ! form the matrix t
@@ -29006,15 +29006,15 @@ module stdlib_linalg_lapack_w
                   ! ==================================================================
                   ! restore a for comparison and checking to be removed
                    ! do 45 j = i, i+pk-1
-                      ! lk = min( kd, n-j ) + 1
-                      ! call stdlib_wcopy( lk, ab( 1, j ), 1, a( j, j ), 1 )
+                      ! llk = min( kd, n-j ) + 1
+                      ! call stdlib_wcopy( llk, ab( 1, j ), 1, a( j, j ), 1 )
                       45 continue
                   ! ==================================================================
                end do loop_40
               ! copy the lower band to ab which is the band storage matrix
               do j = n-kd+1, n
-                 lk = min(kd, n-j) + 1
-                 call stdlib_wcopy( lk, a( j, j ), 1, ab( 1, j ), 1 )
+                 llk = min(kd, n-j) + 1
+                 call stdlib_wcopy( llk, a( j, j ), 1, ab( 1, j ), 1 )
               end do
            end if
            work( 1 ) = lwmin

--- a/src/stdlib_linalg_lapack_z.fypp
+++ b/src/stdlib_linalg_lapack_z.fypp
@@ -36922,7 +36922,7 @@ module stdlib_linalg_lapack_z
            
            ! Local Scalars 
            logical(lk) :: lquery, upper
-           integer(ilp) :: i, j, iinfo, lwmin, pn, pk, lk, ldt, ldw, lds2, lds1, ls2, ls1, lw, lt,&
+           integer(ilp) :: i, j, iinfo, lwmin, pn, pk, llk, ldt, ldw, lds2, lds1, ls2, ls1, lw, lt,&
                       tpos, wpos, s2pos, s1pos
            ! Intrinsic Functions 
            intrinsic :: min,max
@@ -36958,13 +36958,13 @@ module stdlib_linalg_lapack_z
            if( n<=kd+1 ) then
                if( upper ) then
                    do i = 1, n
-                       lk = min( kd+1, i )
-                       call stdlib_zcopy( lk, a( i-lk+1, i ), 1,ab( kd+1-lk+1, i ), 1 )
+                       llk = min( kd+1, i )
+                       call stdlib_zcopy( llk, a( i-llk+1, i ), 1,ab( kd+1-llk+1, i ), 1 )
                    end do
                else
                    do i = 1, n
-                       lk = min( kd+1, n-i+1 )
-                       call stdlib_zcopy( lk, a( i, i ), 1, ab( 1, i ), 1 )
+                       llk = min( kd+1, n-i+1 )
+                       call stdlib_zcopy( llk, a( i, i ), 1, ab( 1, i ), 1 )
                    end do
                endif
                work( 1 ) = 1
@@ -37001,8 +37001,8 @@ module stdlib_linalg_lapack_z
                             iinfo )
                   ! copy the upper portion of a into ab
                   do j = i, i+pk-1
-                     lk = min( kd, n-j ) + 1
-                     call stdlib_zcopy( lk, a( j, j ), lda, ab( kd+1, j ), ldab-1 )
+                     llk = min( kd, n-j ) + 1
+                     call stdlib_zcopy( llk, a( j, j ), lda, ab( kd+1, j ), ldab-1 )
                   end do
                   call stdlib_zlaset( 'LOWER', pk, pk, czero, cone,a( i, i+kd ), lda )
                   ! form the matrix t
@@ -37024,8 +37024,8 @@ module stdlib_linalg_lapack_z
                end do
               ! copy the upper band to ab which is the band storage matrix
               do j = n-kd+1, n
-                 lk = min(kd, n-j) + 1
-                 call stdlib_zcopy( lk, a( j, j ), lda, ab( kd+1, j ), ldab-1 )
+                 llk = min(kd, n-j) + 1
+                 call stdlib_zcopy( llk, a( j, j ), lda, ab( kd+1, j ), ldab-1 )
               end do
            else
                ! reduce the lower triangle of a to lower band matrix
@@ -37037,8 +37037,8 @@ module stdlib_linalg_lapack_z
                             iinfo )
                   ! copy the upper portion of a into ab
                   do j = i, i+pk-1
-                     lk = min( kd, n-j ) + 1
-                     call stdlib_zcopy( lk, a( j, j ), 1, ab( 1, j ), 1 )
+                     llk = min( kd, n-j ) + 1
+                     call stdlib_zcopy( llk, a( j, j ), 1, ab( 1, j ), 1 )
                   end do
                   call stdlib_zlaset( 'UPPER', pk, pk, czero, cone,a( i+kd, i ), lda )
                   ! form the matrix t
@@ -37060,15 +37060,15 @@ module stdlib_linalg_lapack_z
                   ! ==================================================================
                   ! restore a for comparison and checking to be removed
                    ! do 45 j = i, i+pk-1
-                      ! lk = min( kd, n-j ) + 1
-                      ! call stdlib_zcopy( lk, ab( 1, j ), 1, a( j, j ), 1 )
+                      ! llk = min( kd, n-j ) + 1
+                      ! call stdlib_zcopy( nlk, ab( 1, j ), 1, a( j, j ), 1 )
                       45 continue
                   ! ==================================================================
                end do loop_40
               ! copy the lower band to ab which is the band storage matrix
               do j = n-kd+1, n
-                 lk = min(kd, n-j) + 1
-                 call stdlib_zcopy( lk, a( j, j ), 1, ab( 1, j ), 1 )
+                 llk = min(kd, n-j) + 1
+                 call stdlib_zcopy( llk, a( j, j ), 1, ab( 1, j ), 1 )
               end do
            end if
            work( 1 ) = lwmin


### PR DESCRIPTION
Fix #810 @jvdp1 @sscalpone

Renaming this variable rather than the logical kind would minimize the number of changes to the code.