### PR TITLE
fix (str2num) : handle leading '+' sign in to_num parsers

### DIFF
--- a/src/strings/stdlib_str2num.fypp
+++ b/src/strings/stdlib_str2num.fypp
@@ -136,11 +136,13 @@ module stdlib_str2num
         ! Find first non white space
         p = shift_to_nonwhitespace(s)
         !----------------------------------------------
-        ! Verify leading negative
+        ! Verify leading sign
         sign = 1
         if(p<=len(s)) then
             if(iachar(s(p:p)) == minus_sign+digit_0 ) then
                 sign = -1
+                p = p + 1
+            else if(iachar(s(p:p)) == plus_sign+digit_0 ) then
                 p = p + 1
             end if
         else
@@ -198,10 +200,12 @@ module stdlib_str2num
         ! Find first non white space
         p = shift_to_nonwhitespace(s)
         !----------------------------------------------
-        ! Verify leading negative
+        ! Verify leading sign
         sign = 1
         if( iachar(s(p:p)) == minus_sign+digit_0 ) then
             sign = -1
+            p = p + 1
+        else if( iachar(s(p:p)) == plus_sign+digit_0 ) then
             p = p + 1
         end if
         if( iachar(s(p:p)) == Inf ) then
@@ -296,10 +300,12 @@ module stdlib_str2num
         ! Find first non white space
         p = shift_to_nonwhitespace(s)
         !----------------------------------------------
-        ! Verify leading negative
+        ! Verify leading sign
         sign = 1
         if( iachar(s(p:p)) == minus_sign+digit_0 ) then
             sign = -1
+            p = p + 1
+        else if( iachar(s(p:p)) == plus_sign+digit_0 ) then
             p = p + 1
         end if
         if( iachar(s(p:p)) == Inf ) then
@@ -395,10 +401,12 @@ module stdlib_str2num
         ! Find first non white space
         p = shift_to_nonwhitespace(s)
         !----------------------------------------------
-        ! Verify leading negative
+        ! Verify leading sign
         sign = 1
         if( iachar(s(p:p)) == minus_sign+digit_0 ) then
             sign = -1
+            p = p + 1
+        else if( iachar(s(p:p)) == plus_sign+digit_0 ) then
             p = p + 1
         end if
         if( iachar(s(p:p)) == Inf ) then
@@ -512,10 +520,12 @@ module stdlib_str2num
         ! Find first non white space
         p = shift_to_nonwhitespace(s)
         !----------------------------------------------
-        ! Verify leading negative
+        ! Verify leading sign
         sign = 1
         if( iachar(s(p:p)) == minus_sign+digit_0 ) then
             sign = -1
+            p = p + 1
+        else if( iachar(s(p:p)) == plus_sign+digit_0 ) then
             p = p + 1
         end if
         if( iachar(s(p:p)) == Inf ) then

--- a/test/string/test_string_to_number.fypp
+++ b/test/string/test_string_to_number.fypp
@@ -71,6 +71,12 @@ contains
         call check(error, ucheck("-1"))
         if (allocated(error)) return
 
+        call check(error, ucheck("+1"))
+        if (allocated(error)) return
+
+        call check(error, ucheck("+1.234"))
+        if (allocated(error)) return
+
         call check(error, ucheck(" -0.23317260678539647E-01 "))
         if (allocated(error)) return
 
@@ -155,6 +161,18 @@ contains
         if (allocated(error)) return
 
         call check(error, ucheck("-123"))
+        if (allocated(error)) return
+
+        call check(error, ucheck("+1"))
+        if (allocated(error)) return
+
+        call check(error, ucheck("+42"))
+        if (allocated(error)) return
+
+        call check(error, ucheck("   +99"))
+        if (allocated(error)) return
+
+        call check(error, ucheck("+0005"))
         if (allocated(error)) return
 
         call check(error, ucheck("   99"))


### PR DESCRIPTION
Fix #1197 by CoPilot:

`to_num()` silently returned 0 for any numeric string with a leading + (e.g. "+1", "+1.234"). The integer and all four real parsers (to_sp_base, to_dp_base, to_xdp_base, to_qp_base) only consumed a leading -; a + was left unadvanced, the digit loop found a non-digit immediately, and the parser succeeded with value 0.
```Fortran
k = to_num("+1", k)   ! returned 0 (wrong)
k = to_num("-1", k)   ! returned -1 (correct)
```
Changes:

* src/strings/stdlib_str2num.fypp — in all five to_*_base parsers, extended the leading-sign check from an if (minus only) to if / else if that also consumes a leading + and advances p. Updated the comment from "Verify leading negative" to "Verify leading sign".
* test/string/test_string_to_number.fypp — added regression cases for integers ("+1", "+42", "   +99", "+0005") and reals ("+1", "+1.234") across all type variants.