### PR TITLE
loadtxt: increase length of internal buffers

### DIFF
--- a/src/stdlib_io.fypp
+++ b/src/stdlib_io.fypp
@@ -120,7 +120,7 @@ contains
       !!
       integer :: s
       integer :: nrow, ncol, i, ios, skiprows_, max_rows_
-      character(len=128) :: iomsg, msgout
+      character(len=1024) :: iomsg, msgout
 
       skiprows_ = max(optval(skiprows, 0), 0)
       max_rows_ = optval(max_rows, -1)
@@ -214,7 +214,7 @@ contains
       !!
 
       integer :: s, i, ios
-      character(len=128) :: iomsg, msgout
+      character(len=1024) :: iomsg, msgout
       s = open(filename, "w")
       do i = 1, size(d, 1)
         #:if 'real' in t1


### PR DESCRIPTION
`loadtxt` keeps failing often in the CI tests, [see e.g. here](https://github.com/fortran-lang/stdlib/actions/runs/11934455143/job/33263598092?pr=892) or #862 . 

Ifort output is: 
```
160/340 Test #161: loadtxt ................................***Failed    0.01 sec
forrtl: severe (66): output statement overflows record, unit -5, file Internal Formatted Write
Image              PC                Routine            Line        Source             
example_loadtxt    0000000000444ECE  Unknown               Unknown  Unknown
example_loadtxt    0000000000404AF2  Unknown               Unknown  Unknown
example_loadtxt    0000000000404253  Unknown               Unknown  Unknown
example_loadtxt    00000000004041BD  Unknown               Unknown  Unknown
libc.so.6          00007F7E6A629D90  Unknown               Unknown  Unknown
libc.so.6          00007F7E6A629E40  __libc_start_main     Unknown  Unknown
example_loadtxt    00000000004040D5  Unknown               Unknown  Unknown
```

So we can infer: 
- Error happens when running [example_loadtxt](https://github.com/fortran-lang/stdlib/blob/master/example/io/example_loadtxt.f90), examples are also used as test programs
- `output statement` -> Writing to something
- `unit -5` -> Writing to an internal unit = a character string
- `overflows record` -> record is too short -> string is too short. 

I believe the error may be triggered in one of these statements: 
https://github.com/fortran-lang/stdlib/blob/7511064e45476cc2deaa5af195fdb70cb73214d1/src/stdlib_io.fypp#L148

With a long file name (many sub-folders), it is possible that the output message exceeds 128 characters.

In other words, some other error has occurred, but the second error hides the root cause. This PR attempts to fix the second error (insufficient internal string length), that will hopefully help us understand why the example program sometimes fails. 

cc: @fortran-lang/stdlib @jvdp1 @jalvesz 
