### PR TITLE
Rewrite fypp directive to avoid the use of removesuffix in stdlib_math_meshgrip

### DIFF
--- a/src/stdlib_math_meshgrid.fypp
+++ b/src/stdlib_math_meshgrid.fypp
@@ -7,7 +7,7 @@
   do i${j}$ = 1, size(x${j}$)
   #:endfor
   #:for j in indices
-  xm${j}$(${"".join(f"i{j}," for j in indices).removesuffix(",")}$) = &
+  xm${j}$(${",".join(f"i{j}" for j in indices)}$) = &
           x${j}$(i${j}$)
   #:endfor
   #:for j in indices
@@ -33,7 +33,7 @@ contains
     #: set RName = rname("meshgrid", rank, t1, k1)
     module procedure ${RName}$
 
-        integer :: ${"".join(f"i{j}," for j in range(1, rank + 1)).removesuffix(",")}$
+        integer :: ${",".join(f"i{j}" for j in range(1, rank + 1))}$
 
         select case (optval(indexing, stdlib_meshgrid_xy))
         case (stdlib_meshgrid_xy)


### PR DESCRIPTION
`removesuffix` used in `stdlib_math_meshgrid` requires Python >3.9. 

Here is a small change to avoid the requirement of Python >3.9.

@igirault : was there a special need to use `removesuffix`? Do I overlook something? Or are my changes satisfying?

\cc @perazz @jalvesz 