### PR TITLE
Update author picture in API documentation webpage

### DIFF
--- a/API-doc-FORD-file.md
+++ b/API-doc-FORD-file.md
@@ -43,6 +43,7 @@ project_website: https://stdlib.fortran-lang.org
 favicon: doc/media/favicon.ico
 license: by-sa
 author: fortran-lang/stdlib contributors
+author_pic: https://fortran-lang.org/en/_static/fortran-logo-256x256.png 
 email: fortran-lang@groups.io
 github: https://github.com/fortran-lang
 twitter: https://twitter.com/fortranlang

--- a/API-doc-FORD-file.md
+++ b/API-doc-FORD-file.md
@@ -43,7 +43,6 @@ project_website: https://stdlib.fortran-lang.org
 favicon: doc/media/favicon.ico
 license: by-sa
 author: fortran-lang/stdlib contributors
-author_pic: https://fortran-lang.org/assets/img/fortran_logo_512x512.png
 email: fortran-lang@groups.io
 github: https://github.com/fortran-lang
 twitter: https://twitter.com/fortranlang


### PR DESCRIPTION
Fixes #838 
Replacing the link to a valid does not solve the issue.
The same issue is also in [`fpm API website`](https://fortran-lang.github.io/fpm/).