### PR TITLE
Fix: Race Condition in Parallel Fypp Preprocessing

### DIFF
--- a/config/fypp_deployment.py
+++ b/config/fypp_deployment.py
@@ -47,11 +47,9 @@ def pre_process_fypp(args):
         options.line_numbering = True
     tool = fypp.Fypp(options)
 
-    # Check destination folder for preprocessing. if not 'stdlib-fpm', it is assumed to be the root folder.
-    if not os.path.exists('src'+os.sep+'temp'):
-        os.makedirs('src'+os.sep+'temp')
-    if not os.path.exists('test'+os.sep+'temp'):
-        os.makedirs('test'+os.sep+'temp')
+    # Create destination folders for preprocessing
+    os.makedirs('src'+os.sep+'temp', exist_ok=True)
+    os.makedirs('test'+os.sep+'temp', exist_ok=True)
 
     # Define the folders to search for *.fypp files
     folders = ['src','test']
@@ -63,8 +61,7 @@ def pre_process_fypp(args):
     def process_f(file):
         source_file = file
         root = os.path.dirname(file)
-        if not os.path.exists(root+os.sep+'temp'):
-            os.makedirs(root+os.sep+'temp')
+        os.makedirs(root+os.sep+'temp', exist_ok=True)
         basename = os.path.splitext(os.path.basename(source_file))[0]
         sfx = 'f90' if basename not in C_PREPROCESSED else 'F90'
         target_file = root+os.sep+'temp' + os.sep + basename + '.' + sfx
@@ -89,14 +86,10 @@ def deploy_stdlib_fpm(with_ilp64):
     else:
         base_folder = 'stdlib-fpm'        
 
-    if not os.path.exists(base_folder+os.sep+'include'):
-        os.makedirs(base_folder+os.sep+'include')
-    if not os.path.exists(base_folder+os.sep+'src'):
-        os.makedirs(base_folder+os.sep+'src')
-    if not os.path.exists(base_folder+os.sep+'test'):
-        os.makedirs(base_folder+os.sep+'test')
-    if not os.path.exists(base_folder+os.sep+'example'):
-        os.makedirs(base_folder+os.sep+'example')
+    os.makedirs(base_folder+os.sep+'include', exist_ok=True)
+    os.makedirs(base_folder+os.sep+'src', exist_ok=True)
+    os.makedirs(base_folder+os.sep+'test', exist_ok=True)
+    os.makedirs(base_folder+os.sep+'example', exist_ok=True)
 
     def recursive_copy(folder):
         for root, _, files in os.walk(folder):


### PR DESCRIPTION
**Problem**
When building stdlib with parallel fypp preprocessing `--njob > 1` the build intermittently fails with:
`FileExistsError: [Errno 17] File exists: 'src/math/temp'`

**Solution**
Replaced the check-then-create pattern with `os.makedirs(path, exist_ok=True)` to prevent race conditions when parallel jobs attempt to create the same directory simultaneously. This atomic approach eliminates intermittent `FileExistsError` failures in CI builds with `--njob > 1`.