### PR TITLE
Fix warnings [-Wunused-xxx] from compilation

### DIFF
--- a/example/hashmaps/example_hashmaps_get_other_data.f90
+++ b/example/hashmaps/example_hashmaps_get_other_data.f90
@@ -1,6 +1,6 @@
 program example_get_other_data
   use stdlib_kinds, only: int8, int64
-  use stdlib_hashmaps, only: chaining_hashmap_type, int_index
+  use stdlib_hashmaps, only: chaining_hashmap_type
   use stdlib_hashmap_wrappers, only: fnv_1_hasher, key_type, other_type, set, get
   implicit none
   logical                     :: conflict

--- a/example/hashmaps/example_hashmaps_remove.f90
+++ b/example/hashmaps/example_hashmaps_remove.f90
@@ -1,6 +1,6 @@
 program example_remove
   use stdlib_kinds, only: int8, int64
-  use stdlib_hashmaps, only: open_hashmap_type, int_index
+  use stdlib_hashmaps, only: open_hashmap_type
   use stdlib_hashmap_wrappers, only: fnv_1_hasher, &
                                      fnv_1a_hasher, key_type, other_type, set
   implicit none

--- a/example/hashmaps/example_hashmaps_set_other_data.f90
+++ b/example/hashmaps/example_hashmaps_set_other_data.f90
@@ -1,5 +1,4 @@
 program example_set_other_data
-  use stdlib_kinds, only: int8
   use stdlib_hashmaps, only: open_hashmap_type
   use stdlib_hashmap_wrappers, only: fnv_1_hasher, &
                                      fnv_1a_hasher, key_type, other_type, set

--- a/example/linalg/example_determinant.f90
+++ b/example/linalg/example_determinant.f90
@@ -2,7 +2,6 @@ program example_determinant
   use stdlib_kinds, only: dp
   use stdlib_linalg, only: det, linalg_state_type
   implicit none
-  type(linalg_state_type) :: err
 
   real(dp) :: d
 

--- a/example/linalg/example_eigvals.f90
+++ b/example/linalg/example_eigvals.f90
@@ -3,7 +3,6 @@ program example_eigvals
   use stdlib_linalg, only: eigvals
   implicit none
 
-  integer :: i
   real, allocatable :: A(:,:),lambda(:)
   complex, allocatable :: cA(:,:),clambda(:)
 

--- a/example/linalg/example_eigvalsh.f90
+++ b/example/linalg/example_eigvalsh.f90
@@ -3,7 +3,6 @@ program example_eigvalsh
   use stdlib_linalg, only: eigvalsh
   implicit none
 
-  integer :: i
   real, allocatable :: A(:,:),lambda(:)
   complex, allocatable :: cA(:,:)
 

--- a/example/linalg/example_state2.f90
+++ b/example/linalg/example_state2.f90
@@ -7,7 +7,6 @@ program example_state2
   use stdlib_linalg_state, only: linalg_state_type, LINALG_VALUE_ERROR, LINALG_SUCCESS, &
           linalg_error_handling
   implicit none
-  integer :: info
   type(linalg_state_type) :: err
   real :: a_div_b
   

--- a/example/selection/selection_vs_sort.f90
+++ b/example/selection/selection_vs_sort.f90
@@ -1,5 +1,5 @@
 program selection_vs_sort
-  use stdlib_kinds, only: dp, sp, int64
+  use stdlib_kinds, only: int64
   use stdlib_selection, only: select, arg_select
   use stdlib_sorting, only: sort
   implicit none

--- a/src/stdlib_linalg_blas_c.fypp
+++ b/src/stdlib_linalg_blas_c.fypp
@@ -2549,8 +2549,6 @@ module stdlib_linalg_blas_c
         ! -- reference blas level1 routine --
         ! -- reference blas is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
-        ! Constants 
-        integer, parameter :: wp = kind(1._sp)
         ! Scaling Constants 
         ! Scalar Arguments 
         real(sp), intent(out) :: c

--- a/src/stdlib_linalg_blas_d.fypp
+++ b/src/stdlib_linalg_blas_d.fypp
@@ -848,7 +848,6 @@ module stdlib_linalg_blas_d
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
            ! march 2021
         ! Constants 
-        integer, parameter :: wp = kind(1._dp)
         real(dp), parameter :: maxn = huge(0.0_dp)
         ! .. blue's scaling constants ..
         ! Scalar Arguments 
@@ -985,8 +984,6 @@ module stdlib_linalg_blas_d
         ! -- reference blas level1 routine --
         ! -- reference blas is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
-        ! Constants 
-        integer, parameter :: wp = kind(1._dp)
         ! Scaling Constants 
         ! Scalar Arguments 
         real(dp), intent(inout) :: a, b
@@ -4422,7 +4419,6 @@ module stdlib_linalg_blas_d
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
            ! march 2021
         ! Constants 
-        integer, parameter :: wp = kind(1._dp)
         real(dp), parameter :: maxn = huge(0.0_dp)
         ! .. blue's scaling constants ..
         ! Scalar Arguments 

--- a/src/stdlib_linalg_blas_q.fypp
+++ b/src/stdlib_linalg_blas_q.fypp
@@ -852,7 +852,6 @@ module stdlib_linalg_blas_${ri}$
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
            ! march 2021
         ! Constants 
-        integer, parameter :: wp = kind(1._${rk}$)
         real(${rk}$), parameter :: maxn = huge(0.0_${rk}$)
         ! .. blue's scaling constants ..
         ! Scalar Arguments 
@@ -989,8 +988,6 @@ module stdlib_linalg_blas_${ri}$
         ! -- reference blas level1 routine --
         ! -- reference blas is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
-        ! Constants 
-        integer, parameter :: wp = kind(1._${rk}$)
         ! Scaling Constants 
         ! Scalar Arguments 
         real(${rk}$), intent(inout) :: a, b
@@ -4426,7 +4423,6 @@ module stdlib_linalg_blas_${ri}$
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
            ! march 2021
         ! Constants 
-        integer, parameter :: wp = kind(1._${rk}$)
         real(${rk}$), parameter :: maxn = huge(0.0_${rk}$)
         ! .. blue's scaling constants ..
         ! Scalar Arguments 

--- a/src/stdlib_linalg_blas_s.fypp
+++ b/src/stdlib_linalg_blas_s.fypp
@@ -233,7 +233,6 @@ module stdlib_linalg_blas_s
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
            ! march 2021
         ! Constants 
-        integer, parameter :: wp = kind(1._sp)
         real(sp), parameter :: maxn = huge(0.0_sp)
         ! .. blue's scaling constants ..
         ! Scalar Arguments 
@@ -1028,7 +1027,6 @@ module stdlib_linalg_blas_s
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
            ! march 2021
         ! Constants 
-        integer, parameter :: wp = kind(1._sp)
         real(sp), parameter :: maxn = huge(0.0_sp)
         ! .. blue's scaling constants ..
         ! Scalar Arguments 
@@ -1166,7 +1164,6 @@ module stdlib_linalg_blas_s
         ! -- reference blas is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
         ! Constants 
-        integer, parameter :: wp = kind(1._sp)
         ! Scaling Constants 
         ! Scalar Arguments 
         real(sp), intent(inout) :: a, b

--- a/src/stdlib_linalg_blas_w.fypp
+++ b/src/stdlib_linalg_blas_w.fypp
@@ -2635,8 +2635,6 @@ module stdlib_linalg_blas_${ci}$
         ! -- reference blas level1 routine --
         ! -- reference blas is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
-        ! Constants 
-        integer, parameter :: wp = kind(1._${ck}$)
         ! Scaling Constants 
         ! Scalar Arguments 
         real(${ck}$), intent(out) :: c

--- a/src/stdlib_linalg_blas_z.fypp
+++ b/src/stdlib_linalg_blas_z.fypp
@@ -2627,8 +2627,6 @@ module stdlib_linalg_blas_z
         ! -- reference blas level1 routine --
         ! -- reference blas is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
-        ! Constants 
-        integer, parameter :: wp = kind(1._dp)
         ! Scaling Constants 
         ! Scalar Arguments 
         real(dp), intent(out) :: c

--- a/src/stdlib_linalg_cholesky.fypp
+++ b/src/stdlib_linalg_cholesky.fypp
@@ -54,7 +54,7 @@ submodule (stdlib_linalg) stdlib_linalg_cholesky
 
          !> Local variables
          type(linalg_state_type) :: err0
-         integer(ilp) :: lda,n,info,i,j
+         integer(ilp) :: lda,n,info,j
          logical(lk) :: lower_,other_zeroed_
          character :: triangle
          ${rt}$, parameter :: zero = 0.0_${rk}$

--- a/src/stdlib_linalg_eigenvalues.fypp
+++ b/src/stdlib_linalg_eigenvalues.fypp
@@ -162,14 +162,17 @@ submodule (stdlib_linalg) stdlib_linalg_eigenvalues
 
          !> Local variables
          type(linalg_state_type) :: err0
-         integer(ilp) :: m,n,lda,ldu,ldv,info,k,lwork,lrwork,neig
+         integer(ilp) :: m,n,lda,ldu,ldv,info,k,lwork,neig
          logical(lk) :: copy_a
          character :: task_u,task_v
          ${rt}$, target :: work_dummy(1),u_dummy(1,1),v_dummy(1,1)
          ${rt}$, allocatable :: work(:)
+         ${rt}$, pointer :: amat(:,:),umat(:,:),vmat(:,:)
+         #:if rt.startswith('complex')
          real(${rk}$), allocatable :: rwork(:)
-         ${rt}$, pointer :: amat(:,:),lreal(:),limag(:),umat(:,:),vmat(:,:)
-
+         #:else
+         ${rt}$, pointer :: lreal(:),limag(:)
+         #:endif
          !> Matrix size
          m    = size(a,1,kind=ilp)
          n    = size(a,2,kind=ilp)
@@ -388,7 +391,9 @@ submodule (stdlib_linalg) stdlib_linalg_eigenvalues
          character :: triangle,task
          ${rt}$, target :: work_dummy(1)
          ${rt}$, allocatable :: work(:)
+         #:if rt.startswith('complex')
          real(${rk}$), allocatable :: rwork(:)
+         #:endif
          ${rt}$, pointer :: amat(:,:)
 
          !> Matrix size

--- a/src/stdlib_linalg_lapack_c.fypp
+++ b/src/stdlib_linalg_lapack_c.fypp
@@ -38666,7 +38666,7 @@ module stdlib_linalg_lapack_c
            ! Local Scalars 
            integer(ilp) :: ncols, i, j, k, kp
            real(sp) :: amax, umax, rpvgrw, tmp
-           logical(lk) :: upper, lsame
+           logical(lk) :: upper
            complex(sp) :: zdum
            ! Intrinsic Functions 
            intrinsic :: abs,real,aimag,max,min

--- a/src/stdlib_linalg_lapack_d.fypp
+++ b/src/stdlib_linalg_lapack_d.fypp
@@ -6042,7 +6042,7 @@ module stdlib_linalg_lapack_d
            
            
            ! Local Scalars 
-           integer(ilp) :: i, i1, i2, i3, i4, it1, it2, it3, it4, j
+           integer(ilp) :: i, i1, i2, i3, i4, it1, it2, it3, it4
            ! Local Arrays 
            integer(ilp) :: mm(lv,4)
            ! Intrinsic Functions 

--- a/src/stdlib_linalg_lapack_s.fypp
+++ b/src/stdlib_linalg_lapack_s.fypp
@@ -6071,7 +6071,7 @@ module stdlib_linalg_lapack_s
            
            
            ! Local Scalars 
-           integer(ilp) :: i, i1, i2, i3, i4, it1, it2, it3, it4, j
+           integer(ilp) :: i, i1, i2, i3, i4, it1, it2, it3, it4
            ! Local Arrays 
            integer(ilp) :: mm(lv,4)
            ! Intrinsic Functions 

--- a/src/stdlib_linalg_lapack_w.fypp
+++ b/src/stdlib_linalg_lapack_w.fypp
@@ -35519,7 +35519,7 @@ module stdlib_linalg_lapack_${ci}$
            ! Local Scalars 
            integer(ilp) :: ncols, i, j, k, kp
            real(${ck}$) :: amax, umax, rpvgrw, tmp
-           logical(lk) :: upper, lsame
+           logical(lk) :: upper
            complex(${ck}$) :: zdum
            ! Intrinsic Functions 
            intrinsic :: abs,real,aimag,max,min

--- a/src/stdlib_linalg_lapack_z.fypp
+++ b/src/stdlib_linalg_lapack_z.fypp
@@ -39073,7 +39073,7 @@ module stdlib_linalg_lapack_z
            ! Local Scalars 
            integer(ilp) :: ncols, i, j, k, kp
            real(dp) :: amax, umax, rpvgrw, tmp
-           logical(lk) :: upper, lsame
+           logical(lk) :: upper
            complex(dp) :: zdum
            ! Intrinsic Functions 
            intrinsic :: abs,real,aimag,max,min

--- a/src/stdlib_linalg_least_squares.fypp
+++ b/src/stdlib_linalg_least_squares.fypp
@@ -203,12 +203,18 @@ submodule (stdlib_linalg) stdlib_linalg_least_squares
          !! Local variables
          type(linalg_state_type) :: err0
          integer(ilp) :: m,n,lda,ldb,nrhs,ldx,nrhsx,info,mnmin,mnmax,arank,lrwork,liwork,lcwork
-         integer(ilp) :: nrs,nis,ncs,nsvd
+         integer(ilp) :: nrs,nis,nsvd
+         #:if rt.startswith('complex')         
+         integer(ilp) :: ncs
+         #:endif
          integer(ilp), pointer :: iwork(:)
          logical(lk) :: copy_a,large_enough_x
          real(${rk}$) :: acond,rcond
          real(${rk}$), pointer :: rwork(:),singular(:)
-         ${rt}$, pointer :: xmat(:,:),amat(:,:),cwork(:)
+         ${rt}$, pointer :: xmat(:,:),amat(:,:)
+         #:if rt.startswith('complex')         
+         ${rt}$, pointer :: cwork(:)
+         #:endif  
 
          ! Problem sizes
          m     = size(a,1,kind=ilp)

--- a/src/stdlib_linalg_svd.fypp
+++ b/src/stdlib_linalg_svd.fypp
@@ -147,7 +147,9 @@ submodule(stdlib_linalg) stdlib_linalg_svd
          character :: task
          ${rt}$, target :: work_dummy(1),u_dummy(1,1),vt_dummy(1,1)
          ${rt}$, allocatable :: work(:)
+         #:if rt.startswith('complex')
          real(${rk}$), allocatable :: rwork(:)
+         #:endif
          ${rt}$, pointer :: amat(:,:),umat(:,:),vtmat(:,:)
 
          !> Matrix determinant size

--- a/src/stdlib_specialfunctions_gamma.fypp
+++ b/src/stdlib_specialfunctions_gamma.fypp
@@ -232,7 +232,7 @@ contains
         integer :: i
 
         real(${k1}$), parameter :: zero_k1 = 0.0_${k1}$
-        ${t2}$, parameter :: zero = 0.0_${k2}$, half = 0.5_${k2}$,             &
+        ${t2}$, parameter :: half = 0.5_${k2}$,             &
                              one = 1.0_${k2}$, pi = acos(- one), sqpi = sqrt(pi)
         complex(${k2}$) :: y, x, sum
 
@@ -714,7 +714,7 @@ contains
         ${t1}$, intent(in) :: p
         ${t2}$, intent(in) :: x
         ${t2}$ :: res, p_lim, a, b, g, c, d, y
-        integer :: n, m
+        integer :: n
         ${t2}$, parameter :: zero = 0.0_${k2}$, one = 1.0_${k2}$
         ${t2}$, parameter :: dm = tiny(1.0_${k2}$) * 10 ** 6
         ${t1}$, parameter :: zero_k1 = 0_${k1}$, two = 2_${k1}$


### PR DESCRIPTION
Cleaning duty, warnings are generates with

`fpm build --verbose  --flag '-Wunused-variable -Wunused-dummy-argument -Wunused-parameter'
`
> ### Progress
> * [x]  42 unused-variable
> * [x]  15 unused-parameter
> * [x]  12/67 unused-dummy-argument
> * [ ]  55/67 unused-dummy-argument


Leaving 55 unused-dummy-argument warnings unresolvable, see conversation about those.