### PR TITLE
#862 Fix flaky loadtxt test for int32 by adding sleep after savetxt. .

### DIFF
--- a/test/io/test_loadtxt.f90
+++ b/test/io/test_loadtxt.f90
@@ -41,17 +41,21 @@ contains
             call random_number(harvest)
             input = int(harvest * 100)
             call savetxt('test_int32.txt', input)
+            call sleep(1)
             call loadtxt('test_int32.txt', expected)
             call check(error, all(input == expected),'Default list directed read failed')
             if (allocated(error)) return
             call loadtxt('test_int32.txt', expected, fmt='*')
+            call sleep(1)
             call check(error, all(input == expected),'User specified list directed read faile')
             if (allocated(error)) return
             call savetxt('test_int32.txt', input, delimiter=',')
+            call sleep(1)
             call loadtxt('test_int32.txt', expected, delimiter=',')
             call check(error, all(input == expected),'User specified delimiter `,` read failed')
             if (allocated(error)) return
             call savetxt('test_int32.txt', input, delimiter='-')
+            call sleep(1)
             call loadtxt('test_int32.txt', expected, delimiter='-')
             call check(error, all(input == expected),'User specified delimiter `-` read failed')
             if (allocated(error)) return
@@ -73,6 +77,7 @@ contains
             call random_number(input)
             input = input - 0.5
             call savetxt('test_sp.txt', input)
+            call sleep(1)
             call loadtxt('test_sp.txt', expected)
             call check(error, all(input == expected),'Default format read failed')
             if (allocated(error)) return
@@ -83,10 +88,12 @@ contains
             call check(error, all(input == expected),'User specified format failed')
             if (allocated(error)) return
             call savetxt('test_sp.txt', input, delimiter=',')
+            call sleep(1)
             call loadtxt('test_sp.txt', expected, delimiter=',')
             call check(error, all(input == expected),'User specified delimiter `,` read failed')
             if (allocated(error)) return
             call savetxt('test_sp.txt', input, delimiter=';')
+            call sleep(1)
             call loadtxt('test_sp.txt', expected, delimiter=';')
             call check(error, all(input == expected),'User specified delimiter `;` read failed')
             if (allocated(error)) return
@@ -165,6 +172,7 @@ contains
             call random_number(input)
             input = input - 0.5
             call savetxt('test_dp.txt', input)
+            call sleep(1)
             call loadtxt('test_dp.txt', expected)
             call check(error, all(input == expected),'Default format read failed')
             if (allocated(error)) return
@@ -175,6 +183,7 @@ contains
             call check(error, all(input == expected),'User specified format failed')
             if (allocated(error)) return
             call savetxt('test_dp.txt', input, delimiter=',')
+            call sleep(1)
             call loadtxt('test_dp.txt', expected, delimiter=',')
             call check(error, all(input == expected),'User specified delimiter read failed')
             if (allocated(error)) return
@@ -197,6 +206,7 @@ contains
                 call random_number(input)
                 input = input - 0.5
                 call savetxt('test_dp_max_skip.txt', input)
+                call sleep(1)
                 call loadtxt('test_dp_max_skip.txt', expected, skiprows=m, max_rows=n)
                 call check(error, all(input(m+1:min(n+m,10),:) == expected),'Default format read failed')
                 if (allocated(error)) return
@@ -227,6 +237,7 @@ contains
             call random_number(input)
             input = (input - 0.5) * huge(input)
             call savetxt('test_dp_huge.txt', input)
+            call sleep(1)
             call loadtxt('test_dp_huge.txt', expected)
             call check(error, all(input == expected),'Default format read failed')
             if (allocated(error)) return
@@ -255,6 +266,7 @@ contains
             call random_number(input)
             input = (input - 0.5) * tiny(input)
             call savetxt('test_dp_tiny.txt', input)
+            call sleep(1)
             call loadtxt('test_dp_tiny.txt', expected)
             call check(error, all(input == expected),'Default format read failed')
             if (allocated(error)) return
@@ -287,16 +299,19 @@ contains
             call random_number(im)
             input = cmplx(re, im)
             call savetxt('test_complex.txt', input)
+            call sleep(1)
             call loadtxt('test_complex.txt', expected)
             call check(error, all(input == expected))
             call loadtxt('test_complex.txt', expected, fmt="(*"//FMT_COMPLEX_dp(1:len(FMT_COMPLEX_dp)-1)//",1x))")
             call check(error, all(input == expected))
             if (allocated(error)) return
             call savetxt('test_complex.txt', input, delimiter=',')
+            call sleep(1)
             call loadtxt('test_complex.txt', expected, delimiter=',')
             call check(error, all(input == expected))
             if (allocated(error)) return
             call savetxt('test_complex.txt', input, delimiter=';')
+            call sleep(1)
             call loadtxt('test_complex.txt', expected, delimiter=';')
             call check(error, all(input == expected))
             if (allocated(error)) return


### PR DESCRIPTION
Added sleep calls to test_loadtxt.f90 to introduce delays between file operations.   because before file was being read even before it was writeen and closed

<!--
Thank you for contributing to stdlib.
To help us get your pull request merged more quickly, please consider reviewing any of the already open pull requests.
-->
Fixes #862

This PR addresses the intermittent failure of the `loadtxt` test for int32,
which occasionally produced:
- Fortran runtime error: Bad value during floating point read
End-of-file during read

Root cause:
The test wrote data to 'test_int32.txt' and immediately attempted to read
it with loadtxt. 
Fix:
After every call to savetxt, a short delay has been added:
call sleep(1)
This ensures the file is fully written and stable before loadtxt reads it.
This is a beginner-friendly first fix; maintainers may later improve it
using proper file flushing.
