### PR TITLE
Fix: `copy_a` deallocation in `determinant`

### DIFF
--- a/src/stdlib_linalg_determinant.fypp
+++ b/src/stdlib_linalg_determinant.fypp
@@ -224,7 +224,7 @@ submodule (stdlib_linalg) stdlib_linalg_determinant
                        err0 = linalg_state_type(this,LINALG_INTERNAL_ERROR,'catastrophic error')
                 end select
 
-                if (.not.copy_a) deallocate(amat)
+                if (copy_a) deallocate(amat)
 
          end select
 

--- a/test/linalg/test_linalg_determinant.fypp
+++ b/test/linalg/test_linalg_determinant.fypp
@@ -47,6 +47,7 @@ module test_linalg_determinant
         integer(ilp), parameter :: n = 128_ilp
 
         ${rt}$ :: a(n,n),deta
+        ${rt}$, allocatable :: aalloc(:,:)
 
         a = eye(n)
 
@@ -55,8 +56,18 @@ module test_linalg_determinant
         
         call check(error,state%ok(),state%print())
         if (allocated(error)) return
-        
         call check(error, abs(deta-1.0_${rk}$)<epsilon(0.0_${rk}$), 'det(eye(n))==1')
+        if (allocated(error)) return
+
+        !> Test with allocatable matrix
+        aalloc = eye(n)
+        deta = det(aalloc,overwrite_a=.false.,err=state)
+        call check(error,state%ok(),state%print()//' (allocatable a)')
+        if (allocated(error)) return
+        call check(error,allocated(aalloc),'a is still allocated')
+        if (allocated(error)) return
+        call check(error, abs(deta-1.0_${rk}$)<epsilon(0.0_${rk}$), 'det(eye(n))==1 (allocatable a))')
+        if (allocated(error)) return
         
     end subroutine test_${rt[0]}$${rk}$_eye_determinant
 


### PR DESCRIPTION
I noticed a typo in `det` that does not deallocate the internal pointer matrix properly: it should be when the temporary is created (`copy_a==.true.`):

 https://github.com/fortran-lang/stdlib/blob/206f84a0915d1e7ac31e7d2ad254c2b88ada2695/src/stdlib_linalg_determinant.fypp#L227

I don't know why an error was never printed in the tests, as it should be impossible to deallocate the target
of a pointer, if this is not `allocatable`. 
Anyways this is a fix for it, plus an additional test. 

cc: @jvdp1 @jalvesz 