### PR TITLE
Make quadruple precision in `stdlib_specialfunctions_gamma.f90` optional

### DIFF
--- a/example/specialfunctions_gamma/example_gamma.f90
+++ b/example/specialfunctions_gamma/example_gamma.f90
@@ -8,14 +8,12 @@ program example_gamma
   real :: x
   real(dp) :: y
   complex :: z
-  complex(dp) :: z1
 
   i = 10
   n = 15_int64
   x = 2.5
   y = 4.3_dp
   z = (2.3, 0.6)
-  z1 = (-4.2_dp, 3.1_dp)
 
   print *, gamma(i)              !integer gives exact result
 ! 362880
@@ -32,6 +30,4 @@ program example_gamma
   print *, gamma(z)
 ! (0.988054395, 0.383354813)
 
-  print *, gamma(z1)
-! (-2.78916032990983999E-005, 9.83164600163221218E-006)
 end program example_gamma

--- a/example/specialfunctions_gamma/example_log_gamma.f90
+++ b/example/specialfunctions_gamma/example_log_gamma.f90
@@ -7,13 +7,11 @@ program example_log_gamma
   real :: x
   real(dp) :: y
   complex :: z
-  complex(dp) :: z1
 
   i = 10
   x = 8.76
   y = x
   z = (5.345, -3.467)
-  z1 = z
   print *, log_gamma(i)     !default single precision output
 !12.8018274
 
@@ -29,7 +27,4 @@ program example_log_gamma
 
 !(2.56165648, -5.73382425)
 
-  print *, log_gamma(z1)
-
-!(2.5616575105114614, -5.7338247782852498)
 end program example_log_gamma

--- a/src/stdlib_specialfunctions_gamma.fypp
+++ b/src/stdlib_specialfunctions_gamma.fypp
@@ -1,11 +1,14 @@
 #:include "common.fypp"
 #:set R_KINDS_TYPES = [KT for KT in REAL_KINDS_TYPES if KT[0] in ["sp","dp"]]
-#:set C_KINDS_TYPES = [KT for KT in CMPLX_KINDS_TYPES if KT[0] in ["sp","dp"]]
-#:set CI_KINDS_TYPES = INT_KINDS_TYPES + C_KINDS_TYPES
+#:set CR_KINDS_TYPES = [KT + KT2 for KT in CMPLX_KINDS_TYPES if KT[0] == "sp" for KT2 in REAL_KINDS_TYPES if KT2[0] == "dp"]
+#:set RR_KINDS_TYPES = [KT + KT2 for KT in REAL_KINDS_TYPES if KT[0] == "sp" for KT2 in REAL_KINDS_TYPES if KT2[0] == "dp"]
+#:if WITH_QP
+  #:set CR_KINDS_TYPES = CR_KINDS_TYPES + [KT + KT2 for KT in CMPLX_KINDS_TYPES if KT[0] == "dp" for KT2 in REAL_KINDS_TYPES if KT2[0] == "qp"]
+  #:set RR_KINDS_TYPES = RR_KINDS_TYPES + [KT + KT2 for KT in REAL_KINDS_TYPES if KT[0] == "dp" for KT2 in REAL_KINDS_TYPES if KT2[0] == "qp"]
+#:endif
 module stdlib_specialfunctions_gamma
-    use iso_fortran_env, only : qp => real128
     use ieee_arithmetic, only: ieee_value, ieee_quiet_nan
-    use stdlib_kinds, only :  sp, dp, int8, int16, int32, int64
+    use stdlib_kinds, only :  sp, dp, qp, int8, int16, int32, int64
     use stdlib_error, only : error_stop
 
     implicit none
@@ -19,7 +22,9 @@ module stdlib_specialfunctions_gamma
     #:for k1, t1 in R_KINDS_TYPES
     ${t1}$, parameter :: tol_${k1}$ = epsilon(1.0_${k1}$)
     #:endfor
+    #:if WITH_QP
     real(qp), parameter :: tol_qp = epsilon(1.0_qp)
+    #:endif
 
 
 
@@ -33,7 +38,7 @@ module stdlib_specialfunctions_gamma
     interface gamma
     !! Gamma function for integer and complex numbers
     !!
-        #:for k1, t1 in CI_KINDS_TYPES
+        #:for k1, t1 in INT_KINDS_TYPES + CR_KINDS_TYPES
         module procedure gamma_${t1[0]}$${k1}$
         #:endfor
     end interface gamma
@@ -43,7 +48,7 @@ module stdlib_specialfunctions_gamma
     interface log_gamma
     !! Logarithm of gamma function
     !!
-        #:for k1, t1 in CI_KINDS_TYPES
+        #:for k1, t1 in INT_KINDS_TYPES + CR_KINDS_TYPES
         module procedure l_gamma_${t1[0]}$${k1}$
         #:endfor
     end interface log_gamma
@@ -69,7 +74,7 @@ module stdlib_specialfunctions_gamma
           #:endfor
         #:endfor
 
-        #:for k1, t1 in R_KINDS_TYPES
+        #:for k1, t1 in RR_KINDS_TYPES
         module procedure ingamma_low_${t1[0]}$${k1}$
         #:endfor
     end interface lower_incomplete_gamma
@@ -85,7 +90,7 @@ module stdlib_specialfunctions_gamma
           #:endfor
         #:endfor
 
-        #:for k1, t1 in R_KINDS_TYPES
+        #:for k1, t1 in RR_KINDS_TYPES
         module procedure l_ingamma_low_${t1[0]}$${k1}$
         #:endfor
     end interface log_lower_incomplete_gamma
@@ -101,7 +106,7 @@ module stdlib_specialfunctions_gamma
           #:endfor
         #:endfor
 
-        #:for k1, t1 in R_KINDS_TYPES
+        #:for k1, t1 in RR_KINDS_TYPES
         module procedure ingamma_up_${t1[0]}$${k1}$
         #:endfor
     end interface upper_incomplete_gamma
@@ -117,7 +122,7 @@ module stdlib_specialfunctions_gamma
           #:endfor
         #:endfor
 
-        #:for k1, t1 in R_KINDS_TYPES
+        #:for k1, t1 in RR_KINDS_TYPES
         module procedure l_ingamma_up_${t1[0]}$${k1}$
         #:endfor
     end interface log_upper_incomplete_gamma
@@ -133,7 +138,7 @@ module stdlib_specialfunctions_gamma
           #:endfor
         #:endfor
 
-        #:for k1, t1 in R_KINDS_TYPES
+        #:for k1, t1 in RR_KINDS_TYPES
         module procedure regamma_p_${t1[0]}$${k1}$
         #:endfor
     end interface regularized_gamma_p
@@ -149,7 +154,7 @@ module stdlib_specialfunctions_gamma
           #:endfor
         #:endfor
 
-        #:for k1, t1 in R_KINDS_TYPES
+        #:for k1, t1 in RR_KINDS_TYPES
         module procedure regamma_q_${t1[0]}$${k1}$
         #:endfor
     end interface regularized_gamma_q
@@ -160,7 +165,7 @@ module stdlib_specialfunctions_gamma
     ! Incomplete gamma G function.
     ! Internal use only
     !
-        #:for k1, t1 in R_KINDS_TYPES
+        #:for k1, t1 in RR_KINDS_TYPES
         module procedure gpx_${t1[0]}$${k1}$         !for real p and x
         #:endfor
 
@@ -219,13 +224,7 @@ contains
 
 
 
-    #:for k1, t1 in C_KINDS_TYPES
-      #:if k1 == "sp"
-          #:set k2 = "dp"
-      #:elif k1 == "dp"
-          #:set k2 = "qp"
-      #:endif
-      #:set t2 = "real({})".format(k2)
+    #:for k1, t1, _, k2, t2, _ in CR_KINDS_TYPES
 
     impure elemental function gamma_${t1[0]}$${k1}$(z) result(res)
         ${t1}$, intent(in) :: z
@@ -415,13 +414,7 @@ contains
 
 
 
-    #:for k1, t1 in C_KINDS_TYPES
-      #:if k1 == "sp"
-          #:set k2 = "dp"
-      #:elif k1 == "dp"
-          #:set k2 = "qp"
-      #:endif
-      #:set t2 = "real({})".format(k2)
+    #:for k1, t1, _, k2, t2, _ in CR_KINDS_TYPES
     impure elemental function l_gamma_${t1[0]}$${k1}$(z) result (res)
     !
     ! log_gamma function for any complex number, excluding negative whole number
@@ -557,13 +550,7 @@ contains
 
 
 
-    #:for k1, t1 in R_KINDS_TYPES
-      #:if k1 == "sp"
-          #:set k2 = "dp"
-      #:elif k1 == "dp"
-          #:set k2 = "qp"
-      #:endif
-      #:set t2 = "real({})".format(k2)
+    #:for k1, t1, _, k2, t2, _ in RR_KINDS_TYPES
 
     impure elemental function gpx_${t1[0]}$${k1}$(p, x) result(res)
     !
@@ -824,7 +811,7 @@ contains
 
 
 
-    #:for k1, t1 in R_KINDS_TYPES
+    #:for k1, t1 in RR_KINDS_TYPES
     impure elemental function ingamma_low_${t1[0]}$${k1}$(p, x) result(res)
     !
     ! Approximation of lower incomplete gamma function with real p.
@@ -901,7 +888,7 @@ contains
 
 
 
-    #:for k1, t1 in R_KINDS_TYPES
+    #:for k1, t1 in RR_KINDS_TYPES
     impure elemental function l_ingamma_low_${t1[0]}$${k1}$(p, x) result(res)
 
         ${t1}$, intent(in) :: p, x
@@ -970,7 +957,7 @@ contains
 
 
 
-    #:for k1, t1 in R_KINDS_TYPES
+    #:for k1, t1 in RR_KINDS_TYPES
     impure elemental function ingamma_up_${t1[0]}$${k1}$(p, x) result(res)
     !
     ! Approximation of upper incomplete gamma function with real p.
@@ -1050,7 +1037,7 @@ contains
 
 
 
-    #:for k1, t1 in R_KINDS_TYPES
+    #:for k1, t1 in RR_KINDS_TYPES
     impure elemental function l_ingamma_up_${t1[0]}$${k1}$(p, x) result(res)
 
         ${t1}$, intent(in) :: p, x
@@ -1129,7 +1116,7 @@ contains
 
 
 
-    #:for k1, t1 in R_KINDS_TYPES
+    #:for k1, t1 in RR_KINDS_TYPES
     impure elemental function regamma_p_${t1[0]}$${k1}$(p, x) result(res)
     !
     ! Approximation of regularized incomplete gamma function P(p,x) for real p
@@ -1200,7 +1187,7 @@ contains
 
 
 
-    #:for k1, t1 in R_KINDS_TYPES
+    #:for k1, t1 in RR_KINDS_TYPES
     impure elemental function regamma_q_${t1[0]}$${k1}$(p, x) result(res)
     !
     ! Approximation of regularized incomplete gamma function Q(p,x) for real p


### PR DESCRIPTION
This pull request addresses systems that do not support `real128` (see issue #964).
In `stdlib_specialfunctions_gamma.f90`, I added `fypp` directives to choose whether to include quadruple precision code.
- `--with_qp`: Quadruple precision is enabled.
- No `--with_qp`: All `qp` references (and related `_cdp` / `_rdp` procedures) are removed.

## How it works
- I added `#:if WITH_QP ... #:endif` blocks in `fypp`, and replaced references to real128 with a new variable.
- When `--with_qp` is passed to `fypp_deployment.py`, the code for `qp` remains.
- When `--with_qp` is omitted, the code for `qp` is excluded.

## diffs old and new `src/temp/stdlib_specialfunctions_gamma.f90`
### With `--with-qp`
- Very few changes: `iso_fortran_env, only : qp => real128` is replaced by `use stdlib_kinds, only : ... qp`, so quadruple precision still works essentially as before.

```bash
 $ python3 config/fypp_deployment.py --with_qp
 ```

```diff
@@ -1,7 +1,6 @@
 module stdlib_specialfunctions_gamma
-    use iso_fortran_env, only : qp => real128
     use ieee_arithmetic, only: ieee_value, ieee_quiet_nan
-    use stdlib_kinds, only :  sp, dp, int8, int16, int32, int64
+    use stdlib_kinds, only :  sp, dp, qp, int8, int16, int32, int64
     use stdlib_error, only : error_stop

     implicit none
```

### Without `--with_qp`
- No `qp` references are generated, and any `_cdp` / `_rdp` procedures are removed.

```bash
 $ python3 config/fypp_deployment.py
 ```
(...) denotes abbreviation.
```diff
@@ -1,7 +1,6 @@
 module stdlib_specialfunctions_gamma
-    use iso_fortran_env, only : qp => real128
     use ieee_arithmetic, only: ieee_value, ieee_quiet_nan
-    use stdlib_kinds, only :  sp, dp, int8, int16, int32, int64
+    use stdlib_kinds, only :  sp, dp, qp, int8, int16, int32, int64
     use stdlib_error, only : error_stop

     implicit none
@@ -14,7 +13,6 @@

     real(sp), parameter :: tol_sp = epsilon(1.0_sp)
     real(dp), parameter :: tol_dp = epsilon(1.0_dp)
-    real(qp), parameter :: tol_qp = epsilon(1.0_qp)



@@ -33,7 +31,6 @@
         module procedure gamma_iint32
         module procedure gamma_iint64
         module procedure gamma_csp
-        module procedure gamma_cdp
     end interface gamma


@@ -46,7 +43,6 @@
         module procedure l_gamma_iint32
         module procedure l_gamma_iint64
         module procedure l_gamma_csp
-        module procedure l_gamma_cdp
     end interface log_gamma


@@ -75,7 +71,6 @@
         module procedure ingamma_low_iint64dp

         module procedure ingamma_low_rsp
-        module procedure ingamma_low_rdp
     end interface lower_incomplete_gamma


@@ -93,7 +88,6 @@
         module procedure l_ingamma_low_iint64dp

         module procedure l_ingamma_low_rsp
-        module procedure l_ingamma_low_rdp
     end interface log_lower_incomplete_gamma


@@ -111,7 +105,6 @@
         module procedure ingamma_up_iint64dp

         module procedure ingamma_up_rsp
-        module procedure ingamma_up_rdp
     end interface upper_incomplete_gamma


@@ -129,7 +122,6 @@
         module procedure l_ingamma_up_iint64dp

         module procedure l_ingamma_up_rsp
-        module procedure l_ingamma_up_rdp
     end interface log_upper_incomplete_gamma


@@ -147,7 +139,6 @@
         module procedure regamma_p_iint64dp

         module procedure regamma_p_rsp
-        module procedure regamma_p_rdp
     end interface regularized_gamma_p


@@ -165,7 +156,6 @@
         module procedure regamma_q_iint64dp

         module procedure regamma_q_rsp
-        module procedure regamma_q_rdp
     end interface regularized_gamma_q


@@ -175,7 +165,6 @@
     ! Internal use only
     !
         module procedure gpx_rsp         !for real p and x
-        module procedure gpx_rdp         !for real p and x

         module procedure gpx_iint8sp   !for integer p and real x
         module procedure gpx_iint8dp   !for integer p and real x
@@ -375,90 +364,6 @@
     end function gamma_csp


-    impure elemental function gamma_cdp(z) result(res)
(...)
-    end function gamma_cdp
-
-



@@ -962,102 +867,6 @@
         res = cmplx(sum, kind = sp)
     end function l_gamma_csp

-    impure elemental function l_gamma_cdp(z) result (res)
(...)
-    end function l_gamma_cdp
-



@@ -1298,122 +1107,6 @@
     end function gpx_rsp


-    impure elemental function gpx_rdp(p, x) result(res)
(...)
-    end function gpx_rdp
-
-


     impure elemental function gpx_iint8sp(p, x) result(res)
@@ -2514,37 +2207,6 @@
         end if
     end function ingamma_low_rsp

-    impure elemental function ingamma_low_rdp(p, x) result(res)
(...)
-    end function ingamma_low_rdp
-



@@ -2853,36 +2515,6 @@
         end if
     end function l_ingamma_low_rsp

-    impure elemental function l_ingamma_low_rdp(p, x) result(res)
(...)
-    end function l_ingamma_low_rdp
-



@@ -3130,38 +2762,6 @@
         end if
     end function ingamma_up_rsp

-    impure elemental function ingamma_up_rdp(p, x) result(res)
(...)
-    end function ingamma_up_rdp
-



@@ -3487,37 +3087,6 @@
         end if
     end function l_ingamma_up_rsp

-    impure elemental function l_ingamma_up_rdp(p, x) result(res)
(...)
-    end function l_ingamma_up_rdp
-



@@ -3827,35 +3396,6 @@
         end if
     end function regamma_p_rsp

-    impure elemental function regamma_p_rdp(p, x) result(res)
(...)
-    end function regamma_p_rdp
-



@@ -4131,35 +3671,6 @@
         end if
     end function regamma_q_rsp

-    impure elemental function regamma_q_rdp(p, x) result(res)
(...)
-    end function regamma_q_rdp
-
```

## `example/specialfunctions_gamma/example_gamma.f90` and `example/specialfunctions_gamma/example_log_gamma.f90`
- Change: Remove functions referencing deleted kinds (those requiring quad precision).

## Summary
- Fix: Make `qp` optional to avoid build failures on systems without quadmath.
- Fix: Update two example files by removing references to non-existent (deleted) kinds.
