### PR TITLE
Reduce occurrences of intrinsic stdlib_matmul test failures

### DIFF
--- a/test/intrinsics/test_intrinsics.fypp
+++ b/test/intrinsics/test_intrinsics.fypp
@@ -292,14 +292,14 @@ subroutine test_matmul(error)
         call random_number(z)
 
         ! Normalize matrices.
-        x = x / mnorm(x, "fro")
-        y = y / mnorm(y, "fro")
-        z = z / mnorm(z, "fro")
+        x = x / mnorm(x, 1)
+        y = y / mnorm(y, 1)
+        z = z / mnorm(z, 1)
 
         r = stdlib_matmul(x, y, z) ! the optimal ordering would be (x(yz))
         r1 = matmul(matmul(x, y), z) ! the opposite order to induce a difference
 
-        call check(error, mnorm(r-r1, "fro") <= n*epsilon(0._${k}$), "real, ${k}$, 3 args: error too large")
+        call check(error, mnorm(r-r1, 1) <= n*epsilon(0._${k}$), "real, ${k}$, 3 args: error too large")
         if (allocated(error)) return
     end block
 
@@ -312,15 +312,15 @@ subroutine test_matmul(error)
         call random_number(w)
 
         ! Normalize matrices.
-        x = x / mnorm(x, "fro")
-        y = y / mnorm(y, "fro")
-        z = z / mnorm(z, "fro")
-        w = w / mnorm(w, "fro")
+        x = x / mnorm(x, 1)
+        y = y / mnorm(y, 1)
+        z = z / mnorm(z, 1)
+        w = w / mnorm(w, 1)
 
         r = stdlib_matmul(x, y, z, w) ! the optimal order would be ((x(yz))w)
         r1 = matmul(matmul(x, y), matmul(z, w))
 
-        call check(error, mnorm(r-r1, "fro") <= n*epsilon(0._${k}$), "real, ${k}$, 4 args: error too large")
+        call check(error, mnorm(r-r1, 1) <= n*epsilon(0._${k}$), "real, ${k}$, 4 args: error too large")
         if (allocated(error)) return
     end block
     #:endfor


### PR DESCRIPTION
Following the discussion in #1086 about the intrinsic test failure, this PR implements the following changes to the `test_matmul` (intrinsic module) :
- All matrices used in the test have now been normalized to have unit-norm (1-norm).
- The error check has been replaced from element-wise checks to 1-norm norm of the difference.

As far as I can recall, the error estimates are basically correct, although sharper ones could be used but I haven't been able to find my old lecture notes yet about matrix-matrix multiplications and floating point error analysis. In the mean time, this should (hopefully) reduce the number of times the CI fails on these tests. Something similar could be done with the `pseudoinverse` tests which do fail quite regularly (the single precision mostly I believe).

ping: @perazz, @jvdp1, @jalvesz 