### PR TITLE
Fixed a typo in documentation

### DIFF
--- a/src/strings/stdlib_string_type.fypp
+++ b/src/strings/stdlib_string_type.fypp
@@ -363,7 +363,7 @@ module stdlib_string_type
         module procedure :: write_unformatted
     end interface
 
-    !> Read a character sequence from a connected unformatted unit into the string.
+    !> Read a character sequence from a connected formatted unit into the string.
     interface read(formatted)
         module procedure :: read_formatted
     end interface


### PR DESCRIPTION
<!--
Thank you for contributing to stdlib.
To help us get your pull request merged more quickly, please consider reviewing any of the already open pull requests.
-->
Fixed a typo in stdlib_string_type.fypp where "formatted" was mis-spelled as "unformatted".
Fixes issue #1028

I noticed this issue was assigned to @manvendra5345 a while back with no recent activity, so I went ahead and submitted the fix. 
