### PR TITLE
CI: deprecate macos-12

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,7 +39,7 @@ jobs:
           - os: macos-13
             toolchain: {compiler: intel, version: '2024.1'}
           - os: macos-13
-            toolchain: {compiler: gcc, version: 13} 
+            toolchain: {compiler: gcc, version: 13}
     env:
       BUILD_DIR: ${{ matrix.build == 'cmake' && 'build' || '.' }}
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,7 +35,7 @@ jobs:
               - {compiler: gcc, version: 10}
         exclude:
           - os: macos-13
-            toolchain: {compiler: intel, version: '2024.1'}
+            toolchain: {compiler: intel-classic, version: '2024.1'}
           - os: macos-13
             toolchain: {compiler: gcc, version: 13}
     env:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-12]
+        os: [ubuntu-latest, macos-13]
         toolchain:
           - {compiler: gcc, version: 10}
           - {compiler: gcc, version: 11}
@@ -34,9 +34,9 @@ jobs:
             toolchain:
               - {compiler: gcc, version: 10}
         exclude:
-          - os: macos-12
+          - os: macos-13
             toolchain: {compiler: intel, version: '2024.1'}
-          - os: macos-12
+          - os: macos-13
             toolchain: {compiler: gcc, version: 13}
     env:
       BUILD_DIR: ${{ matrix.build == 'cmake' && 'build' || '.' }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,6 +38,8 @@ jobs:
             toolchain: {compiler: intel-classic, version: '2021.9'}
           - os: macos-13
             toolchain: {compiler: intel, version: '2024.1'}
+          - os: macos-13
+            toolchain: {compiler: gcc, version: 13} 
     env:
       BUILD_DIR: ${{ matrix.build == 'cmake' && 'build' || '.' }}
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,9 +35,9 @@ jobs:
               - {compiler: gcc, version: 10}
         exclude:
           - os: macos-13
-            toolchain: {compiler: intel-classic, version: '2024.1'}
+            toolchain: {compiler: intel-classic, version: '2021.9'}
           - os: macos-13
-            toolchain: {compiler: gcc, version: 13}
+            toolchain: {compiler: intel, version: '2024.1'}
     env:
       BUILD_DIR: ${{ matrix.build == 'cmake' && 'build' || '.' }}
 


### PR DESCRIPTION
`macos-12` is deprecated by the GitHub runners, an update to macos-13 is proposed. 

cc: @jvdp1 @fortran-lang/stdlib 