### PR TITLE
GCC 15.1 fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,13 @@ if(CMAKE_Fortran_COMPILER_ID STREQUAL GNU AND CMAKE_Fortran_COMPILER_VERSION VER
   message(FATAL_ERROR "GCC Version 9 or newer required")
 endif()
 
+# --- silence gfortran-15 argument-mismatch warnings
+if(CMAKE_Fortran_COMPILER_ID STREQUAL GNU
+   AND CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 15.0
+   AND CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 16.0)
+    add_compile_options("$<$<COMPILE_LANGUAGE:Fortran>:-Wno-external-argument-mismatch>")
+endif()
+
 # --- compiler feature checks
 include(CheckFortranSourceCompiles)
 include(CheckFortranSourceRuns)

--- a/test/linalg/test_linalg_cholesky.fypp
+++ b/test/linalg/test_linalg_cholesky.fypp
@@ -22,7 +22,7 @@ module test_linalg_cholesky
         allocate(tests(0))
         
         #:for rk,rt,ri in RC_KINDS_TYPES
-        tests = [tests,new_unittest("least_cholesky_${ri}$",test_cholesky_${ri}$)]
+        call add_test(tests,new_unittest("least_cholesky_${ri}$",test_cholesky_${ri}$))
         #:endfor
 
     end subroutine test_cholesky_factorization
@@ -66,6 +66,26 @@ module test_linalg_cholesky
 
     #:endfor
 
+    ! gcc-15 bugfix utility
+    subroutine add_test(tests,new_test)
+        type(unittest_type), allocatable, intent(inout) :: tests(:)    
+        type(unittest_type), intent(in) :: new_test
+        
+        integer :: n
+        type(unittest_type), allocatable :: new_tests(:)
+        
+        if (allocated(tests)) then 
+            n = size(tests)
+        else
+            n = 0
+        end if
+        
+        allocate(new_tests(n+1))
+        if (n>0) new_tests(1:n) = tests(1:n)
+                 new_tests(1+n) = new_test
+        call move_alloc(from=new_tests,to=tests)        
+        
+    end subroutine add_test
 
 end module test_linalg_cholesky
 

--- a/test/linalg/test_linalg_determinant.fypp
+++ b/test/linalg/test_linalg_determinant.fypp
@@ -145,7 +145,7 @@ module test_linalg_determinant
     #:endfor
     
     ! gcc-15 bugfix utility
-    pure subroutine add_test(tests,new_test)
+    subroutine add_test(tests,new_test)
         type(unittest_type), allocatable, intent(inout) :: tests(:)    
         type(unittest_type), intent(in) :: new_test
         

--- a/test/linalg/test_linalg_determinant.fypp
+++ b/test/linalg/test_linalg_determinant.fypp
@@ -23,13 +23,13 @@ module test_linalg_determinant
 
         #:for rk,rt in RC_KINDS_TYPES
         #:if rk!="xdp"
-        tests = [tests,new_unittest("$eye_det_${rt[0]}$${rk}$",test_${rt[0]}$${rk}$_eye_determinant)]
-        tests = [tests,new_unittest("$eye_det_multiple_${rt[0]}$${rk}$",test_${rt[0]}$${rk}$_eye_multiple)]
+        call add_test(tests,new_unittest("$eye_det_${rt[0]}$${rk}$",test_${rt[0]}$${rk}$_eye_determinant))
+        call add_test(tests,new_unittest("$eye_det_multiple_${rt[0]}$${rk}$",test_${rt[0]}$${rk}$_eye_multiple))
         #:endif
         #:endfor
         #:for ck,ct in CMPLX_KINDS_TYPES
         #:if ck!="xdp"
-        tests = [tests,new_unittest("$complex_det_${rt[0]}$${rk}$",test_${ct[0]}$${ck}$_complex_determinant)]
+        call add_test(tests,new_unittest("$complex_det_${rt[0]}$${rk}$",test_${ct[0]}$${ck}$_complex_determinant))
         #:endif
         #: endfor
 
@@ -143,6 +143,27 @@ module test_linalg_determinant
 
     #:endif
     #:endfor
+    
+    ! gcc-15 bugfix utility
+    pure subroutine add_test(tests,new_test)
+        type(unittest_type), allocatable, intent(inout) :: tests(:)    
+        type(unittest_type), intent(in) :: new_test
+        
+        integer :: n
+        type(unittest_type), allocatable :: new_tests(:)
+        
+        if (allocated(tests)) then 
+            n = size(tests)
+        else
+            n = 0
+        end if
+        
+        allocate(new_tests(n+1))
+        if (n>0) new_tests(1:n) = tests(1:n)
+                 new_tests(1+n) = new_test
+        call move_alloc(from=new_tests,to=tests)        
+        
+    end subroutine add_test
 
 end module test_linalg_determinant
 

--- a/test/linalg/test_linalg_eigenvalues.fypp
+++ b/test/linalg/test_linalg_eigenvalues.fypp
@@ -21,17 +21,17 @@ module test_linalg_eigenvalues
         allocate(tests(0))
 
         #:for rk,rt,ri in REAL_KINDS_TYPES
-        tests = [tests,new_unittest("test_eig_real_${ri}$",test_eig_real_${ri}$), &
-                       new_unittest("test_eigvals_identity_${ri}$",test_eigvals_identity_${ri}$), &    
-                       new_unittest("test_eigvals_diagonal_B_${ri}$",test_eigvals_diagonal_B_${ri}$), &
-                       new_unittest("test_eigvals_nondiagonal_B_${ri}$",test_eigvals_nondiagonal_B_${ri}$), &
-                       new_unittest("test_eigh_real_${ri}$",test_eigh_real_${ri}$)]        
+        call add_test(tests,new_unittest("test_eig_real_${ri}$",test_eig_real_${ri}$))
+        call add_test(tests,new_unittest("test_eigvals_identity_${ri}$",test_eigvals_identity_${ri}$))
+        call add_test(tests,new_unittest("test_eigvals_diagonal_B_${ri}$",test_eigvals_diagonal_B_${ri}$))
+        call add_test(tests,new_unittest("test_eigvals_nondiagonal_B_${ri}$",test_eigvals_nondiagonal_B_${ri}$))
+        call add_test(tests,new_unittest("test_eigh_real_${ri}$",test_eigh_real_${ri}$))
         #: endfor
         
         #:for ck,ct,ci in CMPLX_KINDS_TYPES
-        tests = [tests,new_unittest("test_eig_complex_${ci}$",test_eig_complex_${ci}$), &
-                       new_unittest("test_eig_generalized_complex_${ci}$",test_eigvals_generalized_complex_${ci}$), &
-                       new_unittest("test_eig_issue_927_${ci}$",test_issue_927_${ci}$)]                
+        call add_test(tests,new_unittest("test_eig_complex_${ci}$",test_eig_complex_${ci}$))
+        call add_test(tests,new_unittest("test_eig_generalized_complex_${ci}$",test_eigvals_generalized_complex_${ci}$))
+        call add_test(tests,new_unittest("test_eig_issue_927_${ci}$",test_issue_927_${ci}$))
         #: endfor 
 
     end subroutine test_eig_eigh
@@ -347,8 +347,26 @@ module test_linalg_eigenvalues
 
     #:endfor
 
-
-
+    ! gcc-15 bugfix utility
+    subroutine add_test(tests,new_test)
+        type(unittest_type), allocatable, intent(inout) :: tests(:)    
+        type(unittest_type), intent(in) :: new_test
+        
+        integer :: n
+        type(unittest_type), allocatable :: new_tests(:)
+        
+        if (allocated(tests)) then 
+            n = size(tests)
+        else
+            n = 0
+        end if
+        
+        allocate(new_tests(n+1))
+        if (n>0) new_tests(1:n) = tests(1:n)
+                 new_tests(1+n) = new_test
+        call move_alloc(from=new_tests,to=tests)        
+        
+    end subroutine add_test
 
 end module test_linalg_eigenvalues
 

--- a/test/linalg/test_linalg_inverse.fypp
+++ b/test/linalg/test_linalg_inverse.fypp
@@ -22,9 +22,9 @@ module test_linalg_inverse
         allocate(tests(0))
 
         #:for rk,rt,ri in RC_KINDS_TYPES
-        tests = [tests,new_unittest("${ri}$_eye_inverse",test_${ri}$_eye_inverse), &
-                       new_unittest("${ri}$_singular_inverse",test_${ri}$_singular_inverse), &
-                       new_unittest("${ri}$_random_spd_inverse",test_${ri}$_random_spd_inverse)]
+        call add_test(tests,new_unittest("${ri}$_eye_inverse",test_${ri}$_eye_inverse)) 
+        call add_test(tests,new_unittest("${ri}$_singular_inverse",test_${ri}$_singular_inverse)) 
+        call add_test(tests,new_unittest("${ri}$_random_spd_inverse",test_${ri}$_random_spd_inverse))
         #:endfor
 
     end subroutine test_inverse_matrix
@@ -290,6 +290,27 @@ module test_linalg_inverse
     end subroutine test_${ci}$_singular_inverse
 
     #:endfor
+
+    ! gcc-15 bugfix utility
+    pure subroutine add_test(tests,new_test)
+        type(unittest_type), allocatable, intent(inout) :: tests(:)    
+        type(unittest_type), intent(in) :: new_test
+        
+        integer :: n
+        type(unittest_type), allocatable :: new_tests(:)
+        
+        if (allocated(tests)) then 
+            n = size(tests)
+        else
+            n = 0
+        end if
+        
+        allocate(new_tests(n+1))
+        if (n>0) new_tests(1:n) = tests(1:n)
+                 new_tests(1+n) = new_test
+        call move_alloc(from=new_tests,to=tests)        
+        
+    end subroutine add_test
 
 end module test_linalg_inverse
 

--- a/test/linalg/test_linalg_inverse.fypp
+++ b/test/linalg/test_linalg_inverse.fypp
@@ -292,7 +292,7 @@ module test_linalg_inverse
     #:endfor
 
     ! gcc-15 bugfix utility
-    pure subroutine add_test(tests,new_test)
+    subroutine add_test(tests,new_test)
         type(unittest_type), allocatable, intent(inout) :: tests(:)    
         type(unittest_type), intent(in) :: new_test
         

--- a/test/linalg/test_linalg_lstsq.fypp
+++ b/test/linalg/test_linalg_lstsq.fypp
@@ -140,7 +140,7 @@ module test_linalg_least_squares
     end subroutine test_issue_823
 
     ! gcc-15 bugfix utility
-    pure subroutine add_test(tests,new_test)
+    subroutine add_test(tests,new_test)
         type(unittest_type), allocatable, intent(inout) :: tests(:)    
         type(unittest_type), intent(in) :: new_test
         

--- a/test/linalg/test_linalg_lstsq.fypp
+++ b/test/linalg/test_linalg_lstsq.fypp
@@ -21,11 +21,11 @@ module test_linalg_least_squares
         
         allocate(tests(0))
         
-        tests = [tests,new_unittest("issue_823",test_issue_823)]
+        call add_test(tests,new_unittest("issue_823",test_issue_823))
 
         #:for rk,rt,ri in REAL_KINDS_TYPES
-        tests = [tests,new_unittest("least_squares_${ri}$",test_lstsq_one_${ri}$), &
-                       new_unittest("least_squares_randm_${ri}$",test_lstsq_random_${ri}$)]
+        call add_test(tests,new_unittest("least_squares_${ri}$",test_lstsq_one_${ri}$))
+        call add_test(tests,new_unittest("least_squares_randm_${ri}$",test_lstsq_random_${ri}$))
         #:endfor
 
     end subroutine test_least_squares
@@ -138,6 +138,27 @@ module test_linalg_least_squares
         if (allocated(error)) return
 
     end subroutine test_issue_823
+
+    ! gcc-15 bugfix utility
+    pure subroutine add_test(tests,new_test)
+        type(unittest_type), allocatable, intent(inout) :: tests(:)    
+        type(unittest_type), intent(in) :: new_test
+        
+        integer :: n
+        type(unittest_type), allocatable :: new_tests(:)
+        
+        if (allocated(tests)) then 
+            n = size(tests)
+        else
+            n = 0
+        end if
+        
+        allocate(new_tests(n+1))
+        if (n>0) new_tests(1:n) = tests(1:n)
+                 new_tests(1+n) = new_test
+        call move_alloc(from=new_tests,to=tests)        
+        
+    end subroutine add_test
 
 end module test_linalg_least_squares
 

--- a/test/linalg/test_linalg_mnorm.fypp
+++ b/test/linalg/test_linalg_mnorm.fypp
@@ -18,9 +18,9 @@ module test_linalg_mnorm
         allocate(tests(0))
         
         #:for rk,rt,ri in RC_KINDS_TYPES
-        tests = [tests,new_unittest("test_matrix_norms_${ri}$",test_matrix_norms_${ri}$)]
+        call add_test(tests,new_unittest("test_matrix_norms_${ri}$",test_matrix_norms_${ri}$))
         #:for rank in range(3, MAXRANK)
-        tests = [tests,new_unittest("test_mnorm_${ri}$_${rank}$d",test_mnorm_${ri}$_${rank}$d)]
+        call add_test(tests,new_unittest("test_mnorm_${ri}$_${rank}$d",test_mnorm_${ri}$_${rank}$d))
         #:endfor
         #:endfor
         
@@ -134,6 +134,27 @@ module test_linalg_mnorm
     #:endfor    
     
     #:endfor
+
+    ! gcc-15 bugfix utility
+    pure subroutine add_test(tests,new_test)
+        type(unittest_type), allocatable, intent(inout) :: tests(:)    
+        type(unittest_type), intent(in) :: new_test
+        
+        integer :: n
+        type(unittest_type), allocatable :: new_tests(:)
+        
+        if (allocated(tests)) then 
+            n = size(tests)
+        else
+            n = 0
+        end if
+        
+        allocate(new_tests(n+1))
+        if (n>0) new_tests(1:n) = tests(1:n)
+                 new_tests(1+n) = new_test
+        call move_alloc(from=new_tests,to=tests)        
+        
+    end subroutine add_test
 
 end module test_linalg_mnorm
 

--- a/test/linalg/test_linalg_mnorm.fypp
+++ b/test/linalg/test_linalg_mnorm.fypp
@@ -136,7 +136,7 @@ module test_linalg_mnorm
     #:endfor
 
     ! gcc-15 bugfix utility
-    pure subroutine add_test(tests,new_test)
+    subroutine add_test(tests,new_test)
         type(unittest_type), allocatable, intent(inout) :: tests(:)    
         type(unittest_type), intent(in) :: new_test
         

--- a/test/linalg/test_linalg_norm.fypp
+++ b/test/linalg/test_linalg_norm.fypp
@@ -269,7 +269,7 @@ module test_linalg_norm
     #:endfor
 
     ! gcc-15 bugfix utility
-    pure subroutine add_test(tests,new_test)
+    subroutine add_test(tests,new_test)
         type(unittest_type), allocatable, intent(inout) :: tests(:)    
         type(unittest_type), intent(in) :: new_test
         

--- a/test/linalg/test_linalg_norm.fypp
+++ b/test/linalg/test_linalg_norm.fypp
@@ -32,16 +32,16 @@ module test_linalg_norm
         allocate(tests(0))
         
         #:for rk,rt,ri in RC_KINDS_TYPES
-        tests = [tests,new_unittest("strided_1d_norm_${ri}$",test_strided_1d_${ri}$)]
+        call add_test(tests,new_unittest("strided_1d_norm_${ri}$",test_strided_1d_${ri}$))
         #:for rank in range(1, MAXRANK)
-        tests = [tests,new_unittest("norm_${ri}$_${rank}$d",test_norm_${ri}$_${rank}$d)]        
+        call add_test(tests,new_unittest("norm_${ri}$_${rank}$d",test_norm_${ri}$_${rank}$d))      
         #:endfor
         #:for rank in range(2, MAXRANK)
         #:if rt.startswith('real')
-        tests = [tests,new_unittest("norm2_${ri}$_${rank}$d",test_norm2_${ri}$_${rank}$d)]        
+        call add_test(tests,new_unittest("norm2_${ri}$_${rank}$d",test_norm2_${ri}$_${rank}$d))        
         #:endif
-        tests = [tests,new_unittest("maxabs_${ri}$_${rank}$d",test_maxabs_${ri}$_${rank}$d)]        
-        tests = [tests,new_unittest("norm_dimmed_${ri}$_${rank}$d",test_norm_dimmed_${ri}$_${rank}$d)]        
+        call add_test(tests,new_unittest("maxabs_${ri}$_${rank}$d",test_maxabs_${ri}$_${rank}$d))        
+        call add_test(tests,new_unittest("norm_dimmed_${ri}$_${rank}$d",test_norm_dimmed_${ri}$_${rank}$d))        
         #:endfor
         #:endfor
 
@@ -268,6 +268,26 @@ module test_linalg_norm
     #:endfor
     #:endfor
 
+    ! gcc-15 bugfix utility
+    pure subroutine add_test(tests,new_test)
+        type(unittest_type), allocatable, intent(inout) :: tests(:)    
+        type(unittest_type), intent(in) :: new_test
+        
+        integer :: n
+        type(unittest_type), allocatable :: new_tests(:)
+        
+        if (allocated(tests)) then 
+            n = size(tests)
+        else
+            n = 0
+        end if
+        
+        allocate(new_tests(n+1))
+        if (n>0) new_tests(1:n) = tests(1:n)
+                 new_tests(1+n) = new_test
+        call move_alloc(from=new_tests,to=tests)        
+        
+    end subroutine add_test
 
 end module test_linalg_norm
 

--- a/test/linalg/test_linalg_pseudoinverse.fypp
+++ b/test/linalg/test_linalg_pseudoinverse.fypp
@@ -21,13 +21,13 @@ module test_linalg_pseudoinverse
         allocate(tests(0))
 
         #:for rk,rt,ri in REAL_KINDS_TYPES
-        tests = [tests,new_unittest("${ri}$_eye_pseudoinverse",test_${ri}$_eye_pseudoinverse)]        
+        call add_test(tests,new_unittest("${ri}$_eye_pseudoinverse",test_${ri}$_eye_pseudoinverse))       
         #:endfor
         #:for rk,rt,ri in RC_KINDS_TYPES
-        tests = [tests,new_unittest("${ri}$_square_pseudoinverse",test_${ri}$_square_pseudoinverse), &
-                       new_unittest("${ri}$_tall_pseudoinverse",test_${ri}$_tall_pseudoinverse), &
-                       new_unittest("${ri}$_wide_pseudoinverse",test_${ri}$_wide_pseudoinverse), &
-                       new_unittest("${ri}$_singular_pseudoinverse",test_${ri}$_singular_pseudoinverse)]
+        call add_test(tests,new_unittest("${ri}$_square_pseudoinverse",test_${ri}$_square_pseudoinverse))
+        call add_test(tests,new_unittest("${ri}$_tall_pseudoinverse",test_${ri}$_tall_pseudoinverse))
+        call add_test(tests,new_unittest("${ri}$_wide_pseudoinverse",test_${ri}$_wide_pseudoinverse))
+        call add_test(tests,new_unittest("${ri}$_singular_pseudoinverse",test_${ri}$_singular_pseudoinverse))
         #:endfor
 
     end subroutine test_pseudoinverse_matrix
@@ -217,6 +217,27 @@ module test_linalg_pseudoinverse
     end subroutine test_${ri}$_singular_pseudoinverse
 
     #:endfor
+
+    ! gcc-15 bugfix utility
+    pure subroutine add_test(tests,new_test)
+        type(unittest_type), allocatable, intent(inout) :: tests(:)    
+        type(unittest_type), intent(in) :: new_test
+        
+        integer :: n
+        type(unittest_type), allocatable :: new_tests(:)
+        
+        if (allocated(tests)) then 
+            n = size(tests)
+        else
+            n = 0
+        end if
+        
+        allocate(new_tests(n+1))
+        if (n>0) new_tests(1:n) = tests(1:n)
+                 new_tests(1+n) = new_test
+        call move_alloc(from=new_tests,to=tests)        
+        
+    end subroutine add_test
 
 end module test_linalg_pseudoinverse
 

--- a/test/linalg/test_linalg_pseudoinverse.fypp
+++ b/test/linalg/test_linalg_pseudoinverse.fypp
@@ -219,7 +219,7 @@ module test_linalg_pseudoinverse
     #:endfor
 
     ! gcc-15 bugfix utility
-    pure subroutine add_test(tests,new_test)
+    subroutine add_test(tests,new_test)
         type(unittest_type), allocatable, intent(inout) :: tests(:)    
         type(unittest_type), intent(in) :: new_test
         

--- a/test/linalg/test_linalg_qr.fypp
+++ b/test/linalg/test_linalg_qr.fypp
@@ -111,7 +111,7 @@ module test_linalg_qr
     #:endfor
 
     ! gcc-15 bugfix utility
-    pure subroutine add_test(tests,new_test)
+    subroutine add_test(tests,new_test)
         type(unittest_type), allocatable, intent(inout) :: tests(:)    
         type(unittest_type), intent(in) :: new_test
         

--- a/test/linalg/test_linalg_qr.fypp
+++ b/test/linalg/test_linalg_qr.fypp
@@ -22,7 +22,7 @@ module test_linalg_qr
         allocate(tests(0))
         
         #:for rk,rt,ri in RC_KINDS_TYPES
-        tests = [tests,new_unittest("qr_random_${ri}$",test_qr_random_${ri}$)]
+        call add_test(tests,new_unittest("qr_random_${ri}$",test_qr_random_${ri}$))
         #:endfor
 
     end subroutine test_qr_factorization
@@ -110,6 +110,26 @@ module test_linalg_qr
 
     #:endfor
 
+    ! gcc-15 bugfix utility
+    pure subroutine add_test(tests,new_test)
+        type(unittest_type), allocatable, intent(inout) :: tests(:)    
+        type(unittest_type), intent(in) :: new_test
+        
+        integer :: n
+        type(unittest_type), allocatable :: new_tests(:)
+        
+        if (allocated(tests)) then 
+            n = size(tests)
+        else
+            n = 0
+        end if
+        
+        allocate(new_tests(n+1))
+        if (n>0) new_tests(1:n) = tests(1:n)
+                 new_tests(1+n) = new_test
+        call move_alloc(from=new_tests,to=tests)        
+        
+    end subroutine add_test
 
 end module test_linalg_qr
 

--- a/test/linalg/test_linalg_schur.fypp
+++ b/test/linalg/test_linalg_schur.fypp
@@ -208,7 +208,7 @@ module test_linalg_schur
     #:endfor
 
     ! gcc-15 bugfix utility
-    pure subroutine add_test(tests,new_test)
+    subroutine add_test(tests,new_test)
         type(unittest_type), allocatable, intent(inout) :: tests(:)    
         type(unittest_type), intent(in) :: new_test
         

--- a/test/linalg/test_linalg_schur.fypp
+++ b/test/linalg/test_linalg_schur.fypp
@@ -22,9 +22,9 @@ module test_linalg_schur
         allocate(tests(0))
         
         #:for rk,rt,ri in RC_KINDS_TYPES
-        tests = [tests,new_unittest("schur_api_${ri}$",test_schur_api_${ri}$), &
-                       new_unittest("schur_random_${ri}$",test_schur_random_${ri}$), &
-                       new_unittest("schur_symmetric_${ri}$",test_schur_symmetric_${ri}$)]
+        call add_test(tests,new_unittest("schur_api_${ri}$",test_schur_api_${ri}$))
+        call add_test(tests,new_unittest("schur_random_${ri}$",test_schur_random_${ri}$))
+        call add_test(tests,new_unittest("schur_symmetric_${ri}$",test_schur_symmetric_${ri}$))
         #:endfor
 
     end subroutine test_schur_decomposition
@@ -205,8 +205,28 @@ module test_linalg_schur
 
     end subroutine test_schur_symmetric_${ri}$
 
-
     #:endfor
+
+    ! gcc-15 bugfix utility
+    pure subroutine add_test(tests,new_test)
+        type(unittest_type), allocatable, intent(inout) :: tests(:)    
+        type(unittest_type), intent(in) :: new_test
+        
+        integer :: n
+        type(unittest_type), allocatable :: new_tests(:)
+        
+        if (allocated(tests)) then 
+            n = size(tests)
+        else
+            n = 0
+        end if
+        
+        allocate(new_tests(n+1))
+        if (n>0) new_tests(1:n) = tests(1:n)
+                 new_tests(1+n) = new_test
+        call move_alloc(from=new_tests,to=tests)        
+        
+    end subroutine add_test
 
 end module test_linalg_schur
 

--- a/test/linalg/test_linalg_solve.fypp
+++ b/test/linalg/test_linalg_solve.fypp
@@ -152,7 +152,7 @@ module test_linalg_solve
     #:endfor
     
     ! gcc-15 bugfix utility
-    pure subroutine add_test(tests,new_test)
+    subroutine add_test(tests,new_test)
         type(unittest_type), allocatable, intent(inout) :: tests(:)    
         type(unittest_type), intent(in) :: new_test
         

--- a/test/linalg/test_linalg_solve.fypp
+++ b/test/linalg/test_linalg_solve.fypp
@@ -22,13 +22,13 @@ module test_linalg_solve
         allocate(tests(0))
 
         #:for rk,rt,ri in REAL_KINDS_TYPES
-        tests = [tests,new_unittest("solve_${ri}$",test_${ri}$_solve), &
-                       new_unittest("solve_${ri}$_multiple",test_${ri}$_solve_multiple)]
+        call add_test(tests,new_unittest("solve_${ri}$",test_${ri}$_solve))
+        call add_test(tests,new_unittest("solve_${ri}$_multiple",test_${ri}$_solve_multiple))
         #:endfor
 
         #:for ck,ct,ci in CMPLX_KINDS_TYPES
-        tests = [tests,new_unittest("solve_complex_${ci}$",test_${ci}$_solve), &
-                       new_unittest("solve_2x2_complex_${ci}$",test_2x2_${ci}$_solve)]
+        call add_test(tests,new_unittest("solve_complex_${ci}$",test_${ci}$_solve))
+        call add_test(tests,new_unittest("solve_2x2_complex_${ci}$",test_2x2_${ci}$_solve))
         #:endfor
 
     end subroutine test_linear_systems    
@@ -150,7 +150,28 @@ module test_linalg_solve
 
     end subroutine test_2x2_${ri}$_solve
     #:endfor
-
+    
+    ! gcc-15 bugfix utility
+    pure subroutine add_test(tests,new_test)
+        type(unittest_type), allocatable, intent(inout) :: tests(:)    
+        type(unittest_type), intent(in) :: new_test
+        
+        integer :: n
+        type(unittest_type), allocatable :: new_tests(:)
+        
+        if (allocated(tests)) then 
+            n = size(tests)
+        else
+            n = 0
+        end if
+        
+        allocate(new_tests(n+1))
+        if (n>0) new_tests(1:n) = tests(1:n)
+                 new_tests(1+n) = new_test
+        call move_alloc(from=new_tests,to=tests)        
+    
+    end subroutine add_test
+    
 end module test_linalg_solve
 
 program test_solve

--- a/test/linalg/test_linalg_svd.fypp
+++ b/test/linalg/test_linalg_svd.fypp
@@ -265,7 +265,7 @@ module test_linalg_svd
     #:endfor
 
     ! gcc-15 bugfix utility
-    pure subroutine add_test(tests,new_test)
+    subroutine add_test(tests,new_test)
         type(unittest_type), allocatable, intent(inout) :: tests(:)    
         type(unittest_type), intent(in) :: new_test
         

--- a/test/linalg/test_linalg_svd.fypp
+++ b/test/linalg/test_linalg_svd.fypp
@@ -20,15 +20,15 @@ module test_linalg_svd
         allocate(tests(0))
 
         #:for rk,rt,ri in REAL_KINDS_TYPES
-        tests = [tests,new_unittest("test_svd_${ri}$",test_svd_${ri}$)]        
+        call add_test(tests,new_unittest("test_svd_${ri}$",test_svd_${ri}$))        
         #:endfor
 
         #:for ck,ct,ci in CMPLX_KINDS_TYPES
-        tests = [tests,new_unittest("test_complex_svd_${ci}$",test_complex_svd_${ci}$)]        
+        call add_test(tests,new_unittest("test_complex_svd_${ci}$",test_complex_svd_${ci}$))        
         #:endfor
 
         #:for rk,rt,ri in RC_KINDS_TYPES
-        tests = [tests,new_unittest("test_svd_row_${ri}$",test_svd_row_${ri}$)]         
+        call add_test(tests,new_unittest("test_svd_row_${ri}$",test_svd_row_${ri}$))         
         #:endfor
 
     end subroutine test_svd
@@ -264,6 +264,26 @@ module test_linalg_svd
 
     #:endfor
 
+    ! gcc-15 bugfix utility
+    pure subroutine add_test(tests,new_test)
+        type(unittest_type), allocatable, intent(inout) :: tests(:)    
+        type(unittest_type), intent(in) :: new_test
+        
+        integer :: n
+        type(unittest_type), allocatable :: new_tests(:)
+        
+        if (allocated(tests)) then 
+            n = size(tests)
+        else
+            n = 0
+        end if
+        
+        allocate(new_tests(n+1))
+        if (n>0) new_tests(1:n) = tests(1:n)
+                 new_tests(1+n) = new_test
+        call move_alloc(from=new_tests,to=tests)        
+    
+    end subroutine add_test
 
 end module test_linalg_svd
 

--- a/test/stringlist/test_append_prepend.f90
+++ b/test/stringlist/test_append_prepend.f90
@@ -102,8 +102,7 @@ contains
                                     & reference_list /= work_list" )
 
             reference_list = all_strings(i-stride+1:i) // reference_list
-            call check( reference_list == &
-                            & [ ( string_type( to_string(j) ), j = i - stride + 1, last ) ], &
+            call check( reference_list == all_strings(i-stride+1:last), &
                             & "test_append_prepend_array: reference_list ==&
                             & [ ( string_type( to_string(j) ), j = i - stride + 1, last ) ]" )
 

--- a/test/stringlist/test_append_prepend.f90
+++ b/test/stringlist/test_append_prepend.f90
@@ -16,6 +16,11 @@ contains
         integer, parameter              :: first = -100
         integer, parameter              :: last = 100
         character(len=:), allocatable   :: string
+        type(string_type)               :: all_strings(first:last)
+        
+        do concurrent (i=first:last)
+            all_strings(i) = string_type( to_string(i) )
+        end do        
 
         do i = first, last
             string = to_string(i)
@@ -26,10 +31,10 @@ contains
         end do
 
         call compare_list( work_list, first, last + 1, 1 )
-        call check( work_list == [ ( string_type( to_string(i) ), i = first, last ) ], &
+        call check( work_list == all_strings, &
                         & "test_append_prepend_string: work_list ==&
                         & [ ( string_type( to_string(i) ), i = first, last ) ]" )
-        call check( [ ( string_type( to_string(i) ), i = first, last ) ] == work_list, &
+        call check( all_strings == work_list, &
                         & "test_append_prepend_string: [ ( string_type( to_string(i) ),&
                         & i = first, last ) ] == work_list" )
 
@@ -47,9 +52,9 @@ contains
         end do
 
         call compare_list( reference_list, first, last + 1, 2 )
-        call check( reference_list == [ ( string_type( to_string(i) ), i = first, last ) ], "test_append_prepend_string:&
+        call check( reference_list == all_strings, "test_append_prepend_string:&
                     & reference_list == [ ( string_type( to_string(i) ), i = first, last ) ]" )
-        call check( [ ( string_type( to_string(i) ), i = first, last ) ] == reference_list, &
+        call check( all_strings == reference_list, &
                     & "test_append_prepend_string: [ ( string_type( to_string(i) ), i = first, last ) ] == reference_list" )
 
         call check( work_list == reference_list, "test_append_prepend_string:&
@@ -66,10 +71,15 @@ contains
         integer, parameter              :: first = -100
         integer, parameter              :: last = 100
         integer, parameter              :: stride = 10
+        type(string_type)               :: all_strings(first:last)
+        
+        do concurrent (j=first:last)
+            all_strings(j) = string_type( to_string(j) )
+        end do   
 
         do i = first, last - 1, stride
-            work_list = work_list // [ ( string_type( to_string(j) ), j = i, i + stride - 1) ]
-            call check( work_list == [ ( string_type( to_string(j) ), j = first, i + stride - 1) ], &
+            work_list = work_list // all_strings(i:i+stride-1)
+            call check( work_list == all_strings(first:i+stride-1), &
                     & "test_append_prepend_array: work_list ==&
                     & [ ( string_type( to_string(j) ), j = first, i + stride - 1) ]" )
 
@@ -78,10 +88,10 @@ contains
         work_list = work_list // to_string(last)
 
         call compare_list( work_list, first, last + 1, 3 )
-        call check( work_list == [ ( string_type( to_string(i) ), i = first, last) ], &
+        call check( work_list == all_strings, &
                     & "test_append_prepend_array: work_list ==&
                     & [ ( string_type( to_string(i) ), i = first, last) ]" )
-        call check( [ ( string_type( to_string(i) ), i = first, last) ] == work_list, &
+        call check( all_strings == work_list, &
                     & "test_append_prepend_array: [ ( string_type( to_string(i) ), i = first, last) ]&
                     & == work_list" )
 
@@ -91,8 +101,7 @@ contains
             call check( reference_list /= work_list, "test_append_prepend_array:&
                                     & reference_list /= work_list" )
 
-            reference_list = [ ( string_type( to_string(j) ), j = i - stride + 1, i ) ] &
-                            & // reference_list
+            reference_list = all_strings(i-stride+1:i) // reference_list
             call check( reference_list == &
                             & [ ( string_type( to_string(j) ), j = i - stride + 1, last ) ], &
                             & "test_append_prepend_array: reference_list ==&
@@ -103,10 +112,10 @@ contains
         reference_list = to_string(first) // reference_list
 
         call compare_list( reference_list, first, last + 1, 4 )
-        call check( [ ( string_type( to_string(i) ), i = first, last) ] == reference_list, &
+        call check( all_strings == reference_list, &
                     & "test_append_prepend_array:&
                     & [ ( string_type( to_string(i) ), i = first, last) ] == reference_list" )
-        call check( [ ( string_type( to_string(i) ), i = first, last) ] == reference_list, &
+        call check( all_strings == reference_list, &
                     & "test_append_prepend_array: [ ( string_type( to_string(i) ), i = first, last) ]&
                     & == reference_list" )
 
@@ -124,6 +133,11 @@ contains
         integer, parameter              :: first = -100
         integer, parameter              :: last = 100
         integer, parameter              :: stride = 10
+        type(string_type)               :: all_strings(first:last)
+        
+        do concurrent (j=first:last)
+            all_strings(j) = string_type( to_string(j) )
+        end do   
 
         do i = first, last - 1, stride
             call temp_list%clear()
@@ -132,7 +146,7 @@ contains
             end do
             work_list = work_list // temp_list
             
-            call check( work_list == [ ( string_type( to_string(j) ), j = first, i + stride - 1 ) ], &
+            call check( work_list == all_strings(first:i+stride-1), &
                     & "test_append_prepend_list: work_list ==&
                     & [ ( to_string(j), j = first, i + stride - 1) ]" )
 
@@ -141,9 +155,9 @@ contains
         work_list = work_list // to_string(last)
 
         call compare_list( work_list, first, last + 1, 5 )
-        call check( work_list == [ ( string_type( to_string(i) ), i = first, last) ], "test_append_prepend_list:&
+        call check( work_list == all_strings, "test_append_prepend_list:&
                     & work_list == [ ( string_type( to_string(i) ), i = first, last) ]" )
-        call check( [ ( string_type( to_string(i) ), i = first, last) ] == work_list, &
+        call check( all_strings == work_list, &
                     & "test_append_prepend_list: [ ( string_type( to_string(i) ), i = first, last) ]&
                     & == work_list" )
 
@@ -160,7 +174,7 @@ contains
             reference_list = temp_list // reference_list
 
             call check( reference_list == &
-                            & [ ( string_type( to_string(j) ), j = i - stride + 1, last ) ], &
+                            & all_strings(i-stride+1:last), &
                             & "test_append_prepend_list: reference_list ==&
                             & [ ( string_type( to_string(j) ), j = i - stride + 1, last ) ]" )
 
@@ -169,10 +183,10 @@ contains
         reference_list = to_string(first) // reference_list
 
         call compare_list( reference_list, first, last + 1, 6 )
-        call check( [ ( string_type( to_string(i) ), i = first, last) ] == reference_list, &
+        call check( all_strings == reference_list, &
                     & "test_append_prepend_list:&
                     & [ ( string_type( to_string(i) ), i = first, last) ] == reference_list" )
-        call check( [ ( string_type( to_string(i) ), i = first, last) ] == reference_list, &
+        call check( all_strings == reference_list, &
                     & "test_append_prepend_list: [ ( string_type( to_string(i) ), i = first, last) ]&
                     & == reference_list" )
 

--- a/test/stringlist/test_insert_at.f90
+++ b/test/stringlist/test_insert_at.f90
@@ -204,42 +204,41 @@ contains
         integer, parameter              :: first = -100
         integer, parameter              :: last = 100
         integer, parameter              :: stride = 4
+        type(string_type)               :: all_strings(first:last)
 
         write (*,*) "test_insert_at_array:    Starting work_list!"
+        
+        do concurrent (j=first:last)
+            all_strings(j) = string_type( to_string(j) )
+        end do
 
-        call work_list%insert_at( list_head, &
-                        & [ ( string_type( to_string(j) ), j = first, first + stride - 1 ) ] )
+        call work_list%insert_at( list_head, all_strings(first:first+stride-1) )
 
         call compare_list( work_list, first, first + stride, 5 )
 
-        call work_list%insert_at( list_tail, &
-                        & [ ( string_type( to_string(j) ), j = last - stride, last - 1 ) ] )
+        call work_list%insert_at( list_tail, all_strings(last-stride:last-1) )
 
         do i = first + stride, last - stride - 1, stride
-            call work_list%insert_at( fidx( i - first + 1 ), &
-                        & [ ( string_type( to_string(j) ), j = i, i + stride - 1 ) ] )
+            call work_list%insert_at( fidx( i - first + 1 ), all_strings(i:i+stride-1) )
         end do
 
-        call work_list%insert_at( list_tail, [ to_string(last) ] )
+        call work_list%insert_at( list_tail, all_strings(last:last) )
 
         call compare_list( work_list, first, last + 1, 6 )
 
         write (*,*) "test_insert_at_array:    Starting reference_list!"
 
-        call reference_list%insert_at( list_tail, &
-                        & [ ( string_type( to_string(j) ), j = last - stride + 1, last ) ] )
+        call reference_list%insert_at( list_tail, all_strings (last-stride+1:last) )
 
         call compare_list( reference_list, last - stride + 1, last + 1, 7 )
 
-        call reference_list%insert_at( list_head, &
-                        & [ ( string_type( to_string(j) ), j = first + 1, first + stride ) ] )
+        call reference_list%insert_at( list_head, all_strings(first+1:first+stride) )
 
         do i = last - stride, first + stride + 1, -1 * stride
-            call reference_list%insert_at( bidx( last - i + 1 ), &
-                        & [ ( string_type( to_string(j) ), j = i - stride + 1, i ) ] )
+            call reference_list%insert_at( bidx( last - i + 1 ), all_strings(i-stride+1:i) )
         end do
 
-        call reference_list%insert_at( list_head, [ to_string(first) ] )
+        call reference_list%insert_at( list_head, all_strings(first:first) )
 
         call compare_list( reference_list, first, last + 1, 8 )
 
@@ -252,12 +251,17 @@ contains
         integer, parameter              :: first = -100
         integer, parameter              :: last = 100
         integer, parameter              :: stride = 4
+        type(string_type)               :: all_strings(first:last)
 
         write (*,*) "test_insert_at_list:     Starting work_list!"
+        
+        do concurrent (j=first:last)
+            all_strings(j) = string_type( to_string(j) )
+        end do        
 
         call temp_list%clear()
         do j = first, first + stride - 1
-            call temp_list%insert_at( list_tail, string_type( to_string(j) ) )
+            call temp_list%insert_at( list_tail, all_strings(j) )
         end do
 
         call work_list%insert_at(list_head, temp_list)
@@ -265,7 +269,7 @@ contains
 
         call temp_list%clear()
         do j = last - 1, last - stride, -1
-            call temp_list%insert_at( list_head, string_type( to_string(j) ) )
+            call temp_list%insert_at( list_head, all_strings(j) )
         end do
 
         call work_list%insert_at(list_tail, temp_list)
@@ -280,7 +284,7 @@ contains
         end do
 
         call temp_list%clear()
-        call temp_list%insert_at( list_head, to_string(last) )
+        call temp_list%insert_at( list_head, all_strings(last) )
         call work_list%insert_at( list_tail, temp_list )
 
         call compare_list( work_list, first, last + 1, 10 )


### PR DESCRIPTION
Introduces workarounds for known gcc-15 issues: 
- tests: replace array constructors `tests = [tests, new_unittest(...)]` with a tiny helper function `add_test`
- strings: do not use array constructors `[string_t(), string_t(),...]`
- build: add `-Wno-external-argument-mismatch` (to be replaced by PR #1007 when merged). 

cc: @jvdp1 @zoziha @jalvesz 
