### PR TITLE
Added code_coverage support.

### DIFF
--- a/.github/workflows/fpm-deployment.yml
+++ b/.github/workflows/fpm-deployment.yml
@@ -2,10 +2,6 @@ name: fpm-deployment
 
 on: [push, pull_request]
 
-env:
-  FPM_VERSION: 'v0.12.0'  # FPM version
-  SETUP_FPM_VERSION: 'v8' # setup-fpm action version
-
 jobs:
   deploy:
     name: Run tests and deploys the fpm branches
@@ -36,9 +32,9 @@ jobs:
           version: ${{ matrix.toolchain.version }}
 
       - name: Setup Fortran Package Manager
-        uses: fortran-lang/setup-fpm@${{ env.SETUP_FPM_VERSION }}
+        uses: fortran-lang/setup-fpm@v8
         with:
-          fpm-version: ${{ env.FPM_VERSION }}
+          fpm-version: v0.12.0
 
       - run: | # Just for deployment: create stdlib-fpm folder
           python config/fypp_deployment.py --deploy_stdlib_fpm
@@ -90,9 +86,9 @@ jobs:
           version: ${{ matrix.toolchain.version }}
 
       - name: Setup Fortran Package Manager
-        uses: fortran-lang/setup-fpm@${{ env.SETUP_FPM_VERSION }}
+        uses: fortran-lang/setup-fpm@v8
         with:
-          fpm-version: ${{ env.FPM_VERSION }}
+          fpm-version: v0.12.0
 
       - name: Prepare for code coverage
         if: contains( matrix.os, 'ubuntu')


### PR DESCRIPTION
Following the discussion in https://github.com/fortran-lang/stdlib/issues/937, this PR add code coverage to stdlib using [codecov](https://app.codecov.io/).

## Key facts

- Extends the `fpm-deployment.yml` Action with code coverage.
- Uses fpm to run the test with the added -coverage flag added for compilation with gfortran.
- Use the release profile with xdp and qp turned on.
- Automatically upload the coverage report to codecov
- Requires a CODECOV_TOKEN to be set up in the settings of the repo. This should be done by the one of the org owners I believe.

Ping: @perazz, @jalvesz, @jvdp1 

PS : This is a re-opening of #1024 which was closed when I randomly decided to delete my fork.