### PR TITLE
fix: enforce incomplete gamma argument domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+Changes to existing modules
+  - Fix negative-argument incomplete gamma functions and uninitialized-result
+    diagnostics
+    [#898](https://github.com/fortran-lang/stdlib/issues/898)
+
 Changes to the existing build system
   - Fixed absolute paths in generated pkg-config file for external BLAS/LAPACK 
     [#1109](https://github.com/fortran-lang/stdlib/issues/1109)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 Changes to existing modules
-  - Fix negative-argument incomplete gamma functions and uninitialized-result
+  - Enforce incomplete gamma argument domains and fix uninitialized-result
     diagnostics
     [#898](https://github.com/fortran-lang/stdlib/issues/898)
 

--- a/src/specialfunctions/stdlib_specialfunctions_gamma.fypp
+++ b/src/specialfunctions/stdlib_specialfunctions_gamma.fypp
@@ -366,6 +366,8 @@ contains
         ${t1}$ :: i
         ${t1}$, parameter :: zero = 0_${k1}$, one = 1_${k1}$, two = 2_${k1}$
 
+        res = 0.0_dp
+
         if(z <= zero) call error_stop("Error(log_gamma): Gamma function"       &
             //" argument must be positive integer.")
 
@@ -406,6 +408,8 @@ contains
         ${t1}$ :: i
         ${t1}$, parameter :: zero = 0_${k1}$, one = 1_${k1}$, two = 2_${k1}$
         ${t2}$, parameter :: zero_k2 = 0.0_${k2}$
+
+        res = zero_k2
 
         if(z <= zero) call error_stop("Error(log_gamma): Gamma function"       &
             //" argument must be positive integer.")
@@ -553,6 +557,8 @@ contains
         ${t1}$, parameter :: zero = 0_${k1}$, one = 1_${k1}$, two = 2_${k1}$
         ${t2}$, parameter :: zero_${k2}$ = 0.0_${k2}$, one_${k2}$ = 1.0_${k2}$
 
+        res = zero_${k2}$
+
         if(n < zero) call error_stop("Error(l_factorial): Logarithm of"        &
             //" factorial function argument must be non-negative")
 
@@ -594,7 +600,7 @@ contains
     ! Fortran 90 program by Jim-215-Fisher
     !
         ${t1}$, intent(in) :: p, x
-        integer :: n
+        integer :: n, m
 
         ${t2}$ :: res, p_lim, a, b, g, c, d, y
         ${t2}$, parameter :: zero = 0.0_${k2}$, one = 1.0_${k2}$
@@ -618,12 +624,9 @@ contains
 
         endif
 
-        if(x < zero_k1 .and. p < p_lim .and. abs(anint(p) - p) > tol_${k1}$)   &
+        if(x < zero_k1 .and. abs(anint(p) - p) > tol_${k1}$)                  &
             call error_stop("Error(gpx): Incomplete gamma function with "      &
-            //"negative x must come with a whole number p not too small")
-
-        if(x < zero_k1) call error_stop("Error(gpx): Incomplete gamma"         &
-            // " function with negative x must have an integer parameter p")
+            //"negative x must come with a whole number p")
 
         if(p >= p_lim) then     !use modified Lentz method of continued fraction
                                 !for eq. (15) in the above reference.
@@ -690,8 +693,30 @@ contains
 
             end do
 
-        else
-            g = ieee_value(1._${k1}$, ieee_quiet_nan)
+        else                            !Algorithm 2 in the reference
+            m = nint(p)
+            a = -x
+            c = one / a
+            d = p - one
+            b = c * (a - d)
+            n = 1
+
+            do
+
+                c = d * (d - one) / (a * a)
+                d = d - 2
+                y = c * (a - d)
+                b = b + y
+                n = n + 1
+
+                if(n > (m - 2) / 2 .or. y < b * tol_${k2}$) exit
+
+            end do
+
+            if(y >= b * tol_${k2}$ .and. mod(m, 2) /= 0) b = b + d * c / a
+
+            g = ((-1) ** m * exp(-a + log_gamma(p) - (p - 1) * log(a))       &
+                + b) / a
 
         end if
 
@@ -851,6 +876,8 @@ contains
         ${t1}$ :: res, s1, y
         ${t1}$, parameter :: zero = 0.0_${k1}$, one = 1.0_${k1}$
 
+        res = zero
+
         if(x == zero) then
 
             res = zero
@@ -867,9 +894,8 @@ contains
             res = gpx(p, x) * exp(s1)
 
         else
-
-            call error_stop("Error(Logarithm of upper incomplete gamma "       &
-              //"function): negative x must be with integer p")
+            s1 = -x + p * log(abs(x))
+            res = (-1) ** nint(p) * gpx(p, x) * exp(s1)
 
         end if
     end function ingamma_low_${t1[0]}$${k1}$
@@ -889,6 +915,8 @@ contains
         ${t2}$, intent(in) :: x
         ${t2}$ :: res, s1, y
         ${t2}$, parameter :: zero = 0.0_${k2}$, one = 1.0_${k2}$
+
+        res = zero
 
         if(x == zero) then
 
@@ -926,6 +954,8 @@ contains
         ${t1}$ :: res, s1, y
         ${t1}$, parameter :: zero = 0.0_${k1}$, one = 1.0_${k1}$
 
+        res = zero
+
 
         if(x == zero) then
 
@@ -943,9 +973,8 @@ contains
             res = log(abs(gpx(p, x))) + s1
 
         else
-
-            call error_stop("Error(Logarithm of upper incomplete gamma "       &
-              //"function): negative x must be with integer p")
+            s1 = -x + p * log(abs(x))
+            res = log(abs(gpx(p, x))) + s1
 
         end if
     end function l_ingamma_low_${t1[0]}$${k1}$
@@ -964,6 +993,8 @@ contains
         ${t2}$, intent(in) :: x
         ${t2}$ :: res, s1, y
         ${t2}$, parameter :: zero = 0.0_${k2}$, one = 1.0_${k2}$
+
+        res = zero
 
         if(x == zero) then
 
@@ -997,6 +1028,8 @@ contains
         ${t1}$ :: res, s1, y
         ${t1}$, parameter :: zero = 0.0_${k1}$, one = 1.0_${k1}$
 
+        res = zero
+
         if(x == zero) then
 
             res = gamma(p)
@@ -1013,10 +1046,10 @@ contains
             res = (one - gpx(p, x) * exp(s1)) * exp(y)
 
         else
-
-
-            call error_stop("Error(Logarithm of upper incomplete gamma "       &
-              //"function): negative x must be with integer p")
+            y = log_gamma(p)
+            s1 = -x + p * log(abs(x)) - y
+            res = gpx(p, x) * exp(s1)
+            res = (one - (-1) ** nint(p) * res) * exp(y)
 
         end if
     end function ingamma_up_${t1[0]}$${k1}$
@@ -1036,6 +1069,8 @@ contains
         ${t2}$, intent(in) :: x
         ${t2}$ :: res, s1, y
         ${t2}$, parameter :: zero = 0.0_${k2}$, one = 1.0_${k2}$
+
+        res = zero
 
         if(x == zero) then
 
@@ -1075,6 +1110,8 @@ contains
         ${t1}$ :: res, s1, y
         ${t1}$, parameter :: zero = 0.0_${k1}$, one = 1.0_${k1}$
 
+        res = zero
+
 
         if(x == zero) then
 
@@ -1093,9 +1130,10 @@ contains
             res = log(one - res) + y
 
         else
-
-            call error_stop("Error(Logarithm of upper incomplete gamma "       &
-              //"function): negative x must be with integer p")
+            y = log_gamma(p)
+            s1 = -x + p * log(abs(x)) + log(gpx(p, x))
+            res = (-1) ** nint(p) * exp(s1)
+            res = log(abs(exp(y) - res))
 
         end if
     end function l_ingamma_up_${t1[0]}$${k1}$
@@ -1114,6 +1152,8 @@ contains
         ${t2}$, intent(in) :: x
         ${t2}$ :: res, s1, y
         ${t2}$, parameter :: zero = 0.0_${k2}$, one = 1.0_${k2}$
+
+        res = zero
 
         if(x == zero) then
 
@@ -1156,6 +1196,8 @@ contains
         ${t1}$ :: res, s1
         ${t1}$, parameter :: zero = 0.0_${k1}$, one = 1.0_${k1}$
 
+        res = zero
+
         if(x < zero) call error_stop("Error(regamma_p): Regularized gamma_p"   &
             //" function is not defined at x < 0")
 
@@ -1192,6 +1234,8 @@ contains
         ${t2}$ :: res, s1
         ${t2}$, parameter :: zero = 0.0_${k2}$, one = 1.0_${k2}$
 
+        res = zero
+
         if(x < zero) call error_stop("Error(regamma_p): Regularized gamma_p"   &
             //" function is not defined at x < 0")
 
@@ -1226,6 +1270,8 @@ contains
         ${t1}$, intent(in) :: p, x
         ${t1}$ :: res, s1
         ${t1}$, parameter :: zero = 0.0_${k1}$, one = 1.0_${k1}$
+
+        res = zero
 
         if(x < zero) call error_stop("Error(regamma_p): Regularized gamma_q"   &
             //" function is not defined at x < 0")
@@ -1262,6 +1308,8 @@ contains
         ${t2}$, intent(in) :: x
         ${t2}$ :: res, s1
         ${t2}$, parameter :: zero = 0.0_${k2}$, one = 1.0_${k2}$
+
+        res = zero
 
         if(x < zero) call error_stop("Error(regamma_q): Regularized gamma_q"   &
             //" function is not defined at x < 0")

--- a/src/specialfunctions/stdlib_specialfunctions_gamma.fypp
+++ b/src/specialfunctions/stdlib_specialfunctions_gamma.fypp
@@ -5,7 +5,7 @@
 #:set GAMMA_IDX_CMPLX_KINDS_TYPES = [(i, CMPLX_KINDS[i], CMPLX_TYPES[i], CMPLX_INIT[i]) for i in range(len(CMPLX_KINDS)) if CMPLX_KINDS[i] in ('sp', 'dp', 'xdp')]
 #:set GAMMA_IDX_REAL_KINDS_TYPES  = [(i, REAL_KINDS[i], REAL_TYPES[i], REAL_INIT[i]) for i in range(len(REAL_KINDS)) if REAL_KINDS[i] in ('sp', 'dp', 'xdp')]
 module stdlib_specialfunctions_gamma
-    use ieee_arithmetic, only: ieee_value, ieee_quiet_nan
+    use ieee_arithmetic, only: ieee_value, ieee_quiet_nan, ieee_negative_inf
     use stdlib_kinds, only :  sp, dp, xdp, qp, int8, int16, int32, int64
     use stdlib_error, only : error_stop
 
@@ -600,7 +600,7 @@ contains
     ! Fortran 90 program by Jim-215-Fisher
     !
         ${t1}$, intent(in) :: p, x
-        integer :: n, m
+        integer :: n
 
         ${t2}$ :: res, p_lim, a, b, g, c, d, y
         ${t2}$, parameter :: zero = 0.0_${k2}$, one = 1.0_${k2}$
@@ -624,9 +624,8 @@ contains
 
         endif
 
-        if(x < zero_k1 .and. abs(anint(p) - p) > tol_${k1}$)                  &
-            call error_stop("Error(gpx): Incomplete gamma function with "      &
-            //"negative x must come with a whole number p")
+        if(x < zero_k1) call error_stop("Error(gpx): Incomplete gamma"         &
+            // " function with negative x must have an integer parameter p")
 
         if(p >= p_lim) then     !use modified Lentz method of continued fraction
                                 !for eq. (15) in the above reference.
@@ -693,30 +692,8 @@ contains
 
             end do
 
-        else                            !Algorithm 2 in the reference
-            m = nint(p)
-            a = -x
-            c = one / a
-            d = p - one
-            b = c * (a - d)
-            n = 1
-
-            do
-
-                c = d * (d - one) / (a * a)
-                d = d - 2
-                y = c * (a - d)
-                b = b + y
-                n = n + 1
-
-                if(n > (m - 2) / 2 .or. y < b * tol_${k2}$) exit
-
-            end do
-
-            if(y >= b * tol_${k2}$ .and. mod(m, 2) /= 0) b = b + d * c / a
-
-            g = ((-1) ** m * exp(-a + log_gamma(p) - (p - 1) * log(a))       &
-                + b) / a
+        else
+            g = ieee_value(one, ieee_quiet_nan)
 
         end if
 
@@ -878,6 +855,11 @@ contains
 
         res = zero
 
+        if(p <= zero) call error_stop("Error(lower_incomplete_gamma): "        &
+            //"parameter p must be positive")
+        if(x < zero) call error_stop("Error(lower_incomplete_gamma): negative " &
+            //"x requires an integer parameter p")
+
         if(x == zero) then
 
             res = zero
@@ -892,10 +874,6 @@ contains
 
             s1 = -x + p * log(x)
             res = gpx(p, x) * exp(s1)
-
-        else
-            s1 = -x + p * log(abs(x))
-            res = (-1) ** nint(p) * gpx(p, x) * exp(s1)
 
         end if
     end function ingamma_low_${t1[0]}$${k1}$
@@ -915,8 +893,12 @@ contains
         ${t2}$, intent(in) :: x
         ${t2}$ :: res, s1, y
         ${t2}$, parameter :: zero = 0.0_${k2}$, one = 1.0_${k2}$
+        ${t1}$, parameter :: zero_k1 = 0_${k1}$
 
         res = zero
+
+        if(p <= zero_k1) call error_stop("Error(lower_incomplete_gamma): "     &
+            //"parameter p must be positive")
 
         if(x == zero) then
 
@@ -956,10 +938,14 @@ contains
 
         res = zero
 
+        if(p <= zero) call error_stop("Error(log_lower_incomplete_gamma): "    &
+            //"parameter p must be positive")
+        if(x < zero) call error_stop("Error(log_lower_incomplete_gamma): "     &
+            //"negative x requires an integer parameter p")
 
         if(x == zero) then
 
-            res = zero
+            res = ieee_value(zero, ieee_negative_inf)
 
         else if(x > p) then
 
@@ -969,10 +955,6 @@ contains
 
         else if(x <= p .and. x > zero) then
 
-            s1 = -x + p * log(abs(x))
-            res = log(abs(gpx(p, x))) + s1
-
-        else
             s1 = -x + p * log(abs(x))
             res = log(abs(gpx(p, x))) + s1
 
@@ -993,12 +975,16 @@ contains
         ${t2}$, intent(in) :: x
         ${t2}$ :: res, s1, y
         ${t2}$, parameter :: zero = 0.0_${k2}$, one = 1.0_${k2}$
+        ${t1}$, parameter :: zero_k1 = 0_${k1}$
 
         res = zero
 
+        if(p <= zero_k1) call error_stop("Error(log_lower_incomplete_gamma): " &
+            //"parameter p must be positive")
+
         if(x == zero) then
 
-            res = zero
+            res = ieee_value(zero, ieee_negative_inf)
 
         else if(x > real(p, ${k2}$)) then
 
@@ -1030,6 +1016,11 @@ contains
 
         res = zero
 
+        if(p <= zero) call error_stop("Error(upper_incomplete_gamma): "        &
+            //"parameter p must be positive")
+        if(x < zero) call error_stop("Error(upper_incomplete_gamma): negative " &
+            //"x requires an integer parameter p")
+
         if(x == zero) then
 
             res = gamma(p)
@@ -1044,12 +1035,6 @@ contains
             y = log_gamma(p)
             s1 = -x + p * log(x) - y
             res = (one - gpx(p, x) * exp(s1)) * exp(y)
-
-        else
-            y = log_gamma(p)
-            s1 = -x + p * log(abs(x)) - y
-            res = gpx(p, x) * exp(s1)
-            res = (one - (-1) ** nint(p) * res) * exp(y)
 
         end if
     end function ingamma_up_${t1[0]}$${k1}$
@@ -1069,8 +1054,12 @@ contains
         ${t2}$, intent(in) :: x
         ${t2}$ :: res, s1, y
         ${t2}$, parameter :: zero = 0.0_${k2}$, one = 1.0_${k2}$
+        ${t1}$, parameter :: zero_k1 = 0_${k1}$
 
         res = zero
+
+        if(p <= zero_k1) call error_stop("Error(upper_incomplete_gamma): "     &
+            //"parameter p must be positive")
 
         if(x == zero) then
 
@@ -1112,6 +1101,10 @@ contains
 
         res = zero
 
+        if(p <= zero) call error_stop("Error(log_upper_incomplete_gamma): "    &
+            //"parameter p must be positive")
+        if(x < zero) call error_stop("Error(log_upper_incomplete_gamma): "     &
+            //"negative x requires an integer parameter p")
 
         if(x == zero) then
 
@@ -1128,12 +1121,6 @@ contains
             s1 = -x + p * log(x) - y
             res = gpx(p, x) * exp(s1)
             res = log(one - res) + y
-
-        else
-            y = log_gamma(p)
-            s1 = -x + p * log(abs(x)) + log(gpx(p, x))
-            res = (-1) ** nint(p) * exp(s1)
-            res = log(abs(exp(y) - res))
 
         end if
     end function l_ingamma_up_${t1[0]}$${k1}$
@@ -1152,8 +1139,12 @@ contains
         ${t2}$, intent(in) :: x
         ${t2}$ :: res, s1, y
         ${t2}$, parameter :: zero = 0.0_${k2}$, one = 1.0_${k2}$
+        ${t1}$, parameter :: zero_k1 = 0_${k1}$
 
         res = zero
+
+        if(p <= zero_k1) call error_stop("Error(log_upper_incomplete_gamma): " &
+            //"parameter p must be positive")
 
         if(x == zero) then
 

--- a/test/specialfunctions/CMakeLists.txt
+++ b/test/specialfunctions/CMakeLists.txt
@@ -4,9 +4,11 @@
 set(fppFiles
     test_specialfunctions_activations.fypp
     test_specialfunctions_gamma.fypp
+    test_specialfunctions_gamma_invalid.fypp
 )
 
 fypp_f90("${fyppFlags}" "${fppFiles}" outFiles)
 
 ADDTEST(specialfunctions_gamma)
+ADDTEST(specialfunctions_gamma_invalid)
 ADDTEST(specialfunctions_activations)

--- a/test/specialfunctions/test_specialfunctions_gamma.fypp
+++ b/test/specialfunctions/test_specialfunctions_gamma.fypp
@@ -3,6 +3,7 @@
 #:set GAMMA_CMPLX_KINDS_TYPES = [item for item in CMPLX_KINDS_TYPES if item[0] in ('sp', 'dp', 'xdp')]
 #:set GAMMA_CI_KINDS_TYPES = INT_KINDS_TYPES + GAMMA_CMPLX_KINDS_TYPES
 module test_specialfunctions_gamma
+    use, intrinsic :: ieee_arithmetic, only : ieee_is_finite
     use testdrive, only : new_unittest, unittest_type, error_type, check
     use stdlib_kinds, only: sp, dp, xdp, qp, int8, int16, int32, int64
     use stdlib_error, only: state_type, STDLIB_VALUE_ERROR
@@ -70,6 +71,8 @@ contains
                            test_uincgamma_${t1[0]}$${k1}$)                     &
             , new_unittest("log_upper_incomplete_gamma_${t1[0]}$${k1}$",       &
                            test_log_uincgamma_${t1[0]}$${k1}$)                 &
+            , new_unittest("log_lower_incomplete_gamma_zero_${k1}$",          &
+                           test_log_lincgamma_zero_${k1}$)                     &
             , new_unittest("regularized_gamma_p_${t1[0]}$${k1}$",              &
                            test_gamma_p_${t1[0]}$${k1}$)                       &
             , new_unittest("regularized_gamma_q_${t1[0]}$${k1}$",              &
@@ -80,8 +83,8 @@ contains
                            test_log_beta_${t1[0]}$${k1}$)                      &
             , new_unittest("incomplete_beta_${t1[0]}$${k1}$",                  &
                            test_incomplete_beta_${t1[0]}$${k1}$)               &
-            , new_unittest("negative_real_incomplete_gamma_${k1}$",           &
-                           test_negative_real_incgamma_${k1}$)                 &
+            , new_unittest("negative_integer_incomplete_gamma_${k1}$",        &
+                           test_negative_integer_incgamma_${k1}$)              &
         #:endfor
             ]
     end subroutine collect_specialfunctions_gamma
@@ -486,12 +489,13 @@ contains
 
 
 
-    subroutine test_negative_real_incgamma_${k1}$(error)
+    subroutine test_negative_integer_incgamma_${k1}$(error)
         type(error_type), allocatable, intent(out) :: error
         integer :: i
-        ! 80-digit reference values from
+        ! Reference values evaluated to 80 decimal digits from the exact
+        ! positive-integer identity
         ! gamma(n,x) = (n-1)! * (1-exp(-x)*sum(x**k/k!, k=0,...,n-1)).
-        ${t1}$, parameter :: p(*) = [3.0_${k1}$, 2.0_${k1}$]
+        integer, parameter :: p(*) = [3, 2]
         ${t1}$, parameter :: x(*) = [-5.0_${k1}$, -10.0_${k1}$]
         ${t1}$, parameter :: lower(*) = [                                  &
             -2.52102370474380225816e3_${k1}$,                              &
@@ -509,26 +513,42 @@ contains
 
         do i = 1, size(p)
             call check(error, lower_incomplete_gamma(p(i), x(i)), lower(i), &
-                "Lower incomplete gamma with negative x and real p failed", &
+                "Lower incomplete gamma with negative x and integer p failed", &
                 thr = regression_tol, rel = .true.)
             if (allocated(error)) return
 
             call check(error, log_lower_incomplete_gamma(p(i), x(i)),       &
                 log_lower(i), "Log lower incomplete gamma with negative x " &
-                //"and real p failed", thr = regression_tol, rel = .true.)
+                //"and integer p failed", thr = regression_tol, rel = .true.)
             if (allocated(error)) return
 
             call check(error, upper_incomplete_gamma(p(i), x(i)), upper(i), &
-                "Upper incomplete gamma with negative x and real p failed", &
+                "Upper incomplete gamma with negative x and integer p failed", &
                 thr = regression_tol, rel = .true.)
             if (allocated(error)) return
 
             call check(error, log_upper_incomplete_gamma(p(i), x(i)),       &
                 log_upper(i), "Log upper incomplete gamma with negative x " &
-                //"and real p failed", thr = regression_tol, rel = .true.)
+                //"and integer p failed", thr = regression_tol, rel = .true.)
             if (allocated(error)) return
         end do
-    end subroutine test_negative_real_incgamma_${k1}$
+    end subroutine test_negative_integer_incgamma_${k1}$
+
+
+
+    subroutine test_log_lincgamma_zero_${k1}$(error)
+        type(error_type), allocatable, intent(out) :: error
+        ${t1}$ :: result
+
+        result = log_lower_incomplete_gamma(2, 0.0_${k1}$)
+        call check(error, .not. ieee_is_finite(result) .and. result < 0, &
+            "Log lower incomplete gamma at x=0 with integer p must be -Inf")
+        if (allocated(error)) return
+
+        result = log_lower_incomplete_gamma(2.5_${k1}$, 0.0_${k1}$)
+        call check(error, .not. ieee_is_finite(result) .and. result < 0, &
+            "Log lower incomplete gamma at x=0 with real p must be -Inf")
+    end subroutine test_log_lincgamma_zero_${k1}$
 
 
 

--- a/test/specialfunctions/test_specialfunctions_gamma.fypp
+++ b/test/specialfunctions/test_specialfunctions_gamma.fypp
@@ -80,6 +80,8 @@ contains
                            test_log_beta_${t1[0]}$${k1}$)                      &
             , new_unittest("incomplete_beta_${t1[0]}$${k1}$",                  &
                            test_incomplete_beta_${t1[0]}$${k1}$)               &
+            , new_unittest("negative_real_incomplete_gamma_${k1}$",           &
+                           test_negative_real_incgamma_${k1}$)                 &
         #:endfor
             ]
     end subroutine collect_specialfunctions_gamma
@@ -482,6 +484,54 @@ contains
         end do
     end subroutine test_incomplete_beta_${t1[0]}$${k1}$
 
+
+
+    subroutine test_negative_real_incgamma_${k1}$(error)
+        type(error_type), allocatable, intent(out) :: error
+        integer :: i
+        ! 80-digit reference values from
+        ! gamma(n,x) = (n-1)! * (1-exp(-x)*sum(x**k/k!, k=0,...,n-1)).
+        ${t1}$, parameter :: p(*) = [3.0_${k1}$, 2.0_${k1}$]
+        ${t1}$, parameter :: x(*) = [-5.0_${k1}$, -10.0_${k1}$]
+        ${t1}$, parameter :: lower(*) = [                                  &
+            -2.52102370474380225816e3_${k1}$,                              &
+             1.98239192153260448653e5_${k1}$]
+        ${t1}$, parameter :: log_lower(*) = [                               &
+             7.83242033005676398766_${k1}$,                                &
+             1.21972296217601365312e1_${k1}$]
+        ${t1}$, parameter :: upper(*) = [                                   &
+             2.52302370474380225816e3_${k1}$,                              &
+            -1.98238192153260448653e5_${k1}$]
+        ${t1}$, parameter :: log_upper(*) = [                               &
+             7.83321334405621608025_${k1}$,                                &
+             1.21972245773362193828e1_${k1}$]
+        ${t1}$, parameter :: regression_tol = 128 * epsilon(1.0_${k1}$)
+
+        do i = 1, size(p)
+            call check(error, lower_incomplete_gamma(p(i), x(i)), lower(i), &
+                "Lower incomplete gamma with negative x and real p failed", &
+                thr = regression_tol, rel = .true.)
+            if (allocated(error)) return
+
+            call check(error, log_lower_incomplete_gamma(p(i), x(i)),       &
+                log_lower(i), "Log lower incomplete gamma with negative x " &
+                //"and real p failed", thr = regression_tol, rel = .true.)
+            if (allocated(error)) return
+
+            call check(error, upper_incomplete_gamma(p(i), x(i)), upper(i), &
+                "Upper incomplete gamma with negative x and real p failed", &
+                thr = regression_tol, rel = .true.)
+            if (allocated(error)) return
+
+            call check(error, log_upper_incomplete_gamma(p(i), x(i)),       &
+                log_upper(i), "Log upper incomplete gamma with negative x " &
+                //"and real p failed", thr = regression_tol, rel = .true.)
+            if (allocated(error)) return
+        end do
+    end subroutine test_negative_real_incgamma_${k1}$
+
+
+
     subroutine test_lincgamma_${t1[0]}$${k1}$(error)
         type(error_type), allocatable, intent(out) :: error
         integer, parameter :: n = 4
@@ -565,7 +615,7 @@ contains
 
         ${t1}$, parameter :: ans(n) = [-0.5_${k1}$, -1.9959226032237259_${k1}$,&
                                        -1.2054260888453405_${k1}$,             &
-                                       5.5903962398338761_${k1}$]
+                                        5.5903962398338761_${k1}$]
 
         do i = 1, n
 

--- a/test/specialfunctions/test_specialfunctions_gamma_invalid.fypp
+++ b/test/specialfunctions/test_specialfunctions_gamma_invalid.fypp
@@ -1,0 +1,55 @@
+#:include "common.fypp"
+program test_specialfunctions_gamma_invalid
+    use stdlib_kinds, only : sp, dp
+    use stdlib_specialfunctions_gamma, only : lower_incomplete_gamma, &
+        upper_incomplete_gamma, log_lower_incomplete_gamma, &
+        log_upper_incomplete_gamma
+    implicit none
+
+    integer :: i, exit_status
+    character(len=256) :: executable
+    character(len=32) :: test_case
+    character(len=32), parameter :: cases(*) = [character(len=32) :: &
+        #:for op in ["lower", "log_lower", "upper", "log_upper"]
+          #:for k in ["sp", "dp"]
+            #:for domain in ["negative_real", "zero_real", "negative_p_real", "zero_integer", "negative_p_integer"]
+        "${op}$_${k}$_${domain}$", &
+            #:endfor
+          #:endfor
+        #:endfor
+        ""]
+
+    call get_command_argument(2, test_case)
+    if (len_trim(test_case) == 0) then
+        call get_command_argument(0, executable)
+        do i = 1, size(cases) - 1
+            call execute_command_line(trim(executable)//" child " &
+                //trim(cases(i)), &
+                exitstat=exit_status)
+            if (exit_status == 0) then
+                error stop "Invalid incomplete gamma arguments were accepted: " &
+                    //trim(cases(i))
+            end if
+        end do
+        stop
+    end if
+
+    select case (trim(test_case))
+    #:for op in ["lower", "log_lower", "upper", "log_upper"]
+      #:for k in ["sp", "dp"]
+    case ("${op}$_${k}$_negative_real")
+        print *, ${op}$_incomplete_gamma(1.5_${k}$, -1.0_${k}$)
+    case ("${op}$_${k}$_zero_real")
+        print *, ${op}$_incomplete_gamma(0.0_${k}$, 0.0_${k}$)
+    case ("${op}$_${k}$_negative_p_real")
+        print *, ${op}$_incomplete_gamma(-1.0_${k}$, 0.0_${k}$)
+    case ("${op}$_${k}$_zero_integer")
+        print *, ${op}$_incomplete_gamma(0, 0.0_${k}$)
+    case ("${op}$_${k}$_negative_p_integer")
+        print *, ${op}$_incomplete_gamma(-1, 0.0_${k}$)
+      #:endfor
+    #:endfor
+    case default
+        error stop "Unknown test case"
+    end select
+end program test_specialfunctions_gamma_invalid


### PR DESCRIPTION
## Summary

Fix incomplete gamma handling to match the documented stdlib specification.

For `x >= 0`, `p` may be a positive integer or positive real.

For `x < 0`, `p` must be a positive integer. Real-`p` overloads reject the call.

## Changes

- Keep negative-`x` support for integer-`p` overloads.
- Reject negative `x` in real-`p` overloads.
- Validate `p > 0` before special-case returns.
- Fix `log_lower_incomplete_gamma(p, 0)` to return `-Inf`.
- Remove the invalid real-`p` negative-`x` path.
- Keep generated gamma code clean under strict uninitialized diagnostics.

## Tests

Added coverage for:

- positive integer and non-integer `p` with nonnegative `x`
- positive integer `p` with negative `x`
- rejection of real `p` with negative `x`
- rejection of zero and negative `p`
- lower and upper incomplete gamma
- logarithmic lower and upper incomplete gamma
- `log_lower_incomplete_gamma(p, 0) == -Inf`
- generated single- and double-precision paths

Negative-`x` integer-`p` regressions use a relative tolerance of `128*epsilon(kind)`.

## Verification

GNU Fortran 15.2.0 locally:

- focused gamma tests: 2/2 passed
- strict `-Werror=maybe-uninitialized` check: passed
- full stdlib suite: 428/428 passed twice

Independent verification by [FalseGreen](https://falsegreen.com) also passed the branch-specific gamma/specification gates.

Assisted-By: Codex