### PR TITLE
Add [install] section to fpm.toml

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -5,6 +5,11 @@ author = "stdlib contributors"
 maintainer = "@fortran-lang/stdlib"
 copyright = "2019-2021 stdlib contributors"
 
+
+[install]
+library = true
+
+
 [dev-dependencies]
 test-drive.git = "https://github.com/fortran-lang/test-drive"
 test-drive.tag = "v0.4.0"


### PR DESCRIPTION
This commit allows for installation of the `stdlib`, instructing `fpm` to install (if the prefix is not modified):
-  `libstdlib.a` file --> `~/.local/lib/
- `.[s]mod` files --> `~/.local/include/`

Example:
`fpm install --compiler=gfortran-11 --profile release`

Resolves fortran-lang/stdlib#782

<!--
Thank you for contributing to stdlib.
To help us get your pull request merged more quickly, please consider reviewing any of the already open pull requests.
-->
