### PR TITLE
Upgrade of doc deploymenent CI/CD

### DIFF
--- a/.github/workflows/doc-deployment.yml
+++ b/.github/workflows/doc-deployment.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -v ford==7.0.5
+          pip install -v ford==7.0.12
           pip install fypp
           python --version
           ford --version


### PR DESCRIPTION
Issue: `ford 3.0.5` has issue with `python` >=`3.14`

Proposal:
* Upgrade of `ford` to the latest version