### PR TITLE
Update macOS architecture and OS version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The following combinations are tested on the default branch of stdlib:
 Name | Version | Platform | Architecture
 --- | --- | --- | ---
 GCC Fortran | 10, 11, 12, 13, 14 | Ubuntu 24.04.3 LTS | x86_64
-GCC Fortran | 11, 12, 13, 14 | macOS 14.7.6 (23H626) | x86_64
+GCC Fortran | 11, 12, 13, 14 | macOS 14.8.2 (23J126) | Arm64
 GCC Fortran (MSYS) | 13 | Windows Server 2022 (10.0.20348 Build 1547) | x86_64
 GCC Fortran (MinGW) | 13 | Windows Server 2022 (10.0.20348 Build 1547) | x86_64
 Intel oneAPI LLVM | 2024.1 | Ubuntu 24.04.3 LTS | x86_64


### PR DESCRIPTION
<!--
Thank you for contributing to stdlib.
To help us get your pull request merged more quickly, please consider reviewing any of the already open pull requests.
-->
Closes #1058. The macos-14 CI runner is based on Arm64, so the compiler table in README.md has been updated to reflect this. Also, the macOS version number has been updated. @jvdp1