### PR TITLE
ci: add s390x big-endian workflow for hash function tests

### DIFF
--- a/.github/workflows/ci_big_endian.yml
+++ b/.github/workflows/ci_big_endian.yml
@@ -39,7 +39,7 @@ jobs:
           # Install dependencies (cached in Docker image layer)
           install: |
             apt-get update -q -y
-            apt-get install -q -y gfortran gcc g++ cmake python3-pip ninja-build
+            apt-get install -q -y gfortran gcc g++ cmake python3-pip ninja-build git
             pip3 install --break-system-packages fypp
 
           # Build and run big-endian tests


### PR DESCRIPTION
Hi @jvdp1,

Following up on our discussion in #1130 , this PR adds a dedicated CI job to catch any future Big-Endian regressions.

It uses `uraimo/run-on-arch-action` to emulate an `s390x` (IBM Z) environment using QEMU. Since QEMU emulation is notoriously slow, I've heavily optimized the workflow so it doesn't bottleneck the rest of the project's CI or burn through Actions minutes:

* **Targeted builds:** Instead of building all of `stdlib`, it uses `cmake --build build --target test_hash_functions`. This only compiles the hash modules and their direct dependencies, completely skipping heavy modules like `linalg` or `stats`.
* **Smart triggers:** On PRs, this job will *only* run if `src/hash/`, `test/hash_functions/`, or the workflow file itself is modified. Otherwise, it just runs on merges to `master`.
* **Caching & Safety:** Uses the GitHub token to cache the `apt-get` dependency layer, and adds `--no-tests=error` to `ctest` to ensure the CI forcefully fails if the test target gets renamed in the future.

I've tested this on my fork and it successfully catches the endianness issues we just fixed. Let me know if you'd like to tweak the scope or triggers at all!