### PR TITLE
fix(datetime): correct divisor in civil_from_days (1461 → 1460)

### DIFF
--- a/src/datetime/stdlib_datetime.f90
+++ b/src/datetime/stdlib_datetime.f90
@@ -682,7 +682,7 @@ contains
         end if
         era = int(era64)
         doe = int(zz - era64 * 146097_int64)
-        yoe = (doe - doe/1461 + doe/36524 &
+        yoe = (doe - doe/1460 + doe/36524 &
                - doe/146096) / 365
         y = yoe + era * 400
         doy = doe - (365*yoe + yoe/4 - yoe/100)

--- a/test/datetime/test_datetime.f90
+++ b/test/datetime/test_datetime.f90
@@ -274,6 +274,19 @@ subroutine test_dt_plus_td(error)
     call check(error, res%day == 18, &
         "td + dt day should be 18 (commutative)")
     if (allocated(error)) return
+
+    dt = datetime_type(year=1996, month=2, day=28)
+    td = timedelta(days=1)
+    res = td + dt
+    call check(error, res%year == 1996, &
+        "dt + td year should be 1996")
+    if (allocated(error)) return
+    call check(error, res%month == 2, &
+        "dt + td month should be 2")
+    if (allocated(error)) return
+    call check(error, res%day == 29, &
+        "dt + td day should be 29")
+    if (allocated(error)) return
 end subroutine test_dt_plus_td
 
 subroutine test_dt_minus_td(error)


### PR DESCRIPTION
Fixing https://github.com/fortran-lang/stdlib/issues/1189

I noticed that the yoe (year of era) computation in src/stdlib_datetime.f90 differs from Howard Hinnant's reference algorithm ([date_algorithms](https://howardhinnant.github.io/date_algorithms.html)).

Reference:

`const unsigned yoe = (doe - doe/1460 + doe/36524 - doe/146096) / 365;  // [0, 399]`

Current code in stdlib_datetime.f90:

`yoe = (doe - doe/1461 + doe/36524 - doe/146096) / 365`

The divisor differs: 1460 in the reference versus 1461 here.
