### PR TITLE
linalg: remove `pure` attr from procedures using `openmp` runtime

### DIFF
--- a/src/stdlib_linalg_lapack.fypp
+++ b/src/stdlib_linalg_lapack.fypp
@@ -5261,7 +5261,7 @@ module stdlib_linalg_lapack
           !! HB2ST_KERNELS is an internal routine used by the CHETRD_HB2ST
           !! subroutine.
 #ifdef STDLIB_EXTERNAL_LAPACK
-               pure subroutine  chb2st_kernels( uplo, wantz, ttype,st, ed, sweep, n, nb, ib,a, &
+               pure subroutine chb2st_kernels( uplo, wantz, ttype,st, ed, sweep, n, nb, ib,a, &
                          lda, v, tau, ldvt, work)
                     import sp,dp,qp,ilp,lk 
                     implicit none(type,external) 
@@ -6394,7 +6394,7 @@ module stdlib_linalg_lapack
           !! tridiagonal form T by a unitary similarity transformation:
           !! Q**H * A * Q = T.
 #ifdef STDLIB_EXTERNAL_LAPACK
-               pure subroutine chetrd_hb2st( stage1, vect, uplo, n, kd, ab, ldab,d, e, hous, &
+               subroutine chetrd_hb2st( stage1, vect, uplo, n, kd, ab, ldab,d, e, hous, &
                          lhous, work, lwork, info )
                     import sp,dp,qp,ilp,lk 
                     implicit none(type,external) 
@@ -6412,7 +6412,7 @@ module stdlib_linalg_lapack
                module procedure stdlib_whetrd_hb2st
 #:endif
 #ifdef STDLIB_EXTERNAL_LAPACK
-               pure subroutine zhetrd_hb2st( stage1, vect, uplo, n, kd, ab, ldab,d, e, hous, &
+               subroutine zhetrd_hb2st( stage1, vect, uplo, n, kd, ab, ldab,d, e, hous, &
                          lhous, work, lwork, info )
                     import sp,dp,qp,ilp,lk 
                     implicit none(type,external) 
@@ -6435,7 +6435,7 @@ module stdlib_linalg_lapack
           !! band-diagonal form AB by a unitary similarity transformation:
           !! Q**H * A * Q = AB.
 #ifdef STDLIB_EXTERNAL_LAPACK
-               pure subroutine chetrd_he2hb( uplo, n, kd, a, lda, ab, ldab, tau,work, lwork, info &
+               subroutine chetrd_he2hb( uplo, n, kd, a, lda, ab, ldab, tau,work, lwork, info &
                          )
                     import sp,dp,qp,ilp,lk 
                     implicit none(type,external) 
@@ -6452,7 +6452,7 @@ module stdlib_linalg_lapack
                module procedure stdlib_whetrd_he2hb
 #:endif
 #ifdef STDLIB_EXTERNAL_LAPACK
-               pure subroutine zhetrd_he2hb( uplo, n, kd, a, lda, ab, ldab, tau,work, lwork, info &
+               subroutine zhetrd_he2hb( uplo, n, kd, a, lda, ab, ldab, tau,work, lwork, info &
                          )
                     import sp,dp,qp,ilp,lk 
                     implicit none(type,external) 
@@ -24182,7 +24182,7 @@ module stdlib_linalg_lapack
           !! tridiagonal form T by a orthogonal similarity transformation:
           !! Q**T * A * Q = T.
 #ifdef STDLIB_EXTERNAL_LAPACK
-               pure subroutine dsytrd_sb2st( stage1, vect, uplo, n, kd, ab, ldab,d, e, hous, &
+               subroutine dsytrd_sb2st( stage1, vect, uplo, n, kd, ab, ldab,d, e, hous, &
                          lhous, work, lwork, info )
                     import sp,dp,qp,ilp,lk 
                     implicit none(type,external) 
@@ -24199,7 +24199,7 @@ module stdlib_linalg_lapack
                module procedure stdlib_qsytrd_sb2st
 #:endif
 #ifdef STDLIB_EXTERNAL_LAPACK
-               pure subroutine ssytrd_sb2st( stage1, vect, uplo, n, kd, ab, ldab,d, e, hous, &
+               subroutine ssytrd_sb2st( stage1, vect, uplo, n, kd, ab, ldab,d, e, hous, &
                          lhous, work, lwork, info )
                     import sp,dp,qp,ilp,lk 
                     implicit none(type,external) 
@@ -24221,7 +24221,7 @@ module stdlib_linalg_lapack
           !! band-diagonal form AB by a orthogonal similarity transformation:
           !! Q**T * A * Q = AB.
 #ifdef STDLIB_EXTERNAL_LAPACK
-               pure subroutine dsytrd_sy2sb( uplo, n, kd, a, lda, ab, ldab, tau,work, lwork, info &
+               subroutine dsytrd_sy2sb( uplo, n, kd, a, lda, ab, ldab, tau,work, lwork, info &
                          )
                     import sp,dp,qp,ilp,lk 
                     implicit none(type,external) 
@@ -24238,7 +24238,7 @@ module stdlib_linalg_lapack
                module procedure stdlib_qsytrd_sy2sb
 #:endif
 #ifdef STDLIB_EXTERNAL_LAPACK
-               pure subroutine ssytrd_sy2sb( uplo, n, kd, a, lda, ab, ldab, tau,work, lwork, info &
+               subroutine ssytrd_sy2sb( uplo, n, kd, a, lda, ab, ldab, tau,work, lwork, info &
                          )
                     import sp,dp,qp,ilp,lk 
                     implicit none(type,external) 

--- a/src/stdlib_linalg_lapack_aux.fypp
+++ b/src/stdlib_linalg_lapack_aux.fypp
@@ -1708,7 +1708,7 @@ module stdlib_linalg_lapack_aux
      end function stdlib_ilaenv
 
 
-     pure integer(ilp) function stdlib_iparam2stage( ispec, name, opts,ni, nbi, ibi, nxi )
+     integer(ilp) function stdlib_iparam2stage( ispec, name, opts,ni, nbi, ibi, nxi )
      !! This program sets problem and machine dependent parameters
      !! useful for xHETRD_2STAGE, xHETRD_HE2HB, xHETRD_HB2ST,
      !! xGEBRD_2STAGE, xGEBRD_GE2GB, xGEBRD_GB2BD
@@ -1892,7 +1892,7 @@ module stdlib_linalg_lapack_aux
      end function stdlib_iparam2stage
 
 
-     pure integer(ilp) function stdlib_ilaenv2stage( ispec, name, opts, n1, n2, n3, n4 )
+     integer(ilp) function stdlib_ilaenv2stage( ispec, name, opts, n1, n2, n3, n4 )
      !! ILAENV2STAGE is called from the LAPACK routines to choose problem-dependent
      !! parameters for the local environment.  See ISPEC for a description of
      !! the parameters.

--- a/src/stdlib_linalg_lapack_c.fypp
+++ b/src/stdlib_linalg_lapack_c.fypp
@@ -36212,7 +36212,7 @@ module stdlib_linalg_lapack_c
      end subroutine stdlib_chetrd
 
 
-     pure subroutine stdlib_chetrd_hb2st( stage1, vect, uplo, n, kd, ab, ldab,d, e, hous, lhous, &
+     subroutine stdlib_chetrd_hb2st( stage1, vect, uplo, n, kd, ab, ldab,d, e, hous, lhous, &
      !! CHETRD_HB2ST reduces a complex Hermitian band matrix A to real symmetric
      !! tridiagonal form T by a unitary similarity transformation:
      !! Q**H * A * Q = T.
@@ -36485,7 +36485,7 @@ module stdlib_linalg_lapack_c
      end subroutine stdlib_chetrd_hb2st
 
 
-     pure subroutine stdlib_chetrd_he2hb( uplo, n, kd, a, lda, ab, ldab, tau,work, lwork, info )
+     subroutine stdlib_chetrd_he2hb( uplo, n, kd, a, lda, ab, ldab, tau,work, lwork, info )
      !! CHETRD_HE2HB reduces a complex Hermitian matrix A to complex Hermitian
      !! band-diagonal form AB by a unitary similarity transformation:
      !! Q**H * A * Q = AB.

--- a/src/stdlib_linalg_lapack_d.fypp
+++ b/src/stdlib_linalg_lapack_d.fypp
@@ -41285,7 +41285,7 @@ module stdlib_linalg_lapack_d
      end subroutine stdlib_dsytrd
 
 
-     pure subroutine stdlib_dsytrd_sb2st( stage1, vect, uplo, n, kd, ab, ldab,d, e, hous, lhous, &
+     subroutine stdlib_dsytrd_sb2st( stage1, vect, uplo, n, kd, ab, ldab,d, e, hous, lhous, &
      !! DSYTRD_SB2ST reduces a real symmetric band matrix A to real symmetric
      !! tridiagonal form T by a orthogonal similarity transformation:
      !! Q**T * A * Q = T.
@@ -57070,7 +57070,7 @@ module stdlib_linalg_lapack_d
      end subroutine stdlib_dsysvx
 
 
-     pure subroutine stdlib_dsytrd_sy2sb( uplo, n, kd, a, lda, ab, ldab, tau,work, lwork, info )
+     subroutine stdlib_dsytrd_sy2sb( uplo, n, kd, a, lda, ab, ldab, tau,work, lwork, info )
      !! DSYTRD_SY2SB reduces a real symmetric matrix A to real symmetric
      !! band-diagonal form AB by a orthogonal similarity transformation:
      !! Q**T * A * Q = AB.

--- a/src/stdlib_linalg_lapack_q.fypp
+++ b/src/stdlib_linalg_lapack_q.fypp
@@ -72649,7 +72649,7 @@ module stdlib_linalg_lapack_q
      end subroutine stdlib_qsytrd
 
 
-     pure subroutine stdlib_qsytrd_sb2st( stage1, vect, uplo, n, kd, ab, ldab,d, e, hous, lhous, &
+     subroutine stdlib_qsytrd_sb2st( stage1, vect, uplo, n, kd, ab, ldab,d, e, hous, lhous, &
      !! DSYTRD_SB2ST: reduces a real symmetric band matrix A to real symmetric
      !! tridiagonal form T by a orthogonal similarity transformation:
      !! Q**T * A * Q = T.
@@ -72895,7 +72895,7 @@ module stdlib_linalg_lapack_q
      end subroutine stdlib_qsytrd_sb2st
 
 
-     pure subroutine stdlib_qsytrd_sy2sb( uplo, n, kd, a, lda, ab, ldab, tau,work, lwork, info )
+     subroutine stdlib_qsytrd_sy2sb( uplo, n, kd, a, lda, ab, ldab, tau,work, lwork, info )
      !! DSYTRD_SY2SB: reduces a real symmetric matrix A to real symmetric
      !! band-diagonal form AB by a orthogonal similarity transformation:
      !! Q**T * A * Q = AB.

--- a/src/stdlib_linalg_lapack_s.fypp
+++ b/src/stdlib_linalg_lapack_s.fypp
@@ -41195,7 +41195,7 @@ module stdlib_linalg_lapack_s
      end subroutine stdlib_ssytrd
 
 
-     pure subroutine stdlib_ssytrd_sb2st( stage1, vect, uplo, n, kd, ab, ldab,d, e, hous, lhous, &
+     subroutine stdlib_ssytrd_sb2st( stage1, vect, uplo, n, kd, ab, ldab,d, e, hous, lhous, &
      !! SSYTRD_SB2ST reduces a real symmetric band matrix A to real symmetric
      !! tridiagonal form T by a orthogonal similarity transformation:
      !! Q**T * A * Q = T.
@@ -55545,7 +55545,7 @@ module stdlib_linalg_lapack_s
      end subroutine stdlib_ssysvx
 
 
-     pure subroutine stdlib_ssytrd_sy2sb( uplo, n, kd, a, lda, ab, ldab, tau,work, lwork, info )
+     subroutine stdlib_ssytrd_sy2sb( uplo, n, kd, a, lda, ab, ldab, tau,work, lwork, info )
      !! SSYTRD_SY2SB reduces a real symmetric matrix A to real symmetric
      !! band-diagonal form AB by a orthogonal similarity transformation:
      !! Q**T * A * Q = AB.

--- a/src/stdlib_linalg_lapack_w.fypp
+++ b/src/stdlib_linalg_lapack_w.fypp
@@ -28573,7 +28573,7 @@ module stdlib_linalg_lapack_w
      end subroutine stdlib_whetrd
 
 
-     pure subroutine stdlib_whetrd_hb2st( stage1, vect, uplo, n, kd, ab, ldab,d, e, hous, lhous, &
+     subroutine stdlib_whetrd_hb2st( stage1, vect, uplo, n, kd, ab, ldab,d, e, hous, lhous, &
      !! ZHETRD_HB2ST: reduces a complex Hermitian band matrix A to real symmetric
      !! tridiagonal form T by a unitary similarity transformation:
      !! Q**H * A * Q = T.
@@ -28846,7 +28846,7 @@ module stdlib_linalg_lapack_w
      end subroutine stdlib_whetrd_hb2st
 
 
-     pure subroutine stdlib_whetrd_he2hb( uplo, n, kd, a, lda, ab, ldab, tau,work, lwork, info )
+     subroutine stdlib_whetrd_he2hb( uplo, n, kd, a, lda, ab, ldab, tau,work, lwork, info )
      !! ZHETRD_HE2HB: reduces a complex Hermitian matrix A to complex Hermitian
      !! band-diagonal form AB by a unitary similarity transformation:
      !! Q**H * A * Q = AB.

--- a/src/stdlib_linalg_lapack_z.fypp
+++ b/src/stdlib_linalg_lapack_z.fypp
@@ -36627,7 +36627,7 @@ module stdlib_linalg_lapack_z
      end subroutine stdlib_zhetrd
 
 
-     pure subroutine stdlib_zhetrd_hb2st( stage1, vect, uplo, n, kd, ab, ldab,d, e, hous, lhous, &
+     subroutine stdlib_zhetrd_hb2st( stage1, vect, uplo, n, kd, ab, ldab,d, e, hous, lhous, &
      !! ZHETRD_HB2ST reduces a complex Hermitian band matrix A to real symmetric
      !! tridiagonal form T by a unitary similarity transformation:
      !! Q**H * A * Q = T.
@@ -36900,7 +36900,7 @@ module stdlib_linalg_lapack_z
      end subroutine stdlib_zhetrd_hb2st
 
 
-     pure subroutine stdlib_zhetrd_he2hb( uplo, n, kd, a, lda, ab, ldab, tau,work, lwork, info )
+     subroutine stdlib_zhetrd_he2hb( uplo, n, kd, a, lda, ab, ldab, tau,work, lwork, info )
      !! ZHETRD_HE2HB reduces a complex Hermitian matrix A to complex Hermitian
      !! band-diagonal form AB by a unitary similarity transformation:
      !! Q**H * A * Q = AB.


### PR DESCRIPTION
Fix #825. 

- Remove `pure` attribute from all routines that may use the `openmp` runtime upward. 
- [Reference to the OpenMP standard](https://www.openmp.org/spec-html/5.1/openmpch3.html): 

> OpenMP runtime library routines may not be called from PURE or ELEMENTAL procedures.

cc: @jvdp1 @fortran-lang/stdlib 