### PR TITLE
Build under the project's own -std=f2018 on gfortran 15.2

### DIFF
--- a/src/strings/stdlib_str2num.fypp
+++ b/src/strings/stdlib_str2num.fypp
@@ -109,7 +109,10 @@ module stdlib_str2num
         integer(int8) :: err
         !----------------------------------------------
         call to_num_base(s,v,p,err)
-        p = min( p , len(s) )
+        ! `p` is int8 and `len` returns a default integer, so comparing them
+        ! directly is a GNU extension that -std=f2018 rejects. The result is
+        ! never larger than `p`, so it always fits back into int8.
+        p = min( int(p), len(s) )
         s => s(p:)
         if(present(stat)) stat = err
     end function

--- a/src/strings/stdlib_str2num.fypp
+++ b/src/strings/stdlib_str2num.fypp
@@ -110,8 +110,12 @@ module stdlib_str2num
         !----------------------------------------------
         call to_num_base(s,v,p,err)
         ! `p` is int8 and `len` returns a default integer, so comparing them
-        ! directly is a GNU extension that -std=f2018 rejects. The result is
-        ! never larger than `p`, so it always fits back into int8.
+        ! directly is a GNU extension that -std=f2018 rejects. Promote `p`
+        ! rather than asking for `len(s, kind=int8)`: the string is not bounded
+        ! by 127, and that form wraps silently, with no diagnostic even under
+        ! -std=f2018 -Wall. For a 200 character string it returns -56, so the
+        ! `min` yields -56 and the `s(p:)` below is then a bad substring bound.
+        ! The result here is never larger than `p`, so it fits back into int8.
         p = min( int(p), len(s) )
         s => s(p:)
         if(present(stat)) stat = err

--- a/src/system/stdlib_system.F90
+++ b/src/system/stdlib_system.F90
@@ -1028,7 +1028,10 @@ function c_get_strerror(winapi) result(str)
             import c_size_t, c_ptr, c_bool
             implicit none
             integer(c_size_t), intent(out) :: len
-            logical, intent(in) :: winapi
+            ! The C side takes a `bool` by value. A default `logical` passed by
+            ! reference is neither: -std=f2018 rejects the kind, and the pointer
+            ! that reached C was read as the flag, so it was always true.
+            logical(c_bool), intent(in), value :: winapi
         end function strerror
     end interface
 
@@ -1039,7 +1042,7 @@ function c_get_strerror(winapi) result(str)
 
     winapi_ = optval(winapi, .false.)
 
-    c_str_ptr = strerror(len, winapi_)
+    c_str_ptr = strerror(len, logical(winapi_, kind=c_bool))
 
     str = to_f_char(c_str_ptr, len)
 end function c_get_strerror

--- a/src/system/stdlib_system.F90
+++ b/src/system/stdlib_system.F90
@@ -1030,7 +1030,12 @@ function c_get_strerror(winapi) result(str)
             integer(c_size_t), intent(out) :: len
             ! The C side takes a `bool` by value. A default `logical` passed by
             ! reference is neither: -std=f2018 rejects the kind, and the pointer
-            ! that reached C was read as the flag, so it was always true.
+            ! that reached C was read as the flag, so it was always true. On
+            ! Windows that meant FormatMessageA(GetLastError()) described the
+            ! failure while the code stored beside it came from errno, since
+            ! stdlib_make_directory and friends return errno from the CRT
+            ! calls -- two different error spaces in one message. Every call
+            ! site here passes no argument, so both halves now come from errno.
             logical(c_bool), intent(in), value :: winapi
         end function strerror
     end interface

--- a/src/system/stdlib_system_subprocess.F90
+++ b/src/system/stdlib_system_subprocess.F90
@@ -8,6 +8,17 @@ submodule (stdlib_system) stdlib_system_subprocess
     ! Number of CPU ticks between status updates
     integer(TICKS), parameter :: CHECK_EVERY_TICKS = 100
     
+    ! `exit` is a GNU intrinsic, so `implicit none(external)` does not accept it
+    ! under -std=f2018. Bind it to C's `exit`, which is what the intrinsic calls,
+    ! keeping the behaviour that made it preferable to `stop` here.
+    interface
+        subroutine exit(status) bind(C, name='exit')
+            import c_int
+            implicit none
+            integer(c_int), value :: status
+        end subroutine exit
+    end interface
+
     ! Interface to C support functions from stdlib_system_subprocess.c
     interface
         
@@ -249,14 +260,16 @@ contains
            call save_completed_state(process,delete_files=.not.asynchronous)
 
            ! If the process was forked 
-           ! Note: use `exit` rather than `stop` to prevent the mandatory stdout STOP message           
+           ! Note: use `exit` rather than `stop` to prevent the mandatory stdout STOP message.
+           ! It is bound to C's `exit` explicitly because the GNU intrinsic of the
+           ! same name is not declared under -std=f2018.
            if (asynchronous) then 
                if (command_state/=0) then 
                    ! Invalid command: didn't even start
-                   call exit(command_state)
+                   call exit(int(command_state, c_int))
                else
                    ! Return exit state
-                   call exit(exit_state)                   
+                   call exit(int(exit_state, c_int))
                end if                   
            endif            
            
@@ -371,7 +384,7 @@ contains
 
         ! Determine the wait time
         if (present(max_wait_time)) then
-            wait_time = max(0.0_RTICKS, max_wait_time)
+            wait_time = max(0.0_RTICKS, real(max_wait_time, RTICKS))
         else
             ! No limit if max_wait_time is not provided
             wait_time = huge(wait_time)  

--- a/test/system/test_filesystem.f90
+++ b/test/system/test_filesystem.f90
@@ -18,6 +18,7 @@ contains
 
         testsuite = [ &
             new_unittest("fs_error", test_fs_error), &
+            new_unittest("fs_error_message_from_os", test_fs_error_message_from_os), &
             new_unittest("fs_exists_not_exists", test_exists_not_exists), &
             new_unittest("fs_exists_reg_file", test_exists_reg_file), &
             new_unittest("fs_exists_dir", test_exists_dir), &
@@ -56,6 +57,33 @@ contains
             "FS_ERROR: Could not construct state without code correctly")
         if (allocated(error)) return
     end subroutine test_fs_error
+
+    !> A failing operation must carry the operating system's own description,
+    !> not an empty string. This is the only cover for c_get_strerror, which
+    !> every FS_ERROR_CODE call site reaches with no argument.
+    subroutine test_fs_error_message_from_os(error)
+        type(error_type), allocatable, intent(out) :: error
+        type(state_type) :: err
+        integer :: comma
+
+        character(*), parameter :: missing = "stdlib_no_such_directory_here"
+
+        call set_cwd(missing, err)
+
+        call check(error, err%error(), "Expected an error changing to a missing directory")
+        if (allocated(error)) return
+
+        ! The state formats as "code - <n>, <description>", where the
+        ! description is what c_get_strerror returned. Checking only that the
+        ! message is non-empty would still pass on the code alone, so require
+        ! text after the comma.
+        comma = index(err%message, ",")
+        call check(error, comma > 0, "Expected a formatted error code in: "//err%message)
+        if (allocated(error)) return
+
+        call check(error, len_trim(err%message(comma + 1:)) > 0, &
+            "The failure carried no description from the operating system: "//err%message)
+    end subroutine test_fs_error_message_from_os
 
     subroutine test_exists_not_exists(error)
         type(error_type), allocatable, intent(out) :: error


### PR DESCRIPTION
`config/DefaultFlags.cmake` compiles with `-std=f2018`, but four places rely on GNU extensions that gfortran 15.2 rejects, so a build with the project's own flags stops in `src/strings` and `src/system`:

```
stdlib_str2num.f90:112:    p = min( p , len(s) )
    Error: GNU Extension: Different type kinds

stdlib_system.F90:1058:    type(c_ptr) function strerror(len, winapi) bind(C, name='stdlib_strerror')
    Error: GNU Extension: LOGICAL dummy argument 'winapi' with non-C_Bool kind in BIND(C) procedure

stdlib_system_subprocess.F90:256,259:    call exit(command_state)
    Error: Procedure 'exit' called at (1) is not explicitly declared

stdlib_system_subprocess.F90:374:    wait_time = max(0.0_RTICKS, max_wait_time)
    Error: GNU Extension: Different type kinds
```

### Why CI does not see it

The matrix runs gcc 15 only on `macos-14`; the ubuntu matrix stops at gcc 14. The point release available there still accepts these, so the last full run on master is green. Distro gfortran 15.2 does not.

### The changes

**`stdlib_str2num`** — `min(p, len(s))` compares an `int8` with a default integer. The result can never exceed `p`, so promoting `p` is enough and the value still fits back into `int8`.

**`stdlib_system_subprocess`** — `exit` is a GNU intrinsic, so `implicit none(external)` will not accept it. Bound to C's `exit`, which is what the intrinsic calls, so the reason the comment gives for preferring it to `stop` still holds. And `max(0.0_RTICKS, max_wait_time)` compares `real(RTICKS)` with a default real.

**`stdlib_system`** — this one is worth a closer look, because it is a behaviour fix and not only a build fix.

The interface to `stdlib_strerror` declared `winapi` as a default `logical` passed by reference. The C side is:

```c
char* stdlib_strerror(size_t* len, bool winapi)
```

a `bool` taken by value. So C was reading the *address* of the Fortran logical as the flag — always a non-null pointer, therefore always true, whatever was passed. The interface already imported `c_bool` without using it, which suggests this was the intent and got lost.

On unix nothing changes: the `winapi` branch has no body outside `_WIN32` and falls through to `strerror(errno)` either way. **On Windows it means `FormatMessageA` was always being used, including when `c_get_strerror()` was called with no argument.** That is the intended behaviour restored, but I have no Windows machine and cannot test it — please treat that hunk as the one needing a second opinion.

### Verification

Ubuntu 26.04 aarch64, gfortran 15.2, `-std=f2018` left exactly as the repo sets it:

| | result |
|---|---|
| `master` | build stops, 5 errors across the two files |
| this branch | build completes, **ctest 427/427** |

### What this does not cover

gfortran **16.2** needs more. It additionally rejects the generated BLAS interfaces in `stdlib_linalg_blas.F90` with `Symbol 'lda' is used before it is typed`, roughly 500 of them. That is a separate and much larger change to the generated sources, and I have not touched it. None of the four sites fixed here are among those, so this is a step toward gfortran 16 rather than the whole of it.

Found while building #1208 locally, where I mentioned it and offered to raise it separately.
