### PR TITLE
svd - check the size of storage space

### DIFF
--- a/src/stdlib_linalg_svd.fypp
+++ b/src/stdlib_linalg_svd.fypp
@@ -269,7 +269,11 @@ submodule(stdlib_linalg) stdlib_linalg_svd
          if (info==0) then
 
             !> Prepare working storage
-            lwork = nint(real(work_dummy(1),kind=${rk}$), kind=ilp)
+            ! Check if the returned working storage space is smaller than the largest value
+            ! allowed by lwork
+            lwork = merge(nint(real(work_dummy(1),kind=${rk}$), kind=ilp) &
+                          , huge(lwork) &
+                          , real(work_dummy(1),kind=${rk}$) < real(huge(lwork),kind=${rk}$) )
             allocate(work(lwork))
 
             !> Compute SVD


### PR DESCRIPTION
The procedure `gesdd` might return values for storage space larger than `huge(lwork)`, resulting in a negative value fro `lwork`. Here is a proposition to solve this issue.