### PR TITLE
small fix for `loadtxt`

### DIFF
--- a/src/stdlib_io.fypp
+++ b/src/stdlib_io.fypp
@@ -169,6 +169,7 @@ contains
         
         if (ios/=0) then 
            write(msgout,1) trim(iomsg),i,trim(filename) 
+           1 format('loadtxt: error <',a,'> skipping line ',i0,' of ',a,'.')
            call error_stop(msg=trim(msgout))
         end if
         
@@ -189,7 +190,7 @@ contains
           read (s,*,iostat=ios,iomsg=iomsg) d(i, :)
           
           if (ios/=0) then 
-             write(msgout,1) trim(iomsg),size(d,2),i,trim(filename) 
+             write(msgout,2) trim(iomsg),size(d,2),i,trim(filename)
              call error_stop(msg=trim(msgout))
           end if          
           
@@ -200,7 +201,7 @@ contains
           read (s,fmt_,iostat=ios,iomsg=iomsg) d(i, :)
           
           if (ios/=0) then 
-             write(msgout,1) trim(iomsg),size(d,2),i,trim(filename) 
+             write(msgout,2) trim(iomsg),size(d,2),i,trim(filename)
              call error_stop(msg=trim(msgout))
           end if             
           
@@ -209,7 +210,7 @@ contains
 
       close(s)
       
-      1 format('loadtxt: error <',a,'> reading ',i0,' values from line ',i0,' of ',a,'.')
+      2 format('loadtxt: error <',a,'> reading ',i0,' values from line ',i0,' of ',a,'.')
 
     end subroutine loadtxt_${t1[0]}$${k1}$
   #:endfor


### PR DESCRIPTION
Using the previous format directive would have caused a runtime error if there was an error skipping the required rows as there were only 3 format arguments given (instead of 4)

This PR fixes that and provides a useful error message with the required arguments
