### PR TITLE
promote other ascii functions to elemental

### DIFF
--- a/src/stdlib_ascii.fypp
+++ b/src/stdlib_ascii.fypp
@@ -107,13 +107,13 @@ module stdlib_ascii
 contains
 
     !> Checks whether `c` is an ASCII letter (A .. Z, a .. z).
-    pure logical function is_alpha(c)
+    elemental logical function is_alpha(c)
         character(len=1), intent(in) :: c !! The character to test.
         is_alpha = (c >= 'A' .and. c <= 'Z') .or. (c >= 'a' .and. c <= 'z')
     end function
 
     !> Checks whether `c` is a letter or a number (0 .. 9, a .. z, A .. Z).
-    pure logical function is_alphanum(c)
+    elemental logical function is_alphanum(c)
         character(len=1), intent(in) :: c !! The character to test.
         is_alphanum = (c >= '0' .and. c <= '9') .or. (c >= 'a' .and. c <= 'z') &
             .or. (c >= 'A' .and. c <= 'Z')
@@ -121,13 +121,13 @@ contains
 
     !> Checks whether or not `c` is in the ASCII character set -
     !> i.e. in the range 0 .. 0x7F.
-    pure logical function is_ascii(c)
+    elemental logical function is_ascii(c)
         character(len=1), intent(in) :: c !! The character to test.
         is_ascii = iachar(c) <= int(z'7F')
     end function
 
     !> Checks whether `c` is a control character.
-    pure logical function is_control(c)
+    elemental logical function is_control(c)
         character(len=1), intent(in) :: c !! The character to test.
         integer :: ic
         ic = iachar(c)
@@ -135,19 +135,19 @@ contains
     end function
 
     !> Checks whether `c` is a digit (0 .. 9).
-    pure logical function is_digit(c)
+    elemental logical function is_digit(c)
         character(len=1), intent(in) :: c !! The character to test.
         is_digit = ('0' <= c) .and. (c <= '9')
     end function
 
     !> Checks whether `c` is a digit in base 8 (0 .. 7).
-    pure logical function is_octal_digit(c)
+    elemental logical function is_octal_digit(c)
         character(len=1), intent(in) :: c !! The character to test.
         is_octal_digit = (c >= '0') .and. (c <= '7');
     end function
 
     !> Checks whether `c` is a digit in base 16 (0 .. 9, A .. F, a .. f).
-    pure logical function is_hex_digit(c)
+    elemental logical function is_hex_digit(c)
         character(len=1), intent(in) :: c !! The character to test.
         is_hex_digit = (c >= '0' .and. c <= '9') .or. (c >= 'a' .and. c <= 'f') &
             .or. (c >= 'A' .and. c <= 'F')
@@ -156,7 +156,7 @@ contains
     !> Checks whether or not `c` is a punctuation character. That includes
     !> all ASCII characters which are not control characters, letters,
     !> digits, or whitespace.
-    pure logical function is_punctuation(c)
+    elemental logical function is_punctuation(c)
         character(len=1), intent(in) :: c !! The character to test.
         integer :: ic
         ic = iachar(c) !       '~'                 '!'
@@ -166,7 +166,7 @@ contains
 
     !> Checks whether or not `c` is a printable character other than the
     !> space character.
-    pure logical function is_graphical(c)
+    elemental logical function is_graphical(c)
         character(len=1), intent(in) :: c !! The character to test.
         integer :: ic
         ic = iachar(c)
@@ -177,7 +177,7 @@ contains
 
     !> Checks whether or not `c` is a printable character - including the
     !> space character.
-    pure logical function is_printable(c)
+    elemental logical function is_printable(c)
         character(len=1), intent(in) :: c !! The character to test.
         integer :: ic
         ic = iachar(c)
@@ -186,7 +186,7 @@ contains
     end function
 
     !> Checks whether `c` is a lowercase ASCII letter (a .. z).
-    pure logical function is_lower(c)
+    elemental logical function is_lower(c)
         character(len=1), intent(in) :: c !! The character to test.
         integer :: ic
         ic = iachar(c)
@@ -194,7 +194,7 @@ contains
     end function
 
     !> Checks whether `c` is an uppercase ASCII letter (A .. Z).
-    pure logical function is_upper(c)
+    elemental logical function is_upper(c)
         character(len=1), intent(in) :: c !! The character to test.
         is_upper = (c >= 'A') .and. (c <= 'Z')
     end function
@@ -202,7 +202,7 @@ contains
     !> Checks whether or not `c` is a whitespace character. That includes the
     !> space, tab, vertical tab, form feed, carriage return, and linefeed
     !> characters.
-    pure logical function is_white(c)
+    elemental logical function is_white(c)
         character(len=1), intent(in) :: c !! The character to test.
         integer :: ic
         ic = iachar(c)             ! TAB, LF, VT, FF, CR
@@ -211,7 +211,7 @@ contains
 
     !> Checks whether or not `c` is a blank character. That includes the
     !> only the space and tab characters
-    pure logical function is_blank(c)
+    elemental logical function is_blank(c)
         character(len=1), intent(in) :: c !! The character to test.
         integer :: ic
         ic = iachar(c)             ! TAB

--- a/test/ascii/test_ascii.f90
+++ b/test/ascii/test_ascii.f90
@@ -721,66 +721,6 @@ contains
         end do
     end subroutine
 
-    !
-    !   This test reproduces the true/false table found at
-    !   https://en.cppreference.com/w/cpp/string/byte
-    !
-    subroutine test_ascii_table
-        integer :: i, j
-        logical :: table(15,12)
-
-        abstract interface
-            pure logical function validation_func_interface(c)
-                character(len=1), intent(in) :: c
-            end function
-        end interface
-
-        type :: proc_pointer_array
-            procedure(validation_func_interface), pointer, nopass :: pcf
-        end type proc_pointer_array
-
-        type(proc_pointer_array) :: pcfs(12)
-
-        pcfs(1)%pcf => is_control
-        pcfs(2)%pcf => is_printable
-        pcfs(3)%pcf => is_white
-        pcfs(4)%pcf => is_blank
-        pcfs(5)%pcf => is_graphical
-        pcfs(6)%pcf => is_punctuation
-        pcfs(7)%pcf => is_alphanum
-        pcfs(8)%pcf => is_alpha
-        pcfs(9)%pcf => is_upper
-        pcfs(10)%pcf => is_lower
-        pcfs(11)%pcf => is_digit
-        pcfs(12)%pcf => is_hex_digit
-
-        ! loop through functions
-        do i = 1, 12
-            table(1,i)  = all([(pcfs(i)%pcf(achar(j)),j=0,8)])      ! control codes
-            table(2,i)  = pcfs(i)%pcf(achar(9))                     ! tab
-            table(3,i)  = all([(pcfs(i)%pcf(achar(j)),j=10,13)])    ! whitespaces
-            table(4,i)  = all([(pcfs(i)%pcf(achar(j)),j=14,31)])    ! control codes
-            table(5,i)  = pcfs(i)%pcf(achar(32))                    ! space
-            table(6,i)  = all([(pcfs(i)%pcf(achar(j)),j=33,47)])    ! !"#$%&'()*+,-./
-            table(7,i)  = all([(pcfs(i)%pcf(achar(j)),j=48,57)])    ! 0123456789
-            table(8,i)  = all([(pcfs(i)%pcf(achar(j)),j=58,64)])    ! :;<=>?@
-            table(9,i)  = all([(pcfs(i)%pcf(achar(j)),j=65,70)])    ! ABCDEF
-            table(10,i) = all([(pcfs(i)%pcf(achar(j)),j=71,90)])    ! GHIJKLMNOPQRSTUVWXYZ
-            table(11,i) = all([(pcfs(i)%pcf(achar(j)),j=91,96)])    ! [\]^_`
-            table(12,i) = all([(pcfs(i)%pcf(achar(j)),j=97,102)])   ! abcdef
-            table(13,i) = all([(pcfs(i)%pcf(achar(j)),j=103,122)])  ! ghijklmnopqrstuvwxyz
-            table(14,i) = all([(pcfs(i)%pcf(achar(j)),j=123,126)])  ! {|}~
-            table(15,i) = pcfs(i)%pcf(achar(127))                   ! backspace character
-        end do
-
-        ! output table for verification
-        write(*,'(5X,12(I4))') (i,i=1,12)
-        do j = 1, 15
-            write(*,'(I3,2X,12(L4),2X,I3)') j, (table(j,i),i=1,12), count(table(j,:))
-        end do
-        write(*,'(5X,12(I4))') (count(table(:,i)),i=1,12)
-    end subroutine test_ascii_table
-
     subroutine test_to_lower_string(error)
         !> Error handling
         type(error_type), allocatable, intent(out) :: error


### PR DESCRIPTION
Attempts to address #973 

There was a `subroutine` which would not compile due to this change as procedure pointers cannot point to elemental procedures (according to `gfortran`) and as that `subroutine` was not used anywhere in the tests, is now removed.

Maybe we should add some array test cases to ensure it behaves correctly?