### PR TITLE
CI: upgrade to upload-artifact@v4

### DIFF
--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -59,7 +59,7 @@ jobs:
     - name: CTest
       run: PATH=$PATH:/mingw64/bin/ ctest --test-dir build --output-on-failure --parallel -V -LE quadruple_precision
 
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: WindowsCMakeTestlog

--- a/.github/workflows/doc-deployment.yml
+++ b/.github/workflows/doc-deployment.yml
@@ -40,7 +40,7 @@ jobs:
           ford -r $(git describe --always) --debug ${MAYBE_SKIP_SEARCH} "${FORD_FILE}"
 
       - name: Upload Documentation
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: FORD-API-docs
           path: ./API-doc/


### PR DESCRIPTION
Versions @v1 and @v2 are deprecated, this causes CI builds to fail
- See: https://github.com/fortran-lang/stdlib/actions/runs/10847866794/job/30103827108
- Deprecation notice: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

@jvdp1 @fortran-lang/stdlib 