### PR TITLE
CMake: isssue with an "add_library" added in #1033

### DIFF
--- a/cmake/stdlib.cmake
+++ b/cmake/stdlib.cmake
@@ -69,7 +69,7 @@ function(configure_stdlib_target target_name regular_sources_var fypp_files_var 
     list(APPEND all_sources ${${regular_sources_var}})
 
     add_library(${target_name} ${all_sources})
-    add_library(${PROJECT_NAME}::${target_name} ALIAS ${target_name})
+    #add_library(${PROJECT_NAME}::${target_name} ALIAS ${target_name})
 
     set_target_properties(
       ${target_name}


### PR DESCRIPTION
Following the changes in #1033, the following Cmake directives are broken:
```cmake
...
  if("${method}" STREQUAL "fetch")
    message(STATUS "Retrieving ${_lib} from ${_url}")
    include(FetchContent)
    FetchContent_Declare(
      "${_lib}"
      GIT_REPOSITORY "${_url}"
      GIT_TAG "HEAD"
      )
    FetchContent_MakeAvailable("${_lib}")

    add_library("${_lib}::${_lib}" INTERFACE IMPORTED)
    target_link_libraries("${_lib}::${_lib}" INTERFACE "${_lib}")

    # We need the module directory in the subproject before we finish the configure stage
    FetchContent_GetProperties("${_lib}" SOURCE_DIR "${_pkg}_SOURCE_DIR")
    FetchContent_GetProperties("${_lib}" BINARY_DIR "${_pkg}_BINARY_DIR")
    if(NOT EXISTS "${${_pkg}_BINARY_DIR}/mod_files")
      make_directory("${${_pkg}_BINARY_DIR}/mod_files")
    endif()

    break()
  endif()

...
```

Commenting out the directive `add_library(${PROJECT_NAME}::${target_name} ALIAS ${target_name})` introduced in #1033 solved my issue. However, I am not an experxt in CMake. So, is this required?