### PR TITLE
fix: prevent double-prefixing of absolute install paths in pkg-config

### DIFF
--- a/config/export_pc.cmake
+++ b/config/export_pc.cmake
@@ -183,6 +183,27 @@ endif()
 string(REPLACE ";" " " PC_REQUIRES_PRIVATE "${PC_REQUIRES_PRIVATE}")
 string(REPLACE ";" " " PC_LIBS_PRIVATE "${PC_LIBS_PRIVATE}")
 
+# Handle absolute vs relative install paths for libdir
+if(IS_ABSOLUTE "${CMAKE_INSTALL_LIBDIR}")
+    set(PC_LIBDIR "${CMAKE_INSTALL_LIBDIR}")
+else()
+    set(PC_LIBDIR "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
+endif()
+
+# Handle absolute vs relative install paths for includedir
+if(IS_ABSOLUTE "${CMAKE_INSTALL_INCLUDEDIR}")
+    set(PC_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}")
+else()
+    set(PC_INCLUDEDIR "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+endif()
+
+# Handle absolute vs relative install paths for moduledir
+if(IS_ABSOLUTE "${CMAKE_INSTALL_MODULEDIR}")
+    set(PC_MODULEDIR "${CMAKE_INSTALL_MODULEDIR}")
+else()
+    set(PC_MODULEDIR "\${prefix}/${CMAKE_INSTALL_MODULEDIR}")
+endif()
+
 configure_file(
   "${CMAKE_CURRENT_SOURCE_DIR}/config/template.pc"
   "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"

--- a/config/template.pc
+++ b/config/template.pc
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
-moduledir=${prefix}/@CMAKE_INSTALL_MODULEDIR@
+libdir=@PC_LIBDIR@
+includedir=@PC_INCLUDEDIR@
+moduledir=@PC_MODULEDIR@
 
 Name: @PROJECT_NAME@
 Description: @PROJECT_DESCRIPTION@


### PR DESCRIPTION
This PR fixes a bug in the generated `fortran_stdlib.pc` where `${prefix}/` was incorrectly prepended to installation paths that were already absolute (e.g., on multiarch Linux distributions).

**Changes**

- **Path Logic**: Implemented `IS_ABSOLUTE `checks in `config/export_pc.cmake` for `libdir`, `includedir`, and `moduledir`.

- **Template Update**: Refactored `config/template.pc` to use pre-computed `@PC_*@` variables, ensuring valid paths for both relative (relocatable) and absolute (system-wide) installations.

- **Extended Fix**: Identified and resolved the same double-prefixing issue in `moduledir `during local validation.

**Verification Results**
Validated across both standard and multiarch scenarios:

<img width="770" height="160" alt="image" src="https://github.com/user-attachments/assets/eeb878d5-353f-48b9-af44-914b2a60552b" />

**Regression Testing**
Confirmed that BLAS/LAPACK dependency logic from #1118 is preserved in the `private `metadata fields.

Closes #1121
