### PR TITLE
add null-terminated buffer allocation and copying

### DIFF
--- a/src/stdlib_system.c
+++ b/src/stdlib_system.c
@@ -105,8 +105,13 @@ char* stdlib_get_cwd(size_t* len, int* stat){
 
     *len = strlen(buffer);
 
-    char* res = malloc(*len);
+    char* res = malloc(*len + 1);  // Allocate space for null terminator
+    if (res == NULL) {
+        *stat = ENOMEM;  // Set error code for memory allocation failure
+        return NULL;
+    }
     strncpy(res, buffer, *len);
+    res[*len] = '\0';  // Ensure null termination
 
     return res;
 #endif /* ifdef _WIN32 */
@@ -115,7 +120,7 @@ char* stdlib_get_cwd(size_t* len, int* stat){
 // Wrapper to the platform's `chdir`(change directory) call.
 // Uses `chdir` on unix, `_chdir` on windows.
 // Returns 0 if successful, otherwise returns the `errno`.
-int stdlib_set_cwd(char* path) {
+int stdlib_set_cwd(const char* path) {
     int code;
 #ifdef _WIN32
     code = _chdir(path);


### PR DESCRIPTION
**Buffer Allocation:** Changed malloc(*len) to malloc(*len + 1) to effectively reserve space for the null terminator.

**Robustness:** Added a critical check if (res == NULL) to handle memory allocation failures safely, returning ENOMEM.

**Safety:** Added explicit res[*len] = '\0' to guarantee the string is null-terminated.

**Const Correctness:** Updated stdlib_set_cwd to take const char* path.
