### PR TITLE
fix: to_num_from_stream pointer position correction

### DIFF
--- a/src/stdlib_str2num.fypp
+++ b/src/stdlib_str2num.fypp
@@ -109,7 +109,7 @@ module stdlib_str2num
         integer(int8) :: err
         !----------------------------------------------
         call to_num_base(s,v,p,err)
-        p = min( p , len(s, kind = int8) )
+        p = min( p , len(s) )
         s => s(p:)
         if(present(stat)) stat = err
     end function


### PR DESCRIPTION
This PR fixes the computation of the position in a character stream for the `to_num_from_stream` function to properly advance when the character is a long chain. Otherwise, negative numbers can be obtained from `len(s, lind=int8)` if the string is in effect larger than 127.
