### PR TITLE
fix: index handling in `chomp`

### DIFF
--- a/src/stdlib_strings.fypp
+++ b/src/stdlib_strings.fypp
@@ -303,8 +303,12 @@ contains
         last = len(string)
         nsub = len(substring)
         if (nsub > 0 .and. nsub <= last) then
-            do while(last >= nsub .and. string(last-nsub+1:last) == substring)
-                last = last - nsub
+            do while(last >= nsub)
+                if (string(last-nsub+1:last) == substring) then
+                    last = last - nsub
+                else
+                    exit
+                end if
             end do
         end if
 

--- a/src/stdlib_strings.fypp
+++ b/src/stdlib_strings.fypp
@@ -302,11 +302,17 @@ contains
 
         last = len(string)
         nsub = len(substring)
-        if (nsub > 0) then
-            do while(string(last-nsub+1:last) == substring)
+        if (nsub > 0 .and. nsub <= last) then
+            do while(last >= nsub .and. string(last-nsub+1:last) == substring)
                 last = last - nsub
             end do
         end if
+
+        if (last <= 0) then
+            chomped_string = ''
+            return
+        end if
+
         chomped_string = string(1:last)
 
     end function chomp_substring_char_char

--- a/test/string/test_string_strip_chomp.f90
+++ b/test/string/test_string_strip_chomp.f90
@@ -151,6 +151,8 @@ contains
         call check(error, chomp("hellooooo", "oo") == "hello")
         if (allocated(error)) return
         call check(error, chomp("hellooooo", substring="oo") == "hello")
+        if (allocated(error)) return
+        call check(error, chomp("helhel", substring="hel") == "")
     end subroutine test_chomp_substring_char
 
     subroutine test_chomp_substring_string(error)


### PR DESCRIPTION
To prevent any indices from becoming non-positive

Cause of CI failures in #999 
