### PR TITLE
fix: gamma functions

### DIFF
--- a/src/stdlib_specialfunctions_gamma.fypp
+++ b/src/stdlib_specialfunctions_gamma.fypp
@@ -4,6 +4,7 @@
 #:set CI_KINDS_TYPES = INT_KINDS_TYPES + C_KINDS_TYPES
 module stdlib_specialfunctions_gamma
     use iso_fortran_env, only : qp => real128
+    use ieee_arithmetic, only: ieee_value, ieee_quiet_nan
     use stdlib_kinds, only :  sp, dp, int8, int16, int32, int64
     use stdlib_error, only : error_stop
 
@@ -670,6 +671,9 @@ contains
                 if(abs(y - one) < tol_${k2}$) exit
 
             end do
+
+        else
+            g = ieee_value(1._${k1}$, ieee_quiet_nan)
 
         end if
 

--- a/src/stdlib_specialfunctions_gamma.fypp
+++ b/src/stdlib_specialfunctions_gamma.fypp
@@ -575,9 +575,9 @@ contains
     ! Fortran 90 program by Jim-215-Fisher
     !
         ${t1}$, intent(in) :: p, x
-        integer :: n, m
+        integer :: n
 
-        ${t2}$ :: res, p_lim, a, b, g, c, d, y, ss
+        ${t2}$ :: res, p_lim, a, b, g, c, d, y
         ${t2}$, parameter :: zero = 0.0_${k2}$, one = 1.0_${k2}$
         ${t2}$, parameter :: dm = tiny(1.0_${k2}$) * 10 ** 6
         ${t1}$, parameter :: zero_k1 = 0.0_${k1}$
@@ -602,6 +602,9 @@ contains
         if(x < zero_k1 .and. p < p_lim .and. abs(anint(p) - p) > tol_${k1}$)   &
             call error_stop("Error(gpx): Incomplete gamma function with "      &
             //"negative x must come with a whole number p not too small")
+
+        if(x < zero_k1) call error_stop("Error(gpx): Incomplete gamma"         &
+            // " function with negative x must have an integer parameter p")
 
         if(p >= p_lim) then     !use modified Lentz method of continued fraction
                                 !for eq. (15) in the above reference.
@@ -670,7 +673,6 @@ contains
 
         else                            !Algorithm 2 in the reference
 
-            m = nint(ss)
             a = - x
             c = one / a
             d = p - one
@@ -689,9 +691,9 @@ contains
 
             end do
 
-            if(y >= b * tol_${k2}$ .and. mod(m , 2) /= 0) b = b + d * c / a
+            if(y >= b * tol_${k2}$ .and. mod(int(p), 2) /= 0) b = b + d * c / a
 
-            g = ((-1) ** m * exp(-a + log_gamma(p) - (p - 1) * log(a)) + b) / a
+            g = ((-1) ** p * exp(-a + log_gamma(p) - (p - 1) * log(a)) + b) / a
         end if
 
         res = g

--- a/src/stdlib_specialfunctions_gamma.fypp
+++ b/src/stdlib_specialfunctions_gamma.fypp
@@ -671,29 +671,6 @@ contains
 
             end do
 
-        else                            !Algorithm 2 in the reference
-
-            a = - x
-            c = one / a
-            d = p - one
-            b = c * (a - d)
-            n = 1
-
-            do
-
-                c = d * (d - one) / (a * a)
-                d = d - 2
-                y = c * (a - d)
-                b = b + y
-                n = n + 1
-
-                if(n > int((p - 2) / 2) .or. y < b * tol_${k2}$) exit
-
-            end do
-
-            if(y >= b * tol_${k2}$ .and. mod(int(p), 2) /= 0) b = b + d * c / a
-
-            g = ((-1) ** p * exp(-a + log_gamma(p) - (p - 1) * log(a)) + b) / a
         end if
 
         res = g


### PR DESCRIPTION
This PR tries to address #898 

The problem was in the interface `gpx` (meant for internal use only) which had two procedures for `x, p are real` and `x is real, p is an integer`, `p being > 0` in all cases

Everything was fine with the second procedure but in the first one it is required that ([Fast and accurate evaluation of a
generalized incomplete gamma function](hal.science/hal-01329669v2/document)) `when x < 0, p be an integer` which wasn't actually programmed in the procedure itself but was being taken care of as and when requiring to call `gpx` in such a case. like so https://github.com/fortran-lang/stdlib/blob/master/src/stdlib_specialfunctions_gamma.fypp#L1078-L1099

And hence this was not found earlier as the chunk of code was in the case when `x<0 and p<p_lim(x)` (check Algorithm 3) which is now unreachable, hence removed
