### PR TITLE
Fix missing argument to linalg_invert_inplace_ call in linalg_invert_split

### DIFF
--- a/src/stdlib_linalg_inverse.fypp
+++ b/src/stdlib_linalg_inverse.fypp
@@ -164,7 +164,7 @@ submodule (stdlib_linalg) stdlib_linalg_inverse
             if (allocated(inva)) deallocate(inva)
             allocate(inva(size(a,1,kind=ilp),size(a,2,kind=ilp))) 
             
-            #:if rt.startswith('complex')
+            #:if rt.startswith('real')
             inva = ieee_value(1.0_${rk}$,ieee_quiet_nan)
             #:else
             inva = cmplx(ieee_value(1.0_${rk}$,ieee_quiet_nan), &

--- a/src/stdlib_linalg_inverse.fypp
+++ b/src/stdlib_linalg_inverse.fypp
@@ -121,7 +121,7 @@ submodule (stdlib_linalg) stdlib_linalg_inverse
              inva = a
 
              !> Compute matrix inverse
-             call stdlib_linalg_invert_inplace_${ri}$(inva,err=err0)      
+             call stdlib_linalg_invert_inplace_${ri}$(inva,pivot=pivot,err=err0)      
             
          end if         
          


### PR DESCRIPTION
During the fix of `unused-dummy-argument` in https://github.com/fortran-lang/stdlib/pull/879, I see this case where the pivot argument is not used, but it seems it should be definitely be passed to the linalg_invert_inplace function.

I made a different PR since it is no longer a refactoring but a real fix.

