### PR TITLE
promote ascii functions to elemental

### DIFF
--- a/doc/specs/stdlib_ascii.md
+++ b/doc/specs/stdlib_ascii.md
@@ -38,7 +38,7 @@ Converts input character variable to all lowercase.
 
 #### Class
 
-Pure function.
+Elemental function.
 
 #### Argument
 
@@ -70,7 +70,7 @@ Converts input character variable to all uppercase.
 
 #### Class
 
-Pure function.
+Elemental function.
 
 #### Argument
 
@@ -107,7 +107,7 @@ or numeral present next to either of its 2 ends.
 
 #### Class
 
-Pure function.
+Elemental function.
 
 #### Argument
 
@@ -142,7 +142,7 @@ transformed to lowercase.
 
 #### Class
 
-Pure function.
+Elemental function.
 
 #### Argument
 
@@ -174,7 +174,7 @@ Reverses the order of all characters in the input character type.
 
 #### Class
 
-Pure function.
+Elemental function.
 
 #### Argument
 

--- a/src/stdlib_ascii.fypp
+++ b/src/stdlib_ascii.fypp
@@ -70,35 +70,35 @@ module stdlib_ascii
 
     !> Returns a new character sequence which is the lower case 
     !> version of the input character sequence
-    !> This method is pure and returns a character sequence
+    !> This method is elemental and returns a character sequence
     interface to_lower
         module procedure :: to_lower
     end interface to_lower
 
     !> Returns a new character sequence which is the upper case
     !> version of the input character sequence
-    !> This method is pure and returns a character sequence
+    !> This method is elemental and returns a character sequence
     interface to_upper
         module procedure :: to_upper
     end interface to_upper
 
     !> Returns a new character sequence which is the title case
     !> version of the input character sequence
-    !> This method is pure and returns a character sequence
+    !> This method is elemental and returns a character sequence
     interface to_title
         module procedure :: to_title
     end interface to_title
 
     !> Returns a new character sequence which is the sentence case
     !> version of the input character sequence
-    !> This method is pure and returns a character sequence
+    !> This method is elemental and returns a character sequence
     interface to_sentence
         module procedure :: to_sentence
     end interface to_sentence
 
     !> Returns a new character sequence which is reverse of
     !> the input charater sequence
-    !> This method is pure and returns a character sequence
+    !> This method is elemental and returns a character sequence
     interface reverse
         module procedure :: reverse
     end interface reverse
@@ -220,7 +220,7 @@ contains
 
     !> Returns the corresponding lowercase letter, if `c` is an uppercase
     !> ASCII character, otherwise `c` itself.
-    pure function char_to_lower(c) result(t)
+    elemental function char_to_lower(c) result(t)
         character(len=1), intent(in) :: c !! A character.
         character(len=1)             :: t
         integer, parameter :: wp= iachar('a')-iachar('A'), BA=iachar('A'), BZ=iachar('Z')
@@ -234,7 +234,7 @@ contains
 
     !> Returns the corresponding uppercase letter, if `c` is a lowercase
     !> ASCII character, otherwise `c` itself.
-    pure function char_to_upper(c) result(t)
+    elemental function char_to_upper(c) result(t)
         character(len=1), intent(in) :: c !! A character.
         character(len=1)             :: t
         integer, parameter :: wp= iachar('a')-iachar('A'), la=iachar('a'), lz=iachar('z')
@@ -250,7 +250,7 @@ contains
     !> ([Specification](../page/specs/stdlib_ascii.html#to_lower))
     !>
     !> Version: experimental
-    pure function to_lower(string) result(lower_string)
+    elemental function to_lower(string) result(lower_string)
         character(len=*), intent(in) :: string
         character(len=len(string)) :: lower_string
         integer :: i
@@ -265,7 +265,7 @@ contains
     !> ([Specification](../page/specs/stdlib_ascii.html#to_upper))
     !>
     !> Version: experimental
-    pure function to_upper(string) result(upper_string)
+    elemental function to_upper(string) result(upper_string)
         character(len=*), intent(in) :: string
         character(len=len(string)) :: upper_string
         integer :: i
@@ -280,7 +280,7 @@ contains
     !> ([Specification](../page/specs/stdlib_ascii.html#to_title))
     !>
     !> Version: experimental
-    pure function to_title(string) result(title_string)
+    elemental function to_title(string) result(title_string)
         character(len=*), intent(in) :: string
         character(len=len(string)) :: title_string
         integer :: i
@@ -307,7 +307,7 @@ contains
     !> ([Specification](../page/specs/stdlib_ascii.html#to_sentence))
     !>
     !> Version: experimental
-    pure function to_sentence(string) result(sentence_string)
+    elemental function to_sentence(string) result(sentence_string)
         character(len=*), intent(in) :: string
         character(len=len(string)) :: sentence_string
         integer :: i, n
@@ -333,7 +333,7 @@ contains
     !> ([Specification](../page/specs/stdlib_ascii.html#reverse))
     !>
     !> Version: experimental
-    pure function reverse(string) result(reverse_string)
+    elemental function reverse(string) result(reverse_string)
         character(len=*), intent(in) :: string
         character(len=len(string)) :: reverse_string
         integer :: i, n


### PR DESCRIPTION
Promote ascii functions from pure to elemental for potentially better optimization and ease use for array expressions manipulation.