### PR TITLE
Fix generalized `eig` rwork size

### DIFF
--- a/src/stdlib_linalg_eigenvalues.fypp
+++ b/src/stdlib_linalg_eigenvalues.fypp
@@ -353,7 +353,7 @@ submodule (stdlib_linalg) stdlib_linalg_eigenvalues
 
              ! Compute workspace size
              #:if rt.startswith('complex')
-             allocate(rwork(2*n))
+             allocate(rwork( #{if ei=='ggev'}# 8*n #{else}# 2*n #{endif}# ))
              #:else
              allocate(lreal(n),limag(n))
              #:endif

--- a/src/stdlib_linalg_eigenvalues.fypp
+++ b/src/stdlib_linalg_eigenvalues.fypp
@@ -139,10 +139,10 @@ submodule (stdlib_linalg) stdlib_linalg_eigenvalues
      module function stdlib_linalg_eigvals_${ep}$_${ri}$(a#{if ei=='ggev'}#,b#{endif}#,err) result(lambda)
      !! Return an array of eigenvalues of matrix A.
          !> Input matrix A[m,n]
-         ${rt}$, intent(in), dimension(:,:), target :: a 
+         ${rt}$, intent(in), target :: a(:,:) 
          #:if ei=='ggev'
          !> Generalized problem matrix B[n,n]
-         ${rt}$, intent(inout), dimension(:,:), target :: b         
+         ${rt}$, intent(inout), target :: b(:,:)         
          #:endif                  
          !> [optional] state return flag. On error if not requested, the code will stop
          type(linalg_state_type), intent(out) :: err
@@ -150,7 +150,7 @@ submodule (stdlib_linalg) stdlib_linalg_eigenvalues
          complex(${rk}$), allocatable :: lambda(:)
 
          !> Create
-         ${rt}$, pointer, dimension(:,:) :: amat#{if ei=='ggev'}#, bmat #{endif}#
+         ${rt}$, pointer :: amat(:,:)#{if ei=='ggev'}#, bmat(:,:) #{endif}#
          integer(ilp) :: m,n,k
 
          !> Create an internal pointer so the intent of A won't affect the next call
@@ -172,16 +172,16 @@ submodule (stdlib_linalg) stdlib_linalg_eigenvalues
      module function stdlib_linalg_eigvals_noerr_${ep}$_${ri}$(a#{if ei=='ggev'}#,b#{endif}#) result(lambda)
      !! Return an array of eigenvalues of matrix A.
          !> Input matrix A[m,n]
-         ${rt}$, intent(in), dimension(:,:), target :: a
+         ${rt}$, intent(in), target :: a(:,:)
          #:if ei=='ggev'
          !> Generalized problem matrix B[n,n]
-         ${rt}$, intent(inout), dimension(:,:), target :: b         
+         ${rt}$, intent(inout), target :: b(:,:)         
          #:endif         
          !> Array of eigenvalues
          complex(${rk}$), allocatable :: lambda(:)
 
          !> Create
-         ${rt}$, pointer, dimension(:,:) :: amat#{if ei=='ggev'}#, bmat #{endif}#
+         ${rt}$, pointer :: amat(:,:)#{if ei=='ggev'}#, bmat(:,:) #{endif}#
          integer(ilp) :: m,n,k
 
          !> Create an internal pointer so the intent of A won't affect the next call
@@ -205,10 +205,10 @@ submodule (stdlib_linalg) stdlib_linalg_eigenvalues
      !! Eigendecomposition of matrix A returning an array `lambda` of eigenvalues, 
      !! and optionally right or left eigenvectors.        
          !> Input matrix A[m,n]
-         ${rt}$, intent(inout), dimension(:,:), target :: a 
+         ${rt}$, intent(inout), target :: a(:,:) 
          #:if ei=='ggev'
          !> Generalized problem matrix B[n,n]
-         ${rt}$, intent(inout), dimension(:,:), target :: b         
+         ${rt}$, intent(inout), target :: b(:,:)         
          #:endif         
          !> Array of eigenvalues
          complex(${rk}$), intent(out) :: lambda(:)
@@ -232,7 +232,7 @@ submodule (stdlib_linalg) stdlib_linalg_eigenvalues
          character :: task_u,task_v
          ${rt}$, target :: work_dummy(1),u_dummy(1,1),v_dummy(1,1)
          ${rt}$, allocatable :: work(:)
-         ${rt}$, dimension(:,:), pointer :: amat,umat,vmat#{if ei=='ggev'}#,bmat#{endif}#
+         ${rt}$, pointer :: amat(:,:),umat(:,:),vmat(:,:)#{if ei=='ggev'}#,bmat(:,:)#{endif}#
          #:if rt.startswith('complex')
          real(${rk}$), allocatable :: rwork(:)
          #:else

--- a/test/linalg/test_linalg_eigenvalues.fypp
+++ b/test/linalg/test_linalg_eigenvalues.fypp
@@ -320,9 +320,8 @@ module test_linalg_eigenvalues
     subroutine test_issue_927_${ci}$(error)
       type(error_type), allocatable, intent(out) :: error 
 
-      ${ct}$, dimension(3,3) :: A_Z,S_Z,vecs_r
-      ${ct}$,dimension(3) :: eigs
-      real(${ck}$), dimension(3,3) :: A_D,S_D
+      ${ct}$ :: A_Z(3,3),S_Z(3,3),vecs_r(3,3),eigs(3)
+      real(${ck}$) :: A_D(3,3),S_D(3,3)
       type(linalg_state_type) :: state
       integer :: i
 

--- a/test/linalg/test_linalg_eigenvalues.fypp
+++ b/test/linalg/test_linalg_eigenvalues.fypp
@@ -3,7 +3,7 @@
 module test_linalg_eigenvalues
     use stdlib_linalg_constants
     use stdlib_linalg_state
-    use stdlib_linalg, only: eig, eigh, eigvals, eigvalsh, diag
+    use stdlib_linalg, only: eig, eigh, eigvals, eigvalsh, diag, eye
     use testdrive, only: error_type, check, new_unittest, unittest_type    
 
     implicit none (type,external)
@@ -33,7 +33,8 @@ module test_linalg_eigenvalues
         #:for ck,ct,ci in CMPLX_KINDS_TYPES
         #:if ck!="xdp"    
         tests = [tests,new_unittest("test_eig_complex_${ci}$",test_eig_complex_${ci}$), &
-                       new_unittest("test_eig_generalized_complex_${ci}$",test_eigvals_generalized_complex_${ci}$)]                
+                       new_unittest("test_eig_generalized_complex_${ci}$",test_eigvals_generalized_complex_${ci}$), &
+                       new_unittest("test_eig_issue_927_${ci}$",test_issue_927_${ci}$)]                
         #:endif
         #: endfor 
 
@@ -309,8 +310,6 @@ module test_linalg_eigenvalues
         
         lambda = eigvals(A, B, err=state)
         
-        print *, 'lambda = ',lambda
-
         !> Expected eigenvalues
         lres(1) = czero
         lres(2) = 2*cone
@@ -324,8 +323,40 @@ module test_linalg_eigenvalues
         
     end subroutine test_eigvals_generalized_complex_${ci}$
 
+    ! Generalized eigenvalues should not crash
+    subroutine test_issue_927_${ci}$(error)
+      type(error_type), allocatable, intent(out) :: error 
+
+      ${ct}$, dimension(3,3) :: A_Z,S_Z,vecs_r
+      ${ct}$,dimension(3) :: eigs
+      real(${ck}$), dimension(3,3) :: A_D,S_D
+      type(linalg_state_type) :: state
+      integer :: i
+
+      ! Set matrix
+      A_Z = reshape( [ [1, 6, 3], &
+                        [9, 2, 1], &
+                        [8, 3, 4] ], [3,3] )
+
+      S_Z = eye(3, mold=0.0_${ck}$)
+
+      A_D = real(A_Z)
+      S_D = real(S_Z)
+
+      call eig(A_D,S_D,eigs,right=vecs_r,err=state) 
+      call check(error, state%ok(), 'test issue 927 (${ct}$): '//state%print())
+      if (allocated(error)) return      
+
+      call eig(A_Z,S_Z,eigs,right=vecs_r,err=state) !Fails
+      call check(error, state%ok(), 'test issue 927 (${ct}$): '//state%print())
+      if (allocated(error)) return      
+
+    end subroutine test_issue_927_${ci}$
+
     #:endif
     #:endfor
+
+
 
 
 end module test_linalg_eigenvalues

--- a/test/linalg/test_linalg_eigenvalues.fypp
+++ b/test/linalg/test_linalg_eigenvalues.fypp
@@ -21,28 +21,23 @@ module test_linalg_eigenvalues
         allocate(tests(0))
 
         #:for rk,rt,ri in REAL_KINDS_TYPES
-        #:if rk!="xdp"    
         tests = [tests,new_unittest("test_eig_real_${ri}$",test_eig_real_${ri}$), &
                        new_unittest("test_eigvals_identity_${ri}$",test_eigvals_identity_${ri}$), &    
                        new_unittest("test_eigvals_diagonal_B_${ri}$",test_eigvals_diagonal_B_${ri}$), &
                        new_unittest("test_eigvals_nondiagonal_B_${ri}$",test_eigvals_nondiagonal_B_${ri}$), &
                        new_unittest("test_eigh_real_${ri}$",test_eigh_real_${ri}$)]        
-        #:endif
         #: endfor
         
         #:for ck,ct,ci in CMPLX_KINDS_TYPES
-        #:if ck!="xdp"    
         tests = [tests,new_unittest("test_eig_complex_${ci}$",test_eig_complex_${ci}$), &
                        new_unittest("test_eig_generalized_complex_${ci}$",test_eigvals_generalized_complex_${ci}$), &
                        new_unittest("test_eig_issue_927_${ci}$",test_issue_927_${ci}$)]                
-        #:endif
         #: endfor 
 
     end subroutine test_eig_eigh
 
     !> Simple real matrix eigenvalues
     #:for rk,rt,ri in REAL_KINDS_TYPES
-    #:if rk!="xdp"    
     subroutine test_eig_real_${ri}$(error)
         type(error_type), allocatable, intent(out) :: error
 
@@ -240,12 +235,10 @@ module test_linalg_eigenvalues
         if (allocated(error)) return
     end subroutine test_eigvals_nondiagonal_B_${ri}$
 
-    #:endif
     #:endfor
 
     !> Simple complex matrix eigenvalues
     #:for ck,ct,ci in CMPLX_KINDS_TYPES
-    #:if ck!="xdp"    
     subroutine test_eig_complex_${ci}$(error)
         type(error_type), allocatable, intent(out) :: error
 
@@ -353,7 +346,6 @@ module test_linalg_eigenvalues
 
     end subroutine test_issue_927_${ci}$
 
-    #:endif
     #:endfor
 
 


### PR DESCRIPTION
Fix #927. 

`rwork` size is different in `*GGEV` (`8*n`) vs. in `*GEEV` (`2*n`), I had overlooked that. 

cc: @jalvesz @jvdp1 
Thank you
