### PR TITLE
fix: do-concurrent syntax

### DIFF
--- a/src/stdlib_linalg_pinv.fypp
+++ b/src/stdlib_linalg_pinv.fypp
@@ -74,7 +74,9 @@ submodule(stdlib_linalg) stdlib_linalg_pseudoinverse
          ! Get pseudo-inverse: A_pinv = V * (diag(1/s) * U^H) = V * (U * diag(1/s))^H
          
          ! 1) compute (U * diag(1/s)) in-place
-         do concurrent (i=1:m,j=1:k); u(i,j) = s(j)*u(i,j); end do
+         do concurrent (i=1:m,j=1:k)
+            u(i,j) = s(j)*u(i,j)
+         end do
             
          ! 2) commutate matmul: A_pinv = V * (U * diag(1/s))^H = ((U * diag(1/s)) * V^H)^H. 
          !    This avoids one matrix transpose


### PR DESCRIPTION
fixes #989 

Now works on both Windows and linux with gfortran
