### PR TITLE
Deactivate gcc-13 from CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,11 +20,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-12]
-        gcc_v: [10, 11, 12, 13, 14] # Version of GFortran we want to use.
+        gcc_v: [10, 11, 12] # Version of GFortran we want to use.
         build: [cmake]
-        exclude:
-          - os: ubuntu-latest
-            gcc_v: 13 
         include:
           - os: ubuntu-latest
             gcc_v: 10

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,8 +20,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-12]
-        gcc_v: [10, 11, 12] # Version of GFortran we want to use.
+        gcc_v: [10, 11, 12, 13, 14] # Version of GFortran we want to use.
         build: [cmake]
+        exclude:
+          - os: ubuntu-latest
+            gcc_v: 13 
         include:
           - os: ubuntu-latest
             gcc_v: 10

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,11 +19,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-12]
-        gcc_v: [10, 11, 12] # Version of GFortran we want to use.
+        os: [ubuntu-24.04, macos-12]
+        gcc_v: [10, 11, 12, 13] # Version of GFortran we want to use.
         build: [cmake]
+        exclude: 
+          - os: macos-12
+            gcc_v: 13
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             gcc_v: 10
             build: cmake-inline
     env:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-12]
-        gcc_v: [10, 11, 12, 13] # Version of GFortran we want to use.
+        gcc_v: [10, 11, 12] # Version of GFortran we want to use.
         build: [cmake]
         include:
           - os: ubuntu-latest


### PR DESCRIPTION
Due to on-going issues with GCC-13 in the github runners, I suggest to temporarily deactivate GCC-13 from the CI. 
See: https://github.com/fortran-lang/fpm/pull/1043
cc: @jvdp1 @fortran-lang/stdlib