### PR TITLE
Fixes mistype in version documentation

### DIFF
--- a/doc/specs/stdlib_version.md
+++ b/doc/specs/stdlib_version.md
@@ -34,11 +34,11 @@ Experimental
 
 #### Description
 
-Getter function to retrieve version information
+Getter subroutine to retrieve version information
 
 #### Syntax
 
-`res = ` [[stdlib_version(module):get_stdlib_version(subroutine)]] ` ([major], [minor], [patch], [string])`
+`call ` [[stdlib_version(module):get_stdlib_version(subroutine)]] ` ([major], [minor], [patch], [string])`
 
 #### Class
 


### PR DESCRIPTION
It stated that `get_stdlib_version()` was a function but it really is a subroutine
