### PR TITLE
fix: CI issue with test-drive and gnu 15

### DIFF
--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -40,7 +40,7 @@ jobs:
         -Wdev
         -B build
         -DCMAKE_BUILD_TYPE=Debug
-        -DCMAKE_Fortran_FLAGS_DEBUG="-Wall -Wextra -Wimplicit-interface -fPIC -g -fcheck=all -fbacktrace"
+        -DCMAKE_Fortran_FLAGS_DEBUG="-Wall -Wextra -Wno-external-argument-mismatch -Wimplicit-interface -fPIC -g -fcheck=all -fbacktrace"
         -DCMAKE_MAXIMUM_RANK:String=4
         -DCMAKE_INSTALL_PREFIX=$PWD/_dist
         -DFIND_BLAS:STRING=FALSE


### PR DESCRIPTION
Hacking away the CI for gnu 15: https://github.com/fortran-lang/stdlib/pull/957#issuecomment-3013754809