### PR TITLE
fix : style guide violation

### DIFF
--- a/src/math/stdlib_math.fypp
+++ b/src/math/stdlib_math.fypp
@@ -379,7 +379,7 @@ module stdlib_math
     interface is_close
         #:set RC_KINDS_TYPES = REAL_KINDS_TYPES + CMPLX_KINDS_TYPES
         #:for k1, t1 in RC_KINDS_TYPES
-        elemental module logical function is_close_${t1[0]}$${k1}$(a, b, rel_tol, abs_tol, equal_nan) result(close)
+        elemental logical module function is_close_${t1[0]}$${k1}$(a, b, rel_tol, abs_tol, equal_nan) result(close)
             ${t1}$, intent(in) :: a, b
             real(${k1}$), intent(in), optional :: rel_tol, abs_tol
             logical, intent(in), optional :: equal_nan

--- a/src/math/stdlib_math_is_close.fypp
+++ b/src/math/stdlib_math_is_close.fypp
@@ -14,7 +14,7 @@ contains
     #! Determines whether the values of `a` and `b` are close.
 
     #:for k1, t1 in REAL_KINDS_TYPES
-    elemental module logical function is_close_${t1[0]}$${k1}$(a, b, rel_tol, abs_tol, equal_nan) result(close)
+    elemental logical module function is_close_${t1[0]}$${k1}$(a, b, rel_tol, abs_tol, equal_nan) result(close)
         ${t1}$, intent(in) :: a, b
         real(${k1}$), intent(in), optional :: rel_tol, abs_tol
         logical, intent(in), optional :: equal_nan
@@ -33,7 +33,7 @@ contains
     #:endfor
 
     #:for k1, t1 in CMPLX_KINDS_TYPES
-    elemental module logical function is_close_${t1[0]}$${k1}$(a, b, rel_tol, abs_tol, equal_nan) result(close)
+    elemental logical module function is_close_${t1[0]}$${k1}$(a, b, rel_tol, abs_tol, equal_nan) result(close)
         ${t1}$, intent(in) :: a, b
         real(${k1}$), intent(in), optional :: rel_tol, abs_tol
         logical, intent(in), optional :: equal_nan


### PR DESCRIPTION
Some previous PR introduced a style guide violation regarding where the `module` attibute should be. This produces spurious builds with CMake < 3.26