### PR TITLE
Remove mingw32

### DIFF
--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -13,8 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         include: [
-          { msystem: MINGW64, arch: x86_64 },
-          { msystem: MINGW32, arch: i686   }
+          { msystem: MINGW64, arch: x86_64 }
         ]
     defaults:
       run:

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Name | Version | Platform | Architecture
 GCC Fortran | 10, 11, 12, 13 | Ubuntu 22.04.2 LTS | x86_64
 GCC Fortran | 10, 11, 12, 13 | macOS 12.6.3 (21G419) | x86_64
 GCC Fortran (MSYS) | 13 | Windows Server 2022 (10.0.20348 Build 1547) | x86_64
-GCC Fortran (MinGW) | 13 | Windows Server 2022 (10.0.20348 Build 1547) | x86_64, i686
+GCC Fortran (MinGW) | 13 | Windows Server 2022 (10.0.20348 Build 1547) | x86_64
 Intel oneAPI LLVM | 2024.0 | Ubuntu 22.04.2 LTS | x86_64
 Intel oneAPI classic | 2023.1 | macOS 12.6.3 (21G419) | x86_64
 
@@ -98,7 +98,7 @@ The following combinations are known to work, but they are not tested in the CI:
 
 Name | Version | Platform | Architecture
 --- | --- | --- | ---
-GCC Fortran (MinGW) | 9.3.0, 10.2.0, 11.2.0 | Windows 10 | x86_64, i686
+GCC Fortran (MinGW) | 9.3.0, 10.2.0, 11.2.0 | Windows 10 | x86_64
 
 We try to test as many available compilers and platforms as possible.
 A list of tested compilers which are currently not working and the respective issue are listed below.


### PR DESCRIPTION
This PR removes MINGW32 from the Windows CI checks.  This version of MINGW receives limited support, and I don't believe it makes sense to use for validation of future development.  This change was originally suggested in this [PR](https://github.com/fortran-lang/stdlib/pull/854).    

<!--
Thank you for contributing to stdlib.
To help us get your pull request merged more quickly, please consider reviewing any of the already open pull requests.
-->
