### PR TITLE
Remove `msys` from CI and install `fypp` via msys2 package

### DIFF
--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -23,9 +23,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Setup MinGW native environment
+    - name: Setup environment
       uses: msys2/setup-msys2@v2
-      if: contains(matrix.msystem, 'MINGW')
       with:
         msystem: ${{ matrix.msystem }}
         update: false
@@ -37,21 +36,6 @@ jobs:
           mingw-w64-${{ matrix.arch }}-python-fypp
           mingw-w64-${{ matrix.arch }}-cmake
           mingw-w64-${{ matrix.arch }}-ninja
-
-    - name: Setup msys POSIX environment
-      uses: msys2/setup-msys2@v2
-      if: contains(matrix.msystem, 'MSYS')
-      with:
-        msystem: MSYS
-        update: false
-        install: >-
-          git
-          mingw-w64-x86_64-gcc
-          mingw-w64-x86_64-gcc-fortran
-          python
-          mingw-w64-x86_64-python-fypp
-          cmake
-          ninja
 
     - run: >-
         PATH=$PATH:/mingw64/bin/ cmake

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -57,6 +57,7 @@ jobs:
     - name: Install fypp
       run: pip install fypp
 
+
     - run: >-
         PATH=$PATH:/mingw64/bin/ cmake
         -Wdev

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -23,8 +23,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Setup environment
+    - name: Setup MinGW native environment
       uses: msys2/setup-msys2@v2
+      if: contains(matrix.msystem, 'MINGW')
       with:
         msystem: ${{ matrix.msystem }}
         update: false
@@ -36,6 +37,25 @@ jobs:
           mingw-w64-${{ matrix.arch }}-python-fypp
           mingw-w64-${{ matrix.arch }}-cmake
           mingw-w64-${{ matrix.arch }}-ninja
+    
+    - name: Setup msys POSIX environment
+      uses: msys2/setup-msys2@v2
+      if: contains(matrix.msystem, 'MSYS')
+      with:
+        msystem: MSYS
+        update: false
+        install: >-
+          git
+          mingw-w64-x86_64-gcc
+          mingw-w64-x86_64-gcc-fortran
+          python
+          python-pip
+          cmake
+          ninja
+      
+    - name: Install fypp
+      if: contains(matrix.msystem, 'MSYS')
+      run: pip install fypp
 
     - run: >-
         PATH=$PATH:/mingw64/bin/ cmake

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -13,7 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         include: [
-          { msystem: MSYS,    arch: x86_64 },
           { msystem: MINGW64, arch: x86_64 },
           { msystem: MINGW32, arch: i686   }
         ]
@@ -25,7 +24,6 @@ jobs:
 
     - name: Setup MinGW native environment
       uses: msys2/setup-msys2@v2
-      if: contains(matrix.msystem, 'MINGW')
       with:
         msystem: ${{ matrix.msystem }}
         update: false
@@ -37,25 +35,6 @@ jobs:
           mingw-w64-${{ matrix.arch }}-python-fypp
           mingw-w64-${{ matrix.arch }}-cmake
           mingw-w64-${{ matrix.arch }}-ninja
-
-    - name: Setup msys POSIX environment
-      uses: msys2/setup-msys2@v2
-      if: contains(matrix.msystem, 'MSYS')
-      with:
-        msystem: MSYS
-        update: false
-        install: >-
-          git
-          mingw-w64-x86_64-gcc
-          mingw-w64-x86_64-gcc-fortran
-          python
-          python-pip
-          cmake
-          ninja
-
-    - name: Install fypp
-      if: contains(matrix.msystem, 'MSYS')
-      run: pip install fypp
 
     - run: >-
         PATH=$PATH:/mingw64/bin/ cmake

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -35,7 +35,6 @@ jobs:
           mingw-w64-${{ matrix.arch }}-gcc-fortran
           mingw-w64-${{ matrix.arch }}-python
           mingw-w64-${{ matrix.arch }}-python-fypp
-          mingw-w64-${{ matrix.arch }}-python-setuptools
           mingw-w64-${{ matrix.arch }}-cmake
           mingw-w64-${{ matrix.arch }}-ninja
 

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -34,7 +34,7 @@ jobs:
           mingw-w64-${{ matrix.arch }}-gcc
           mingw-w64-${{ matrix.arch }}-gcc-fortran
           mingw-w64-${{ matrix.arch }}-python
-          mingw-w64-${{ matrix.arch }}-python-pip
+          mingw-w64-${{ matrix.arch }}-python-fypp
           mingw-w64-${{ matrix.arch }}-python-setuptools
           mingw-w64-${{ matrix.arch }}-cmake
           mingw-w64-${{ matrix.arch }}-ninja
@@ -50,13 +50,9 @@ jobs:
           mingw-w64-x86_64-gcc
           mingw-w64-x86_64-gcc-fortran
           python
-          python-pip
+          mingw-w64-x86_64-python-fypp
           cmake
           ninja
-
-    - name: Install fypp
-      run: pip install fypp
-
 
     - run: >-
         PATH=$PATH:/mingw64/bin/ cmake

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -37,7 +37,7 @@ jobs:
           mingw-w64-${{ matrix.arch }}-python-fypp
           mingw-w64-${{ matrix.arch }}-cmake
           mingw-w64-${{ matrix.arch }}-ninja
-    
+
     - name: Setup msys POSIX environment
       uses: msys2/setup-msys2@v2
       if: contains(matrix.msystem, 'MSYS')
@@ -52,7 +52,7 @@ jobs:
           python-pip
           cmake
           ninja
-      
+
     - name: Install fypp
       if: contains(matrix.msystem, 'MSYS')
       run: pip install fypp


### PR DESCRIPTION
- [x] Remove `msystem: msys` from CI.
- [x] Install `fypp` via msys2 package instead of `pip`.

Address https://github.com/fortran-lang/stdlib/issues/853.