### PR TITLE
`linalg`: slightly increase test tolerance

### DIFF
--- a/test/linalg/test_linalg_pseudoinverse.fypp
+++ b/test/linalg/test_linalg_pseudoinverse.fypp
@@ -41,7 +41,7 @@ module test_linalg_pseudoinverse
 
         integer(ilp) :: i,j
         integer(ilp), parameter :: n = 15_ilp
-        real(${rk}$), parameter :: tol = 100*sqrt(epsilon(0.0_${rk}$))
+        real(${rk}$), parameter :: tol = 1000*sqrt(epsilon(0.0_${rk}$))
 
         ${rt}$ :: a(n,n),inva(n,n)
 
@@ -85,7 +85,7 @@ module test_linalg_pseudoinverse
 
         integer(ilp) :: failed
         integer(ilp), parameter :: n = 10
-        real(${rk}$), parameter :: tol = 100*sqrt(epsilon(0.0_${rk}$))
+        real(${rk}$), parameter :: tol = 1000*sqrt(epsilon(0.0_${rk}$))
         ${rt}$ :: a(n, n), inva(n, n)
         #:if rt.startswith('complex')
         real(${rk}$) :: rea(n, n, 2)
@@ -119,7 +119,7 @@ module test_linalg_pseudoinverse
 
         integer(ilp) :: failed
         integer(ilp), parameter :: m = 20, n = 10
-        real(${rk}$), parameter :: tol = 100*sqrt(epsilon(0.0_${rk}$))
+        real(${rk}$), parameter :: tol = 1000*sqrt(epsilon(0.0_${rk}$))
         ${rt}$ :: a(m, n), inva(n, m)
         #:if rt.startswith('complex')
         real(${rk}$) :: rea(m, n, 2)
@@ -153,7 +153,7 @@ module test_linalg_pseudoinverse
 
         integer(ilp) :: failed
         integer(ilp), parameter :: m = 10, n = 20
-        real(${rk}$), parameter :: tol = 100*sqrt(epsilon(0.0_${rk}$))
+        real(${rk}$), parameter :: tol = 1000*sqrt(epsilon(0.0_${rk}$))
         ${rt}$ :: a(m, n), inva(n, m)
         #:if rt.startswith('complex')
         real(${rk}$) :: rea(m, n, 2)
@@ -187,7 +187,7 @@ module test_linalg_pseudoinverse
 
         integer(ilp) :: failed
         integer(ilp), parameter :: n = 10
-        real(${rk}$), parameter :: tol = 100*sqrt(epsilon(0.0_${rk}$))
+        real(${rk}$), parameter :: tol = 1000*sqrt(epsilon(0.0_${rk}$))
         ${rt}$ :: a(n, n), inva(n, n)
         #:if rt.startswith('complex')
         real(${rk}$) :: rea(n, n, 2)


### PR DESCRIPTION
this PR attempts to fix some CI failures by relaxing the `pinv` (pseudoinverse) test tolerance.
`pinv` works with singular matrices and the accuracy of the inverse in the test may be affected by the random number choice. 