### PR TITLE
fix: make ansi examples from documentation executable

### DIFF
--- a/doc/specs/stdlib_ansi.md
+++ b/doc/specs/stdlib_ansi.md
@@ -28,19 +28,7 @@ Experimental
 #### Example
 
 ```fortran
-program demo_color
-  use stdlib_ansi, only : fg_color_blue, style_bold, style_reset, ansi_code, &
-    & operator(//), operator(+)
-  implicit none
-  type(ansi_code) :: highlight, reset
-
-  print '(a)', highlight // "Dull text message" // reset
-
-  highlight = fg_color_blue + style_bold
-  reset = style_reset
-
-  print '(a)', highlight // "Colorful text message" // reset
-end program demo_color
+{!example/ansi/example_ansi_color.f90!}
 ```
 
 
@@ -216,12 +204,7 @@ Experimental
 #### Example
 
 ```fortran
-program demo_string
-  use stdlib_ansi, only : fg_color_green, style_reset, to_string
-  implicit none
-
-  print '(a)', to_string(fg_color_green) // "Colorized text message" // to_string(style_reset)
-end program demo_string
+{!example/ansi/example_ansi_to_string.f90!}
 ```
 
 
@@ -255,13 +238,7 @@ Experimental
 #### Example
 
 ```fortran
-program demo_combine
-  use stdlib_ansi, only : fg_color_red, style_bold, ansi_code
-  implicit none
-  type(ansi_code) :: bold_red
-
-  bold_red = fg_color_red + style_bold
-end program demo_combine
+{!example/ansi/example_ansi_combine.f90!}
 ```
 
 
@@ -295,10 +272,5 @@ Experimental
 #### Example
 
 ```fortran
-program demo_concat
-  use stdlib_ansi, only : fg_color_red, style_reset, operator(//)
-  implicit none
-
-  print '(a)', fg_color_red // "Colorized text message" // style_reset
-end program demo_concat
+{!example/ansi/example_ansi_concat.f90!}
 ```

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -6,6 +6,7 @@ macro(ADD_EXAMPLE name)
              WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 endmacro(ADD_EXAMPLE)
 
+add_subdirectory(ansi)
 add_subdirectory(array)
 add_subdirectory(ascii)
 add_subdirectory(bitsets)

--- a/example/ansi/CMakeLists.txt
+++ b/example/ansi/CMakeLists.txt
@@ -1,0 +1,4 @@
+ADD_EXAMPLE(ansi_color)
+ADD_EXAMPLE(ansi_combine)
+ADD_EXAMPLE(ansi_concat)
+ADD_EXAMPLE(ansi_to_string)

--- a/example/ansi/example_ansi_color.f90
+++ b/example/ansi/example_ansi_color.f90
@@ -1,0 +1,13 @@
+program example_ansi_color
+  use stdlib_ansi, only : fg_color_blue, style_bold, style_reset, ansi_code, &
+    & operator(//), operator(+)
+  implicit none
+  type(ansi_code) :: highlight, reset
+
+  print '(a)', highlight // "Dull text message" // reset
+
+  highlight = fg_color_blue + style_bold
+  reset = style_reset
+
+  print '(a)', highlight // "Colorful text message" // reset
+end program example_ansi_color

--- a/example/ansi/example_ansi_combine.f90
+++ b/example/ansi/example_ansi_combine.f90
@@ -1,0 +1,9 @@
+program example_ansi_combine
+  use stdlib_ansi, only : fg_color_red, style_bold, ansi_code, operator(+), to_string
+  implicit none
+  type(ansi_code) :: bold_red
+
+  bold_red = fg_color_red + style_bold
+  print '(a)', to_string(bold_red)
+  
+end program example_ansi_combine

--- a/example/ansi/example_ansi_concat.f90
+++ b/example/ansi/example_ansi_concat.f90
@@ -1,0 +1,6 @@
+program example_ansi_concat
+  use stdlib_ansi, only : fg_color_red, style_reset, operator(//)
+  implicit none
+
+  print '(a)', fg_color_red // "Colorized text message" // style_reset
+end program example_ansi_concat

--- a/example/ansi/example_ansi_to_string.f90
+++ b/example/ansi/example_ansi_to_string.f90
@@ -1,0 +1,6 @@
+program example_ansi_to_string
+  use stdlib_ansi, only : fg_color_green, style_reset, to_string
+  implicit none
+
+  print '(a)', to_string(fg_color_green) // "Colorized text message" // to_string(style_reset)
+end program example_ansi_to_string


### PR DESCRIPTION
I was reviewing the documentation of the ansi module and realized the examples were not runnable. Here I propose to add them to the list of executable examples.