### PR TITLE
Fix(tridiagonal_matrices): spmv y vector overwrite and missing error check in impure init functions

### DIFF
--- a/src/stdlib_specialmatrices_tridiagonal.fypp
+++ b/src/stdlib_specialmatrices_tridiagonal.fypp
@@ -69,9 +69,9 @@ submodule (stdlib_specialmatrices) tridiagonal_matrices
             call linalg_error_handling(err0)
         endif
         ! Matrix elements.
-        A%dl = [(dl, i = 1, n-1)]
-        A%dv = [(dv, i = 1, n)]
-        A%du = [(du, i = 1, n-1)]
+        allocate( A%dl(n-1), source = dl )
+        allocate( A%dv(n), source= dv )
+        allocate( A%du(n-1), source = du )
     end function
 
     module function initialize_tridiagonal_impure_${s1}$(dl, dv, du, err) result(A)
@@ -135,9 +135,9 @@ submodule (stdlib_specialmatrices) tridiagonal_matrices
             ! Description of the matrix.
             A%n = n
             ! Matrix elements.
-            A%dl = [(dl, i = 1, n-1)]
-            A%dv = [(dv, i = 1, n)]
-            A%du = [(du, i = 1, n-1)]
+            allocate( A%dl(n-1), source = dl )
+            allocate( A%dv(n), source= dv )
+            allocate( A%du(n-1), source = du )
         endif
     end function
     #:endfor

--- a/test/linalg/test_linalg_specialmatrices.fypp
+++ b/test/linalg/test_linalg_specialmatrices.fypp
@@ -76,7 +76,8 @@ contains
 
                     y1 = 0.0_wp
                     call random_number(y2)
-                    y1 = alpha * matmul(Amat, x) + beta * y2 ; call spmv(A, x, y2, alpha=alpha, beta=beta)
+                    y1 = alpha * matmul(Amat, x) + beta * y2
+                    call spmv(A, x, y2, alpha=alpha, beta=beta)
                     call check(error, all_close(y1, y2), .true.)
                     if (allocated(error)) return
                 end do


### PR DESCRIPTION
Summary:
This pr fixes two issues within tridiagonal_matrices module.
1. Inside the impure functions for initializing `tridiagonal_matrices`, the matrix fields were assigned even if there was an error(for example, when the sizes of du and dl vectors differed from dv by more than one). 
2. Inside spmv subroutine, the y vector was forcefully being zeroed instead of using the passed argument.

Changes:
1. Added an `if (err0%ok())` check in the impure initialization functions.
2. Removed the unintended `y = 0.0_${k1}$` in the spmv subroutine.