### PR TITLE
`loadtxt/savetxt`: do not require space after last entry

### DIFF
--- a/src/stdlib_io.fypp
+++ b/src/stdlib_io.fypp
@@ -144,10 +144,15 @@ contains
       do i = 1, skiprows_
         read(s, *)
       end do
-
-      #:if 'real' in t1
+      
       ! Default to format used for savetxt if fmt not specified.
-      fmt_ = optval(fmt, "(*"//FMT_REAL_${k1}$(1:len(FMT_REAL_${k1}$)-1)//",1x))")
+      #:if 'real' in t1
+      fmt_ = optval(fmt, "(*"//FMT_REAL_${k1}$(1:len(FMT_REAL_${k1}$)-1)//",:,1x))")
+      #:elif 'complex' in t1
+      fmt_ = optval(fmt, "(*"//FMT_COMPLEX_${k1}$(1:len(FMT_COMPLEX_${k1}$)-1)//",:,1x))")
+      #:else
+      fmt_ = optval(fmt, "*")
+      #:endif      
 
       if ( fmt_ == '*' ) then
         ! Use list directed read if user has specified fmt='*'
@@ -160,36 +165,6 @@ contains
           read (s,fmt_) d(i, :)
         enddo
       endif
-      #:elif 'complex' in t1
-      ! Default to format used for savetxt if fmt not specified.
-      fmt_ = optval(fmt, "(*"//FMT_COMPLEX_${k1}$(1:len(FMT_COMPLEX_${k1}$)-1)//",1x))")
-      if ( fmt_ == '*' ) then
-        ! Use list directed read if user has specified fmt='*'
-        do i = 1, max_rows_
-          read (s,*) d(i, :)
-        enddo
-      else
-        ! Otherwise pass default or user specified fmt string.
-        do i = 1, max_rows_
-          read (s,fmt_) d(i, :)
-        enddo
-      endif
-      #:else
-      ! Default to list directed for integer
-      fmt_ = optval(fmt, "*")
-      ! Use list directed read if user has specified fmt='*'
-      if ( fmt_ == '*' ) then
-        do i = 1, max_rows_
-          read (s,*) d(i, :)
-        enddo
-      else
-        ! Otherwise pass default user specified fmt string.
-        do i = 1, max_rows_
-          read (s,fmt_) d(i, :)
-        enddo
-      endif
-
-      #:endif
 
       close(s)
 
@@ -222,11 +197,11 @@ contains
       s = open(filename, "w")
       do i = 1, size(d, 1)
         #:if 'real' in t1
-          write(s, "(*"//FMT_REAL_${k1}$(1:len(FMT_REAL_${k1}$)-1)//",1x))") d(i, :)
+          write(s, "(*"//FMT_REAL_${k1}$(1:len(FMT_REAL_${k1}$)-1)//",:,1x))") d(i, :)
         #:elif 'complex' in t1
-          write(s, "(*"//FMT_COMPLEX_${k1}$(1:len(FMT_COMPLEX_${k1}$)-1)//",1x))") d(i, :)
+          write(s, "(*"//FMT_COMPLEX_${k1}$(1:len(FMT_COMPLEX_${k1}$)-1)//",:,1x))") d(i, :)
         #:elif 'integer' in t1
-          write(s, "(*"//FMT_INT(1:len(FMT_INT)-1)//",1x))") d(i, :)
+          write(s, "(*"//FMT_INT(1:len(FMT_INT)-1)//",:,1x))") d(i, :)
         #:else
           write(s, *) d(i, :)
         #:endif


### PR DESCRIPTION
Attempt to address #862. 

The current formats require an end-of-row space both in `savetxt` and `loadtxt`, i.e., 

```
format(*(i0,1x))
```

This PR proposes to not require a space after the last record, i.e., 
 
```
format(*(i0,:,1x))
```

This should hopefully improve the seldom crashing CI tests. 
@fortran-lang/stdlib @chuckyvt @minhqdao 