### PR TITLE
build: point the fypp error message at the variable that works

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,7 @@ if(NOT FYPP OR "${FYPP}" MATCHES "NOTFOUND")
     "   Windows:      'where fypp' and 'where python'\n"
     "   Linux/macOS:  'which fypp' and 'which python'\n\n"
     " Ensure the executable is in your PATH or set it manually during configuration:\n"
-    "   cmake -B build -DFYPP_EXECUTABLE=/path/to/fypp\n"
+    "   cmake -B build -DFYPP=/path/to/fypp\n"
     " ------------------------------------------------------------------------\n"
   )
 endif()


### PR DESCRIPTION
### Problem

The fypp "not found" error tells the user how to recover:

```
 Ensure the executable is in your PATH or set it manually during configuration:
   cmake -B build -DFYPP_EXECUTABLE=/path/to/fypp
```

But `find_program(FYPP fypp)` creates a cache variable named **`FYPP`**. `FYPP_EXECUTABLE` appears exactly once in the repository — in that message — and is read nowhere, so following the instruction sets an unused variable and the build fails again with the same error.

That is a bad failure to hand a new contributor: the message looks authoritative, and the obvious conclusion is that their fypp install is broken rather than that the flag is wrong.

### Verified

With a fypp outside `PATH`, against `9a15c777`:

```
$ cmake -B build -DFYPP_EXECUTABLE=/path/to/fypp
CMake Error at CMakeLists.txt:120 (message):
   [stdlib Build Error]: Preprocessor 'fypp' not found!

$ cmake -B build -DFYPP=/path/to/fypp
-- Configuring done (8.0s)
```

One character changed in the message. Nothing else touched — the surrounding diagnostics added in #1137 are good and stay as they are.

### Related

This came out of looking at #1136, which asked for exactly these improved diagnostics. That issue is **already resolved** by #1137 (`ac98d3bc`), and is probably worth closing — I only found this because the improved message pointed at a flag that does not exist.

An alternative fix would be to accept `FYPP_EXECUTABLE` as well, since it is the more conventional CMake spelling. I went with correcting the message because it is the smaller change and keeps one name for one thing, but happy to switch if you would rather support both.

### AI

I used Claude Code to investigate this and draft the description. The two CMake runs above were executed, not assumed.