### PR TITLE
linalg: fix typo in least-squares complex space allocation

### DIFF
--- a/src/stdlib_linalg_least_squares.fypp
+++ b/src/stdlib_linalg_least_squares.fypp
@@ -305,7 +305,7 @@ submodule (stdlib_linalg) stdlib_linalg_least_squares
          else
             allocate(cwork(lcwork))
          endif
-         ncs = size(iwork,kind=ilp)
+         ncs = size(cwork,kind=ilp)
          #:endif         
                     
          if (nrs<lrwork .or. nis<liwork#{if rt.startswith('c')}# .or. ncs<lcwork#{endif}# &


### PR DESCRIPTION
Attempt to fix #823: there is a typo querying complex storage space in the lstsq solver: 



@jalvesz @loiseaujc if you have an x86 unix setup, can I ask you to check if this fixes your issue? 
It does look indeed like a needed fix. 
