### PR TITLE
Add validation for op argument in spmv routine for special matrices

### DIFF
--- a/src/specialmatrices/stdlib_specialmatrices_tridiagonal.fypp
+++ b/src/specialmatrices/stdlib_specialmatrices_tridiagonal.fypp
@@ -174,8 +174,8 @@ submodule (stdlib_specialmatrices) tridiagonal_matrices
         #:endif
 
         if(present(op)) then
-            if(.not.(op == "N" .or. op == "T" .or. op == "C")) then
-                err0 = linalg_state_type(this, LINALG_VALUE_ERROR, "Invalid matrix operation; expected 'N', 'T', or 'C'.")
+            if(.not.(op == "N" .or. op == "T" .or. op == "C" .or. op == "H")) then
+                err0 = linalg_state_type(this, LINALG_VALUE_ERROR, "Invalid matrix operation; expected 'N', 'T', 'C' or 'H'.")
                 call linalg_error_handling(err0)
             end if
         end if
@@ -184,6 +184,8 @@ submodule (stdlib_specialmatrices) tridiagonal_matrices
         alpha_ = 1.0_${k1}$ ; if (present(alpha)) alpha_ = alpha
         beta_  = 0.0_${k1}$ ; if (present(beta))  beta_  = beta
         op_    = "N"        ; if (present(op))    op_    = op
+        if (op_ == "H") op_ = "C"
+
         #:if t1.startswith('real')
         is_alpha_special = (alpha_ ==  1.0_${k1}$  .or. alpha_ ==  0.0_${k1}$  .or. alpha_ == -1.0_${k1}$)
         is_beta_special  = (beta_  ==  1.0_${k1}$  .or. beta_  ==  0.0_${k1}$  .or. beta_  == -1.0_${k1}$)


### PR DESCRIPTION
This pr adds validation for the optional argument `op` in `stdlib_specialmatrices`.
When op is present and not one of `N`, `T`, or `C`, a `LINALG_VALUE_ERROR` is raised using` linalg error handling`.