### PR TITLE
Addition of tables summarizing preprocessing macros and flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,10 +257,9 @@ with `prog` being the name of the example program (e.g., `example_sort`).
 `stdlib` uses two preprocessing steps:
 
 - *fypp* for meta-programming (templating and feature selection)
-- *C* preprocessing (compiler flag `-cpp`/`-fpp`) for conditional compilation
+- *C* preprocessing (activated through compiler flags like `-cpp`(GNU) or `-fpp`(Intel) or use of uppercase file suffix .F90) for conditional compilation
 
-*fypp* preprocessing macros and flags are supported only through `CMake` and the
-`python` script `config/fypp_deployment.sh`.
+*fypp* preprocessing macros and flags are supported through `CMake` or the `python` script `config/fypp_deployment.py`.
 *C* preprocessing macros and flags are supported through `CMake` and `fpm`.
 
 The table below lists all *fypp* preprocessing macros and flags currently used by `stdlib`:


### PR DESCRIPTION
As suggested by @jalvesz in [his comment](https://github.com/fortran-lang/stdlib/pull/1081#issuecomment-3708510700), here is a PR to introduce tables that summarize fypp and C-preprocessing flags and macros.