### PR TITLE
build: fix absolute paths for external BLAS/LAPACK in pkg-config export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 Changes to the existing build system
-- Fixed absolute paths in generated pkg-config file for external BLAS/LAPACK 
+  - Fixed absolute paths in generated pkg-config file for external BLAS/LAPACK 
     [#1109](https://github.com/fortran-lang/stdlib/issues/1109)
 
 # Version 0.8.1

--- a/config/template.pc
+++ b/config/template.pc
@@ -6,7 +6,7 @@ moduledir=${prefix}/@CMAKE_INSTALL_MODULEDIR@
 Name: @PROJECT_NAME@
 Description: @PROJECT_DESCRIPTION@
 Version: @PROJECT_VERSION@
+Requires.private: @PC_REQUIRES_PRIVATE@
+Cflags: -I${includedir} -I${moduledir}
 Libs: -L${libdir} @PC_CONTENT@
 Libs.private: @PC_LIBS_PRIVATE@
-Cflags: -I${includedir} -I${moduledir}
-Requires.private: @PC_REQUIRES_PRIVATE@


### PR DESCRIPTION
This PR addresses **Issue #1109**, preventing absolute filesystem paths to external BLAS/LAPACK libraries from being hardcoded into the generated fortran_stdlib.pc file.

### **Technical Changes**

1. **Target Interception**: Modified `config/export_pc.cmake` to add `BLAS::BLAS` and `LAPACK::LAPACK` to a skip list during recursive resolution.

2. **Vendor Discovery**: Implemented a probing mechanism using `pkg_check_modules` to identify known BLAS/LAPACK vendor package names (OpenBLAS, MKL, Netlib).

3. **Metadata Separation:** >     * Found packages are correctly added to `Requires.private`.

   - Added a `libs_to_linker_flags` fallback to convert absolute paths to portable `-l` flags (e.g., `-lopenblas`) if no `.pc` file is found.

4. **Template Update**: Updated `config/template.pc` to support `Requires.private` and `Libs.private` fields for better portability.

### **Verification Results (Windows 11, MinGW-W64)**

<img width="490" height="148" alt="image" src="https://github.com/user-attachments/assets/42bc735a-ae8f-437e-8f4c-691802fbbff0" />
