### PR TITLE
fix: collab diagram layout fix

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -116,6 +116,7 @@ Contributing can be daunting, we know! Even more for a big project with many con
 
 In order to help lowering the barrier for collaborating on ongoing efforts (e.g. an open PR), we have crafted a simple script that might come in handy. To explain the process we'll use Alice (the person you want to help) and Bob (you):
 
+```text
        ┌────────────────────────────┐
        │    fortran-lang/stdlib     │
        └────────────▲───────────────┘
@@ -133,6 +134,7 @@ In order to help lowering the barrier for collaborating on ongoing efforts (e.g.
                                      ▲
                                      │
                        [Push access to Alice's repo]
+```
 
 After having forked from `fortran-lang/stdlib` and cloned your `stdlib` fork on your local machine; on an unix compatible terminal with access to the `git` CLI, being at the root folder: 
 ```sh


### PR DESCRIPTION
I noticed that the diagram included to explain the collab script didn't show properly in the documentation html. Adding the text quotes enables a proper visualization of the diagram for both the original markdown and the html.

Current layout in the docs:
![image](https://github.com/user-attachments/assets/1e33b3b8-4848-4d4f-bb34-04ecfee1a6d1)

After fix:
![image](https://github.com/user-attachments/assets/bf9dfc13-1f8a-4a02-9ca8-52fa3acbf846)
