### PR TITLE
feat: Add github collaboration script and workflow documentation

### DIFF
--- a/.github/collab.sh
+++ b/.github/collab.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+echo "📦 GitHub Fork Collaboration Setup Script"
+
+# Prompt for User's GitHub username
+
+read -p "Enter the GitHub username of the fork owner (e.g., alice): " USER
+
+# Prompt for the branch name
+
+read -p "Enter the PR branch name (e.g., feature-branch): " BRANCH
+
+# Add remotes
+
+echo "🔗 Adding remotes..."
+
+git remote add $USER https://github.com/$USER/stdlib.git
+
+# Fetch and checkout the PR branch
+
+echo "📥 Fetching branch '$BRANCH'..."
+
+git fetch $USER
+
+git checkout -b $BRANCH $USER/$BRANCH
+
+# Done
+
+echo "✅ Repo set up. You're now on '$BRANCH'."
+
+echo "You can now make changes and push directly to $USER/stdlib:$BRANCH"

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -109,3 +109,40 @@ The project is usable as CMake subproject. Explicit references to
 break subproject builds.
 An example project is available [here](https://github.com/fortran-lang/stdlib-cmake-example)
 to test the CMake subproject integration.
+
+## GitHub collaboration
+
+Contributing can be daunting, we know! Even more for a big project with many contributors, and if you are not expert on the whole github workflow then even more, we have been there at some point.
+
+In order to help lowering the barrier for collaborating on ongoing efforts (e.g. an open PR), we have crafted a simple script that might come in handy. To explain the process we'll use Alice (the person you want to help) and Bob (you):
+
+       ┌────────────────────────────┐
+       │    fortran-lang/stdlib     │
+       └────────────▲───────────────┘
+                    │
+                    │  [Pull Request]
+                    │
+            ┌───────┴────────┐
+            │  alice/stdlib  │ ←─────┐
+            └──────▲─────────┘       │
+                   │                 │
+   [PR Branch] ←───┘          ┌──────┴──────┐
+   feature-branch             │  bob/stdlib │
+   (hosted here)              │    (fork)   │
+                              └─────────────┘
+                                     ▲
+                                     │
+                       [Push access to Alice's repo]
+
+After having forked and downloaded locally `stdlib` on your local machine; on an unix compatible terminal with access to the `git` CLI, being at the root folder: 
+```sh
+./.github/collab.sh
+```
+You will be asked to enter the username and branch of the other person:
+```bash
+Enter the GitHub username of the fork owner (e.g., alice): alice
+Enter the PR branch name (e.g., feature-branch): feature-branch
+```
+This will fetch Alice's repository and switch your view to Alice's feature-branch. Now you can review, build, run, play around, propose your nice improvements.
+
+Remember, to announce your willingness to help 😉


### PR DESCRIPTION
This script is a proposal to ease the setup of another person's branch in order to help with open PRs.

The script is currently placed within the `.github` folder as it is specific to the github hosting. But it also be in `config`. I've added a diagram in the WORKFLOW.md file to try to explain the process.

cc: @perazz @jvdp1 @ivan-pi 
