### PR TITLE
Add default (mold, array_size) overloads for rvs_normal

### DIFF
--- a/doc/specs/stdlib_stats_distribution_normal.md
+++ b/doc/specs/stdlib_stats_distribution_normal.md
@@ -23,7 +23,7 @@ With two arguments, the function returns a normal distributed random variate \(N
 
 With three arguments, the function returns a rank-1 array of normal distributed random variates.
 
-With two arguments `array_size` and `mold`, the function returns a rank-1 array of standard normal distributed random variates \(N(0,1)\), where the `mold` argument is used only to determine the output type and kind.
+With one or two arguments where the first is `array_size`, the function returns a rank-1 array of standard normal distributed random variates \(N(0,1)\). The `mold` argument determines the output type and kind; it is optional only for `real(dp)` (and defaults to `real(dp)` when omitted), but required for all other types.
 
 @note
 The algorithm used for generating exponential random variates is fundamentally limited to double precision.[^1]
@@ -32,7 +32,7 @@ The algorithm used for generating exponential random variates is fundamentally l
 
 `result = ` [[stdlib_stats_distribution_normal(module):rvs_normal(interface)]] `([loc, scale] [[, array_size]])`
 
-`result = ` [[stdlib_stats_distribution_normal(module):rvs_normal(interface)]] `(array_size, mold)`
+`result = ` [[stdlib_stats_distribution_normal(module):rvs_normal(interface)]] `(array_size [, mold])`
 
 ### Class
 
@@ -44,15 +44,15 @@ Elemental function (passing both `loc` and `scale`).
 
 `scale`: optional argument has `intent(in)` and is a positive scalar of type `real` or `complex`.
 
-`array_size`: optional argument has `intent(in)` and is a scalar of type `integer`. When used with `loc` and `scale`, specifies the size of the output array. When used with `mold`, must be provided as the first argument.
+`array_size`: optional argument has `intent(in)` and is a scalar of type `integer`. When used with `loc` and `scale`, specifies the size of the output array. When used alone or with `mold`, must be provided as the first argument.
 
-`mold`: optional argument has `intent(in)` and is a scalar of type `real` or `complex`. Used only to determine the type and kind of the output; its value is not referenced. When provided, generates standard normal variates \(N(0,1)\).
+`mold`: optional argument (only for `real(dp)`; required for other types) has `intent(in)` and is a scalar of type `real` or `complex`. Used only to determine the type and kind of the output; its value is not referenced. When omitted (only allowed for `real(dp)`), defaults to `real(dp)`. When provided, generates standard normal variates \(N(0,1)\) of the specified type and kind.
 
 `loc` and `scale` arguments must be of the same type.
 
 ### Return value
 
-The result is a scalar or rank-1 array, with a size of `array_size`, and the same type as `scale` and `loc` (or same type and kind as `mold` when using the `(array_size, mold)` form). If `scale` is non-positive, the result is `NaN`.
+The result is a scalar or rank-1 array, with a size of `array_size`, and the same type as `scale` and `loc` (or same type and kind as `mold` when using the `array_size [, mold]` form; defaults to `real(dp)` when `mold` is omitted). If `scale` is non-positive, the result is `NaN`.
 
 ### Example
 

--- a/src/stdlib_stats_distribution_normal.fypp
+++ b/src/stdlib_stats_distribution_normal.fypp
@@ -33,7 +33,7 @@ module stdlib_stats_distribution_normal
 
         #:for k1, t1 in RC_KINDS_TYPES
             module procedure rvs_norm_array_${t1[0]}$${k1}$  !3 dummy variables
-            module procedure rvs_norm_array_default_${t1[0]}$${k1}$  !2 dummy variables (mold, array_size)
+            module procedure rvs_norm_array_default_${t1[0]}$${k1}$  !array_size, mold (mold optional for real(dp) only)
         #:endfor
     end interface rvs_normal
 
@@ -246,7 +246,7 @@ contains
             ! The mold argument is used only to determine the type and is not referenced
             !
             integer, intent(in) :: array_size
-            ${t1}$, intent(in) :: mold
+            ${t1}$, intent(in) #{if t1 == 'real(dp)'}#, optional #{endif}#:: mold
             ${t1}$ :: res(array_size)
 
             res = rvs_norm_array_${t1[0]}$${k1}$ (0.0_${k1}$, 1.0_${k1}$, array_size)

--- a/test/stats/test_distribution_normal.fypp
+++ b/test/stats/test_distribution_normal.fypp
@@ -164,13 +164,18 @@ contains
         call random_seed(seed, get)
 
         ! default mold form: mold used only to disambiguate kind
-        #:if t1[0] == "r"
-            mold = 0.0_${k1}$
+        ! For real(dp), mold is optional; for other types (including complex), it's required
+        #:if t1[0] == "r" and k1 == "dp"
+            a2 = nor_rvs(10)  ! mold optional for rdp only, defaults to real(dp)
         #:else
-            mold = (0.0_${k1}$, 0.0_${k1}$)
+            #! mold required for all other types including complex and non-dp kinds
+            #:if t1[0] == "r"
+                mold = 0.0_${k1}$
+            #:else
+                mold = (0.0_${k1}$, 0.0_${k1}$)
+            #:endif
+            a2 = nor_rvs(10, mold)
         #:endif
-
-        a2 = nor_rvs(10, mold)
 
         call check(all(a1 == a2), msg="normal_distribution_rvs_default_${t1[0]}$${k1}$ failed", warn=warn)
     end subroutine test_nor_rvs_default_${t1[0]}$${k1}$


### PR DESCRIPTION
Resolves #963

- Add convenience overloads for rvs_normal that accept (mold, array_size) and return standard-normal arrays (loc=0, scale=1) for both real and complex kinds.
- Add deterministic tests that compare the new (mold, array_size) call with the explicit (loc=0, scale=1, array_size) call to ensure identical behavior.