### PR TITLE
Fix mantissa overflow and precision loss in xdp/qp parsing in stdlib_str2num

### DIFF
--- a/doc/specs/stdlib_str2num.md
+++ b/doc/specs/stdlib_str2num.md
@@ -77,6 +77,6 @@ The accuracy of the conversion is implementation dependent; it is recommended th
 
 `dp`  : precision up-to 10*epsilon(0.0_dp)
 
-`qp` : precision around 200*epsilon(0.0_qp)
+`qp` : precision around 100*epsilon(0.0_qp)
 
 Where precision refers to the relative difference between `to_num` and `read`. On the other hand, `to_num` provides speed-ups ranging from 4x to >10x compared to the intrinsic `read`.

--- a/src/strings/stdlib_str2num.fypp
+++ b/src/strings/stdlib_str2num.fypp
@@ -473,7 +473,7 @@ module stdlib_str2num
             end if
         else
             if(icount<=maxdpt) then
-                v = sign*(int_dp1 + int_dp2*fractional_base(icount-maxdpt)) *10._wp**(sige*i_exp-resp+1)
+                v = sign*(int_dp1) *10._wp**(sige*i_exp-resp+1)
             else
                 v = sign*(int_dp1 + int_dp2*fractional_base(icount-maxdpt)) *10._wp**(sige*i_exp-resp+1+icount-maxdpt)
             end if
@@ -590,7 +590,7 @@ module stdlib_str2num
             end if
         else
             if(icount<=maxdpt) then
-                v = sign*(int_dp1 + int_dp2*fractional_base(icount-maxdpt)) *10._wp**(sige*i_exp-resp+1)
+                v = sign*(int_dp1) *10._wp**(sige*i_exp-resp+1)
             else
                 v = sign*(int_dp1 + int_dp2*fractional_base(icount-maxdpt)) *10._wp**(sige*i_exp-resp+1+icount-maxdpt)
             end if

--- a/test/string/test_string_to_number.fypp
+++ b/test/string/test_string_to_number.fypp
@@ -102,6 +102,9 @@ contains
         &                        "175706828388979108268586060148663818836212158203125E-44"))
         if (allocated(error)) return
 
+        call check(error, ucheck("5.405355598523852356954817904851589E-0002"))
+        if (allocated(error)) return
+
     contains
         logical function ucheck(s)
             character(*), intent(in) :: s
@@ -121,9 +124,9 @@ contains
             #:elif k1 == "dp"
             if(abs(rel_err) > 10*epsilon(0.0_wp)) then
             #:elif k1 == "xdp"
-            if(abs(rel_err) > 200*epsilon(0.0_wp)) then
+            if(abs(rel_err) > 10*epsilon(0.0_wp)) then
             #:elif k1 == "qp"
-            if(abs(rel_err) > 200*epsilon(0.0_wp)) then
+            if(abs(rel_err) > 100*epsilon(0.0_wp)) then
             #:endif
                 write(*,"('formatted read : ', g0)") formatted_read_out
                 write(*,"('to_num         : ', g0)") to_num_out


### PR DESCRIPTION
This PR fixes an issue in the `str2num` module where mantissas for `real(xdp)` and `real(qp)` could lead to overflow during integer parsing/accumulation, resulting in incorrect parsing.

The fix adjusts `maxdpt` and corrects the mantissa reconstruction formula thus improving numerical accuracy and reduced tolerance.

Thanks to @jalvesz for helping with this issue.